### PR TITLE
build-ees-ha-update: fix build-cortx-ha init call

### DIFF
--- a/conf/script/build-ees-ha-update
+++ b/conf/script/build-ees-ha-update
@@ -93,7 +93,6 @@ $ha_script/build-ha-io $cdf $ioargsfile --cib-file $cib_file --update
 $ha_script/build-ees-ha-csm $csmargsfile --cib-file $cib_file --update
 $ha_script/build-ha-sspl $ioargsfile --cib-file $cib_file --update
 $ha_script/build-ees-ha-uds --cib-file $cib_file --update
-$ha_script/build-cortx-ha init
 
 #XXX Presently replacing the cib xml file does not work if in new versions
 # the resources are deleted.
@@ -101,6 +100,9 @@ $ha_script/build-cortx-ha init
 #cibadmin --replace --xml-file $cib_file
 echo 'Updating Pacemaker CIB...'
 sudo pcs cluster cib-push $cib_file --config
+
+$ha_script/build-cortx-ha init
+
 sudo pcs resource cleanup
 
 echo 'Importing Consul KV...'


### PR DESCRIPTION
build-cortx-ha init should be run *after* pcs cluster cib-push,
otherwise, some resources (like csm-agent) would not be available
in Pacemaker cluster yet and there will be the following error
on SW update:

```
Error: Resource 'csm-agent' not found
Error performing operation: No such device or address
```