### PR TITLE
EOS-10334: Provide a way to mkfs Motr MD store

### DIFF
--- a/conf/script/prov-m0-reset
+++ b/conf/script/prov-m0-reset
@@ -27,6 +27,9 @@ Mandatory parameters:
   --right-volume  <rv>  Right node /var/motr volume (default: /dev/sdc)
                   <CDF>          Hare Cluster Description File
 
+Optional parameters:
+  --mkfs-only           run mkfs on motr meta data devices.
+
 Note: parameters can be specified either directly via cmd-line options
 or via a yaml file, e.g.:
 
@@ -43,6 +46,7 @@ TEMP=$(getopt --options h,i: \
               --longoptions help,ip1:,ip2: \
               --longoptions left-node:,right-node: \
               --longoptions left-volume:,right-volume: \
+              --longoptions mkfs-only \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
@@ -51,20 +55,26 @@ eval set -- "$TEMP"
 
 ip1=
 ip2=
+iface=eth1
+net_type=tcp
 lnode=pod-c1
 rnode=pod-c2
 lvolume=/dev/sdb
 rvolume=/dev/sdc
+mkfs_only=
 
 while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
         --ip1)               ip1=$2; shift 2 ;;
         --ip2)               ip2=$2; shift 2 ;;
+        -i|--interface)      iface=$2; shift 2 ;;
+        --net-type)          net_type=$2; shift 2 ;;
         --left-node)         lnode=$2; shift 2 ;;
         --right-node)        rnode=$2; shift 2 ;;
         --left-volume)       lvolume=$2; shift 2 ;;
         --right-volume)      rvolume=$2; shift 2 ;;
+        --mkfs-only)         mkfs_only=true; shift ;;
         --)                  shift; break ;;
         *)                   break ;;
     esac
@@ -86,6 +96,8 @@ if [[ -f $argsfile ]]; then
        case $name in
            ip1)          ip1=$value     ;;
            ip2)          ip2=$value     ;;
+           interface)    iface=$value   ;;
+           net-type)     net_type=$value ;;
            left-node)    lnode=$value   ;;
            right-node)   rnode=$value   ;;
            left-volume)  lvolume=$value ;;
@@ -102,101 +114,255 @@ fi
 [[ -b $lvolume ]] || die "meta-data volume $lvolume is not available"
 [[ -b $rvolume ]] || die "meta-data volume $rvolume is not available"
 
-echo 'Exporting Consul configuration to /var/lib/hare/consul-conf-exported.json'
-/opt/seagate/cortx/hare/bin/consul kv export > \
-    /var/lib/hare/consul-conf-exported.json
+reset() {
+    echo 'Exporting Consul configuration to /var/lib/hare/consul-conf-exported.json'
+    /opt/seagate/cortx/hare/bin/consul kv export > \
+       /var/lib/hare/consul-conf-exported.json
+    # Temporily move consul resources after lnet on both the nodes so that
+    # lnet resources are still running after we stop consul.
+    echo 'Repositioning Consul resources on both the nodes...'
+    sudo pcs resource group add c1 consul-c1 --after lnet-c1
+    sudo pcs resource group add c2 consul-c2 --after lnet-c2
 
-# Temporily move consul resources after lnet on both the nodes so that
-# lnet resources are still running after we stop consul.
-echo 'Repositioning Consul resources on both the nodes...'
-sudo pcs resource group add c1 consul-c1 --after lnet-c1
-sudo pcs resource group add c2 consul-c2 --after lnet-c2
+    echo 'Disabling Consul resources...'
+    sudo pcs resource disable consul-c1
+    sudo pcs resource disable consul-c2
 
-echo 'Disabling Consul resources...'
-sudo pcs resource disable consul-c1
-sudo pcs resource disable consul-c2
+    echo 'Waiting for Consul agents, hax and m0d services to stop on both the nodes...'
+    while [[ `pgrep -a consul | grep 'consul agent'` ]] || [[ `pgrep hax` ]] ||
+          [[ `pgrep m0d` ]] ||
+          [[ `ssh $rnode 'pgrep -a consul | grep "consul agent"'` ]] ||
+          [[ `ssh $rnode 'pgrep hax'` ]] || [[ `ssh $rnode 'pgrep m0d'` ]]; do
+        sleep 5
+    done
 
-echo 'Waiting for Consul agents, hax and m0d services to stop on both the nodes...'
-while [[ `pgrep -a consul | grep 'consul agent'` ]] || [[ `pgrep hax` ]] ||
-      [[ `pgrep m0d` ]] ||
-      [[ `ssh $rnode 'pgrep -a consul | grep "consul agent"'` ]] ||
-      [[ `ssh $rnode 'pgrep hax'` ]] || [[ `ssh $rnode 'pgrep m0d'` ]]; do
+    # Killing any remaining consul watcher processes.
+    sudo pkill consul || true
+    ssh $rnode 'sudo pkill consul' || true
+
+    ip a | grep -qF $ip1 ||
+      die "IP address $ip1 doesn't appear to be configured at $lnode"
+
+    ssh $rnode "ip a | grep -qF $ip2" ||
+      die "IP address $ip2 doesn't appear to be configured at $rnode"
+
+    sudo lctl list_nids | grep -qF $ip1 ||
+      die "LNet endpoint $ip1 doesn't appear to be configured at $lnode"
+
+    ssh $rnode "sudo lctl list_nids | grep -qF $ip2" ||
+      die "LNet endpoint $ip2 doesn't appear to be configured at $rnode"
+
+    echo 'Conforming if /var/motr on both the nodes is unmounted...'
+    while mountpoint /var/motr && ! umount /var/motr; do sleep 1; done
+    while ssh $rnode 'mountpoint /var/motr && ! umount /var/motr'; do sleep 1; done
+
+    echo "Formatting volumes $lvolume and $rvolume ..."
+    mkfs.ext4 $lvolume
+    mkfs.ext4 $rvolume
+
+    echo 'Mounting /var/motr on both the nodes...'
+    mkdir -p /var/motr &&
+      ! mountpoint -q /var/motr && sudo mount $lvolume /var/motr
+    ssh $rnode "mkdir -p /var/motr &&
+      ! mountpoint -q /var/motr && sudo mount $rvolume /var/motr"
+
+    echo 'Resetting failed systemd units on both the nodes...'
+    sudo systemctl reset-failed hare\* m0d\*
+    ssh $rnode 'sudo systemctl reset-failed hare\* m0d\*'
+
+    echo 'Running hctl bootstrap..'
+    hctl bootstrap --mkfs -c /var/lib/hare
+    hctl shutdown
+
+    # Ideally we will not touch the foreign directories (/var/motr{1,2}) for
+    # each node during reset but we make sure they exist when cluster is back up.
+    sudo mkdir -p /var/motr2
+    ssh $rnode 'sudo mkdir -p /var/motr1'
+
+    echo 'Unmounting /var/motr from both the nodes...'
+    sudo umount /var/motr
+    ssh $rnode 'sudo umount /var/motr'
+
+    # Move consul resources back to their original positions in their respective
+    # resource groups i.e. after virtual ip resources on both the nodes.
+    echo 'Repositioning Consul resources to original location on both the nodes...'
+    sudo pcs resource group add c1 consul-c1 --after ip-c1
+    sudo pcs resource group add c2 consul-c2 --after ip-c2
+
+    echo 'Enabling Consul resources on both the nodes...'
+    sudo pcs resource enable consul-c1
+    sudo pcs resource enable consul-c2
+
+    # Reset failcount once after reset
+    sudo pcs resource cleanup
+
+    echo 'Waiting for Consul agents, hax and m0ds to start on both the nodes...'
+    while true; do
+        if [[ `pgrep -a consul | grep 'consul agent'` &&
+              `pgrep hax` && `pgrep m0d` &&
+              `ssh $rnode 'pgrep -a consul | grep "consul agent"'` &&
+              `ssh $rnode 'pgrep hax'` && `ssh $rnode 'pgrep m0d'` ]]; then
+                break
+       fi
+       sleep 5
+    done
+
+    echo 'Importing /var/lib/hare/consul-conf-exported.json...'
+    for i in {1..10}; do
+        /opt/seagate/cortx/hare/bin/consul kv import \
+            @/var/lib/hare/consul-conf-exported.json && break || sleep 5
+    done
+}
+
+get_fid() {
+    service=$1
+    node=$2
+
+    proc_id=$(/opt/seagate/cortx/hare/bin/consul kv get --recurse \
+              m0conf/nodes/$node/processes | grep $service | \
+              awk 'BEGIN {FS="/"} {print $5}')
+    fid=$(printf '0x7200000000000001:0x%x\n' $proc_id)
+    echo $fid
+}
+
+get_proc_state() {
+    fid=$1
+
+    state=$(/opt/seagate/cortx/hare/bin/consul kv get processes/$fid 2> /dev/null | jq -r '.state')
+    echo $state
+}
+
+m0_mkfs() {
+
+    local confd_fid_c1=$(get_fid 'confd' $lnode)
+    local ios_fid_c1=$(get_fid 'ios' $lnode)
+
+    local confd_fid_c2=$(get_fid 'confd' $rnode)
+    local ios_fid_c2=$(get_fid 'ios' $rnode)
+
+    systemctl is-active --quiet m0d@$confd_fid_c1 ||
+    systemctl is-active --quiet m0d@$ios_fid_c1 ||
+    systemctl is-active --quiet m0d@$confd_fid_c2 ||
+    systemctl is-active --quiet m0d@$ios_fid_c2 &&
+        die 'Active m0d instances found, please stop all the m0d instances'
+
+    sudo systemctl start motr-mkfs@$confd_fid_c1
+    while [[ $(get_proc_state $confd_fid_c1) != M0_CONF_HA_PROCESS_STOPPED ]]; do
+        sleep 1
+    done
+
+    sudo systemctl start m0d@$confd_fid_c1
+    while [[ `systemctl is-active m0d@$confd_fid_c1` != 'active' ]]; do
+       sleep 5
+    done
+
+    sudo systemctl start motr-mkfs@$confd_fid_c2
+    while [[ $(get_proc_state $confd_fid_c2) != M0_CONF_HA_PROCESS_STOPPED ]]; do
+        sleep 1
+    done
+
+    sudo systemctl start m0d@$confd_fid_c2
+    while [[ `systemctl is-active m0d@$confd_fid_c2` != 'active' ]]; do
+       sleep 5
+    done
+
+    sudo systemctl start motr-mkfs@$ios_fid_c1
+    while [[ $(get_proc_state $ios_fid_c1) != M0_CONF_HA_PROCESS_STOPPED ]]; do
+        sleep 1
+    done
+    sudo systemctl start motr-mkfs@$ios_fid_c2
+    while [[ $(get_proc_state $ios_fid_c2) != M0_CONF_HA_PROCESS_STOPPED ]]; do
+        sleep 1
+    done
+
+    sudo systemctl stop m0d@$confd_fid_c1
+    sudo systemctl stop m0d@$confd_fid_c2
+
+    while [[ `pgrep m0d` ]]; do
+       sleep 5
+    done
+}
+
+mkfs() {
+    local local_node=$(cat /var/lib/hare/node-name)
+
+    echo 'Adding ip addresses..'
+    sudo ifconfig $iface:c1 $ip1
+    sudo ifconfig $iface:c2 $ip2
+
+    echo 'Adding lnet interfaces..'
+    sudo modprobe lnet # Its possible that lnet module is not loaded.
+    sudo lnetctl net add --net $net_type --if $iface:c1
+    sudo lnetctl net add --net $net_type --if $iface:c2
+
+    echo 'Restarting motr-kernel..'
+    sudo systemctl restart motr-kernel
+
+    echo 'Modifying Consul systemd units..'
+    sudo sed -i 's/^\(ExecStartPost\|ExecStopPost\)=\/usr\/sbin\/attrd_updater/#&/' \
+                              /usr/lib/systemd/system/hare-consul-agent-c1.service
+    sudo sed -i 's/^\(ExecStartPost\|ExecStopPost\)=\/usr\/sbin\/attrd_updater/#&/' \
+                              /usr/lib/systemd/system/hare-consul-agent-c2.service
+
+    sudo systemctl reset-failed
+    sudo systemctl daemon-reload
+
+    echo 'Starting Consul agents..'
+    sudo systemctl start hare-consul-agent-c1
+    sudo systemctl start hare-consul-agent-c2
+
+    while [[ `systemctl is-active hare-consul-agent-c1` != 'active' ||
+             `systemctl is-active hare-consul-agent-c2` != 'active' ]]; do
+           sleep 5
+    done
+
+    # An issue is observed if we try to fetch data from Consul immediately
+    # after stating Consul services. So, let's wait for 5 more secs.
     sleep 5
-done
 
-# Killing any remaining consul watcher processes.
-sudo pkill consul || true
-ssh $rnode 'sudo pkill consul' || true
+    echo 'Starting Hax..'
+    sudo systemctl start hare-hax-c1
+    sudo systemctl start hare-hax-c2
 
-ip a | grep -qF $ip1 ||
-  die "IP address $ip1 doesn't appear to be configured at $lnode"
+    while [[ `systemctl is-active hare-hax-c1` != 'active' ||
+             `systemctl is-active hare-hax-c2` != 'active' ]]; do
+           sleep 5
+    done
 
-ssh $rnode "ip a | grep -qF $ip2" ||
-  die "IP address $ip2 doesn't appear to be configured at $rnode"
+    echo 'Doing Motr mkfs..'
+    m0_mkfs
 
-sudo lctl list_nids | grep -qF $ip1 ||
-  die "LNet endpoint $ip1 doesn't appear to be configured at $lnode"
+    echo 'Stopping Hax..'
+    sudo systemctl stop hare-hax-c2
+    sudo systemctl stop hare-hax-c1
 
-ssh $rnode "sudo lctl list_nids | grep -qF $ip2" ||
-  die "LNet endpoint $ip2 doesn't appear to be configured at $rnode"
+    echo 'Stopping Consul agents..'
+    sudo systemctl stop hare-consul-agent-c2
+    sudo systemctl stop hare-consul-agent-c1
 
-echo 'Conforming if /var/motr on both the nodes is unmounted...'
-while mountpoint /var/motr && ! umount /var/motr; do sleep 1; done
-while ssh $rnode 'mountpoint /var/motr && ! umount /var/motr'; do sleep 1; done
+    echo 'Deleting lnet interfaces..'
+    sudo lnetctl net del --net $net_type --if $iface:c1
+    sudo lnetctl net del --net $net_type --if $iface:c2
 
-echo "Formatting volumes $lvolume and $rvolume ..."
-mkfs.ext4 $lvolume
-mkfs.ext4 $rvolume
+    echo 'Restarting motr-kernel..'
+    sudo systemctl restart motr-kernel
 
-echo 'Mounting /var/motr on both the nodes...'
-mkdir -p /var/motr &&
-  ! mountpoint -q /var/motr && sudo mount $lvolume /var/motr
-ssh $rnode "mkdir -p /var/motr &&
-  ! mountpoint -q /var/motr && sudo mount $rvolume /var/motr"
+    echo 'Restoring Consul systemd units..'
+    sudo sed -i '/\(#ExecStartPost\|#ExecStopPost\)=\/usr\/sbin\/attrd_updater/s/#//g' \
+                                  /usr/lib/systemd/system/hare-consul-agent-c1.service
+    sudo sed -i '/\(#ExecStartPost\|#ExecStopPost\)=\/usr\/sbin\/attrd_updater/s/#//g' \
+                                  /usr/lib/systemd/system/hare-consul-agent-c2.service
 
-echo 'Resetting failed systemd units on both the nodes...'
-sudo systemctl reset-failed hare\* m0d\*
-ssh $rnode 'sudo systemctl reset-failed hare\* m0d\*'
+    sudo systemctl daemon-reload
+    sudo systemctl reset-failed
 
-echo 'Running hctl bootstrap..'
-hctl bootstrap --mkfs -c /var/lib/hare
-hctl shutdown
+    echo 'Removing ipaddresses..'
+    ip addr del $ip1/24 dev $iface:c1
+    ip addr del $ip2/24 dev $iface:c1
+}
 
-# Ideally we will not touch the foreign directories (/var/motr{1,2}) for
-# each node during reset but we make sure they exist when cluster is back up.
-sudo mkdir -p /var/motr2
-ssh $rnode 'sudo mkdir -p /var/motr1'
-
-echo 'Unmounting /var/motr from both the nodes...'
-sudo umount /var/motr
-ssh $rnode 'sudo umount /var/motr'
-
-# Move consul resources back to their original positions in their respective
-# resource groups i.e. after virtual ip resources on both the nodes.
-echo 'Repositioning Consul resources to original location on both the nodes...'
-sudo pcs resource group add c1 consul-c1 --after ip-c1
-sudo pcs resource group add c2 consul-c2 --after ip-c2
-
-echo 'Enabling Consul resources on both the nodes...'
-sudo pcs resource enable consul-c1
-sudo pcs resource enable consul-c2
-
-# Reset failcount once after reset
-sudo pcs resource cleanup
-
-echo 'Waiting for Consul agents, hax and m0ds to start on both the nodes...'
-while true; do
-    if [[ `pgrep -a consul | grep 'consul agent'` &&
-          `pgrep hax` && `pgrep m0d` &&
-          `ssh $rnode 'pgrep -a consul | grep "consul agent"'` &&
-          `ssh $rnode 'pgrep hax'` && `ssh $rnode 'pgrep m0d'` ]]; then
-            break
-    fi
-    sleep 5
-done
-
-echo 'Importing /var/lib/hare/consul-conf-exported.json...'
-for i in {1..10}; do
-    /opt/seagate/cortx/hare/bin/consul kv import \
-        @/var/lib/hare/consul-conf-exported.json && break || sleep 5
-done
+if [[ $mkfs_only ]]; then
+    mkfs
+else
+    reset
+fi


### PR DESCRIPTION
In case of Motr meta data corruption there's a requirement
to mkfs the existing Motr meta data store as part of the
recovery process of LDR-1 cluster.

Solution:
Extend prov-m0-reset script to support mkfs option inorder to format
motr meta data store. The script with mkfs option stops runs in offline
mode and does not require cluster to be running. The script temporaily
starts the required Consul and hax services to support motr mkfs and
does not affect the exiting cluster configuration.