### PR TITLE
Problem: CSM can't invoke pcswrap after repository splitting

### DIFF
--- a/jenkins/cortx-ha.spec
+++ b/jenkins/cortx-ha.spec
@@ -21,8 +21,8 @@ HA Tools
 rm -rf ${RPM_BUILD_ROOT}
 mkdir -p ${RPM_BUILD_ROOT}<HA_PATH>
 cp -rp . ${RPM_BUILD_ROOT}<HA_PATH>
-make -C pcswrap install DESTDIR=${RPM_BUILD_ROOT}<HA_PATH>
-sed -i -e 's@^#!.*\.py3venv@#!/usr@' ${RPM_BUILD_ROOT}<HA_PATH>/bin/*
+make -C pcswrap install DESTDIR=${RPM_BUILD_ROOT}<HA_PATH>/ha
+sed -i -e 's@^#!.*\.py3venv@#!/usr@' ${RPM_BUILD_ROOT}<HA_PATH>/ha/bin/*
 
 mkdir -p ${RPM_BUILD_ROOT}/usr/lib/ocf/resource.d/cortx/
 mv resource/{dispatch,lnet,sspl} \


### PR DESCRIPTION
Solution:
move `pcswrap` from /opt/seagate/cortx/bin/ to /opt/seagate/cortx/ha/bin/

Relates to https://github.com/Seagate/cortx-hare/pull/1165
Relates to EOS-10650