### PR TITLE
Problem: motr and s3 environment files are missing from backup

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -294,6 +294,22 @@ bootstrap_update_only() {
     hctl shutdown
 }
 
+# Invoked as part of initialisation during node replacement.
+motr_config_init() {
+    if [[ ! -e /etc/sysconfig/motr-kernel ]]; then
+        echo "MOTR_NODE_UUID='$(uuidgen --time)'" |
+            sudo tee /etc/sysconfig/motr-kernel >/dev/null
+    fi
+
+# It is expected for /var/lib/hare/confd.xc to be present during node
+# replacement as a pre step.
+    [[ -f /var/lib/hare/confd.xc ]] ||
+        die 'Cannot bootstrap server node without /var/lib/hare/confd.xc file'
+    sudo mkdir -p /etc/motr
+    sudo cp /var/lib/hare/confd.xc /etc/motr/
+
+}
+
 motr_config() {
     # Prepare Motr conf files on each node:
     lm0confs=$(echo /etc/sysconfig/m0d-*)
@@ -750,6 +766,7 @@ ha_ops=(
     net_config_check
     bootstrap
     bootstrap_update_only
+    motr_config_init
     motr_config
     consul_systemd_prepare
     consul_systemd_update
@@ -786,6 +803,7 @@ declare -A ha_ops_type=(
     [net_config_check]='bootstrap'
     [bootstrap]='bootstrap'
     [bootstrap_update_only]='update-only'
+    [motr_config_init]='init'
     [motr_config]='bootstrap'
     [consul_systemd_prepare]='bootstrap_update_init'
     [consul_systemd_update]='bootstrap_update_init'

--- a/conf/setup-ees.yaml
+++ b/conf/setup-ees.yaml
@@ -42,6 +42,8 @@ ees-ha:
       - /var/lib/hare/consul-*
       - /var/lib/hare/node-name
       - /var/lib/hare/hax-env-*
+      - /etc/sysconfig/m0d-*
+      - /etc/sysconfig/s3server-*
   post_update:
     script: /opt/seagate/cortx/ha/conf/script/build-ees-ha-update
     args:


### PR DESCRIPTION
1. motr-kernel environemnt file containing the node uuid is not recreated during
   node replacement. This leads to the failure of motr-kernel service due to missing
   node uuid.
2. Also, confd.xc is not copied to `/etc/motr` as part of node replacement.
3. Presently there is no mechanism to recreate the motr and s3 environment files
   for a particular node without Consul. These files are needed to backed up and
   retored after node is replaced.

Solution:
- Recreate motr-kernel file if does not exists already during node replacement.
- Re-install confd.xc to /etc/motr directory.
- Add Motr and S3 environment files to backup section in-order to restore them
  on node replacement.