### PR TITLE
Problem: motr uuid file is missing on the replaced node

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -297,21 +297,6 @@ bootstrap_update_only() {
     hctl shutdown
 }
 
-# Invoked as part of initialisation during node replacement.
-motr_config_init() {
-    if [[ ! -e /etc/sysconfig/motr-kernel ]]; then
-        echo "MOTR_NODE_UUID='$(uuidgen --time)'" |
-            sudo tee /etc/sysconfig/motr-kernel >/dev/null
-    fi
-
-# It is expected for /var/lib/hare/confd.xc to be present during node
-# replacement as a pre step.
-    [[ -f /var/lib/hare/confd.xc ]] ||
-        die 'Cannot bootstrap server node without /var/lib/hare/confd.xc file'
-    sudo mkdir -p /etc/motr
-    sudo cp /var/lib/hare/confd.xc /etc/motr/
-}
-
 motr_config() {
     # Prepare Motr conf files on each node:
     lm0confs=$(echo /etc/sysconfig/m0d-*)
@@ -821,7 +806,6 @@ ha_ops=(
     net_config_check
     bootstrap
     bootstrap_update_only
-    motr_config_init
     motr_config
     consul_systemd_prepare
     consul_systemd_update
@@ -861,7 +845,6 @@ declare -A ha_ops_type=(
     [net_config_check]='bootstrap'
     [bootstrap]='bootstrap'
     [bootstrap_update_only]='update-only'
-    [motr_config_init]='restore'
     [motr_config]='bootstrap'
     [consul_systemd_prepare]='bootstrap_update_restore'
     [consul_systemd_update]='bootstrap_update_restore'

--- a/conf/setup-ees.yaml
+++ b/conf/setup-ees.yaml
@@ -38,6 +38,8 @@ ees-ha:
       - /var/lib/hare/cluster.yaml
       - /var/lib/hare/confd.xc
       - /var/lib/hare/confd.dhall
+      - /etc/sysconfig/motr-kernel
+      - /etc/motr/confd.xc
   post_update:
     script: /opt/seagate/cortx/ha/conf/script/build-ees-ha-update
     args:


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
motr-kernel UUID file missing on the replaced node.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem
<pre>
  <code>
After node replacement motr uuid file needs to re-created. Motr uuid
file recreation was added as part of restore-conf feature but this requires
provisioner refresh-config to be executed on the replaced node.
  </code>
</pre>
## Solution
<pre>
  <code>
Instead of recreation add /etc/sysconfig/motr-kernel file to backup section
of setup-ees.yaml file. This will remove dependency of invoking refresh-config
on the replaced node.
  </code>
</pre>
## Unit Testing
<pre>
  <code>
None as part of provisioner backup - restore.
  </code>
</pre>
