### PR TITLE
Problem: build-ha-io restore logic is broken

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -892,11 +892,11 @@ declare -A ha_ops_type=(
 for op in ${ha_ops[@]}; do
     if $restore_conf && [[ ${ha_ops_type[$op]} =~ .*'restore'.* ]]; then
         $op
-    elif ! $update && ! $restore_conf [[ ${ha_ops_type[$op]} =~ .*'bootstrap'.* ]]; then
+    elif ! $update && ! $restore_conf && [[ ${ha_ops_type[$op]} =~ .*'bootstrap'.* ]]; then
         cib_init
         $op
         cib_commit
-    elif $update && $restore_conf [[ ${ha_ops_type[$op]} =~ .*'update'.* ]]; then
+    elif $update && [[ ${ha_ops_type[$op]} =~ .*'update'.* ]]; then
         # We are using existing CIB as a base and re-applying the pcs
         # instructions, thus some instructions would already exist in the
         # CIB, we ignore them.


### PR DESCRIPTION
Restore function was added to support node replacement backup and restore. As
part of this there was a bug introduced due to missing and condition for
bootstrap calls. This was leading to invocation of restore function during
bootstrap.

Solution:
Add an and condition while checking for restore_conf flag in bootstrap path
as well as update path.