### PR TITLE
Problem: SSPL pacemaker resource promotion fails

### DIFF
--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -62,12 +62,12 @@ Location to store the sspl mode. [ Active, Degraded ]
 </parameter>
 </parameters>
 <actions>
-<action name="start"   timeout="20s" />
-<action name="stop"    timeout="22s" />
+<action name="start"   timeout="30s" />
+<action name="stop"    timeout="32s" />
 <action name="monitor" timeout="23s" interval="10s" role="Master"/>
 <action name="monitor" timeout="25s" interval="11s" role="Slave"/>
-<action name="promote" timeout="10s" />
-<action name="demote"  timeout="11s" />
+<action name="promote" timeout="30s"/>
+<action name="demote"  timeout="32s" />
 <action name="meta-data"  timeout="5s" />
 <action name="validate-all"  timeout="30s" />
 </actions>
@@ -104,7 +104,7 @@ stateful_check_state() {
     # So, resource will not be either Master or Slave
     # So, we can return as Resource is safely stopped (OCF_NOT_RUNNING i.e 7)
     # So that, pacemaker will take action to start it
-    return 7
+    return $OCF_NOT_RUNNING
 }
 
 stateful_start() {
@@ -121,11 +121,9 @@ stateful_start() {
 }
 
 stateful_demote() {
-    stateful_monitor
     sspl_state=`systemctl is-active sspl-ll`
-    if [ $sspl_state != 'active' ]; then
-       systemctl start sspl-ll
-    fi
+    [ $sspl_state == 'active' ] || return $OCF_NOT_RUNNING
+
     stateful_update "slave"
 
     if [ -z $OCF_RESKEY_sspl_mode ]; then
@@ -133,19 +131,13 @@ stateful_demote() {
     fi
 
     echo "state=degrade" > /var/cortx/sspl/data/state.txt
-    return 0
+    return $OCF_SUCCESS
 }
 
 stateful_promote() {
-    sleep 5
-    sspl_pid=`/sbin/pidof -s /usr/bin/sspl_ll_d`
-    if [ -z $sspl_pid ]; then
-        return $(stateful_monitor)
-    fi
     sspl_state=`systemctl is-active sspl-ll`
-    if [ $sspl_state != 'active' ]; then
-       systemctl start sspl-ll
-    fi
+    [ $sspl_state == 'active' ] || return $OCF_NOT_RUNNING
+
     stateful_update "master"
 
     if [ -z $OCF_RESKEY_sspl_mode ]; then
@@ -157,7 +149,7 @@ stateful_promote() {
     # this signal is received by SSPL. Without this sspl won't read updated
     # configuration.
     /usr/bin/kill -s SIGHUP $sspl_pid
-    return 0
+    return $OCF_SUCCESS
 }
 
 stateful_stop() {


### PR DESCRIPTION
Due to recent changes to sspl, sspl service takes more time to start while
pacemaker tries to promote the service earlier. In SSPL recource agent's
promote function we fetch the sspl process id on the node, assuming it the
process has already started. But this may not return anything in which case
promote function return OCF_NOT_RUNNING, while sspl service is still starting.
The current timeouts don't adhere to the new sspl service start timings.
This leads to ping pong of sspl Master from one node to another until there's
a point where the promotion succeeds.

Solution:
- Increase start and stop timeouts.
- Increase promotion and demotion timeouts.
- Remove fetching sspl process pid code and use `systemctl is-active sspl-ll`.