### PR TITLE
EOS-12112: hax service stop timeout is less than the systemd timeout

### DIFF
--- a/conf/script/build-ees-ha
+++ b/conf/script/build-ees-ha
@@ -504,8 +504,8 @@ hax_systemd_update() {
 
 hax_rsc_add() {
     log "${FUNCNAME[0]}: Adding hax to Pacemaker..."
-    sudo pcs -f $cib_file resource create hax-c1 systemd:hare-hax-c1 op stop timeout=30
-    sudo pcs -f $cib_file resource create hax-c2 systemd:hare-hax-c2 op stop timeout=30
+    sudo pcs -f $cib_file resource create hax-c1 systemd:hare-hax-c1 op stop timeout=100
+    sudo pcs -f $cib_file resource create hax-c2 systemd:hare-hax-c2 op stop timeout=100
     sudo pcs -f $cib_file resource group add c1 hax-c1
     sudo pcs -f $cib_file resource group add c2 hax-c2
     sudo pcs -f $cib_file constraint order motr-kernel-clone then hax-c1


### PR DESCRIPTION
As hax pacemaker resource stop timeout is less than the default systemd
timeout of 90 secs, hax service does not stop on time in case of situations
where it is unable to unmount /var/motr. This is typically due to ext4 data
sync operation in progress. This situation is observed in case of losing SAS
connection. In normal cases this timeout suffices. Unable to stop hax service
in time leads to stonith action.
Note that we purposefully do not set systemd stop timeout to allow clean
unmount of /var/motr and also because this issue is not seen in regular
failover/failback.

Solution:
Increase hax resource timeout to be more than systemd default timeout.