### PR TITLE
Problem: sspl and csm resource remain undeleted on reset

### DIFF
--- a/conf/script/prov-ha-csm-reset
+++ b/conf/script/prov-ha-csm-reset
@@ -24,7 +24,10 @@ resources=(
     csm-web
     kibana
     kibana-vip
+    uds
+    mgmt_path_health-c1
 )
 for r in ${resources[@]}; do
     pcs resource delete $r || true
 done
+pcs resource cleanup

--- a/conf/script/prov-ha-sspl-reset
+++ b/conf/script/prov-ha-sspl-reset
@@ -20,3 +20,5 @@ export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 # set -x
 
 pcs resource delete sspl || true
+pcs resource delete sspl_primary_hw || true
+pcs resource cleanup


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    sspl and csm pacemaker resource remain undeleted on provisioner command `destroy --ctrl-states`.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Executed scripts directly on the hardware setup. Resources were deleted successfully.
  </code>
</pre>
## Problem Description
<pre>
  <code>
It is seen that even  after `pcs resource delete` command sspl and csm
resources remain in the pacemaker resources list and don't get removed.
  </code>
</pre>
## Solution
<pre>
  <code>
- Delete sspl_master_hw resource along with sspl resource.
- Run `pcs resource cleanup after `pcs resource delete` commands.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    1. Run sspl and csm reset scripts on the cluster, resource should be deleted successfully.
  </code>
</pre>
