### PR TITLE
Problem: setup-ees.yaml use wrong component key name

### DIFF
--- a/src/conf/setup-ees.yaml
+++ b/src/conf/setup-ees.yaml
@@ -1,4 +1,4 @@
-ees-hare:
+ees-ha:
   post_install:
     script: /opt/seagate/cortx/ha/conf/script/build-ees-ha
     args:
@@ -17,7 +17,7 @@ ees-hare:
     script: null
     args: null
   reset:
-    script: /opt/seagate/cortx/hare/libexec/prov-ha-reset
+    script: /opt/seagate/cortx/ha/conf/script/prov-ha-reset
     args: null
   backup:
     files:


### PR DESCRIPTION
setup-ees.yaml uses ees-hare while provisioning uses ees-ha.
HA reset script path is also wrong in setup-ees.yaml.

Solution:
- Change ees-hare to ees-ha in setup-ees.yaml
- Fix prov-ha-reset part in the reset section of setup-ees.yaml