### PR TITLE
Problem: Motr meta data variable name is wrong

### DIFF
--- a/conf/script/build-ees-ha
+++ b/conf/script/build-ees-ha
@@ -284,9 +284,9 @@ motr_config() {
     rm0confs=$(sudo ssh $rnode 'echo /etc/sysconfig/m0d-*')
     sudo scp -q $lm0confs $rnode:/etc/sysconfig/
     sudo scp -q $rnode:\{${rm0confs/ /,}\} /etc/sysconfig/
-    for f in $rm0confs; do sudo sed '1iMERO_M0D_DATA_DIR=/var/motr2' -i $f; done
+    for f in $rm0confs; do sudo sed '1iMOTR_M0D_DATA_DIR=/var/motr2' -i $f; done
     ssh $rnode "for f in $lm0confs; do \
-                           sudo sed '1iMERO_M0D_DATA_DIR=/var/motr1' -i \$f; done"
+                           sudo sed '1iMOTR_M0D_DATA_DIR=/var/motr1' -i \$f; done"
 }
 
 cmd_deregister_node() {


### PR DESCRIPTION
Due to renaming changes in Motr, meta data variable name was changed from MERO_M0D_DATA_DIR
to MOTR_M0D_DATA_DIR. But this change was not reflected in build-ees-ha script in cortx-ha
that adds this variable to /etc/sysconfig/m0d@<service-fid> environment file.
This leads to start failure of Motr services and the wrong meta data dir path is
selected.

Solution:
Rename MERO_M0D_DATA_DIR to MOTR_M0D_DATA_DIR in build-ees-ha script.