### PR TITLE
Problem: argparse library makes pcswrap unreadable 

### DIFF
--- a/ha/pcswrap/pcswrap/__init__.py
+++ b/ha/pcswrap/pcswrap/__init__.py
@@ -1,15 +1,16 @@
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 #
-# This program is free software: you can redistribute it and/or modify it under the
-# terms of the GNU Affero General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+# for more details.
 #
-# You should have received a copy of the GNU Affero General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
-# about this software or licensing, please email opensource@seagate.com or
-# cortx-questions@seagate.com.
-
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>. For
+# any questions about this software or licensing, please emai
+# opensource@seagate.com or cortx-questions@seagate.com.

--- a/ha/pcswrap/pcswrap/cli/__init__.py
+++ b/ha/pcswrap/pcswrap/cli/__init__.py
@@ -1,0 +1,149 @@
+import re
+
+import click
+from click.exceptions import UsageError
+from pcswrap.cli.types import (CLIContext, MaintenanceAll, NoOp, Shutdown,
+                               Standby, StandbyAll, Status, UnmaintenanceAll,
+                               Unstandby, UnstandbyAll)
+from pcswrap.types import Credentials
+
+
+def _sanitize_name(name):
+    name = name.strip('-')
+    return re.sub('-', '_', name)
+
+
+def ensure_either_exists(ctx, var_a, var_b):
+    a = _sanitize_name(var_a)
+    b = _sanitize_name(var_b)
+    ok = bool(ctx.params[a]) ^ bool(ctx.params[b])
+    if not ok:
+        raise UsageError(f'Either {var_a} or {var_b} must be specified. '
+                         'Please choose one.')
+
+
+def ensure_if_first_then_second(ctx, var_a, var_b):
+    a = _sanitize_name(var_a)
+    b = _sanitize_name(var_b)
+    ok = not bool(ctx.params[a]) or bool(ctx.params[b])
+    if not ok:
+        raise UsageError(
+            f'If {var_a} specified then {var_b} is also required. '
+            f' Please add {var_b}.')
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command(help='Show status of all cluster nodes.')
+@click.option('--full',
+              default=False,
+              is_flag=True,
+              help='Show overall cluster status, so not only nodes '
+              'will be included.')
+@click.pass_context
+def status(ctx, full):
+    ctx.obj['command'] = Status(is_full=full)
+    return ctx.obj
+
+
+@cli.command(help='Shutdown (power off) the node by name.')
+@click.argument('node')
+@click.option('--timeout-sec',
+              type=int,
+              default=120,
+              help='Maximum time that this command will'
+              ' wait for any operation to complete before raising an error')
+@click.pass_context
+def shutdown(ctx, node, timeout_sec):
+    ctx.obj['timeout_sec'] = timeout_sec
+    ctx.obj['command'] = Shutdown(node=node)
+    return ctx.obj
+
+
+@cli.command(help='Switch the cluster to maintenance mode.')
+@click.option('--all', is_flag=True, required=True)
+@click.option('--timeout-sec',
+              type=int,
+              default=120,
+              help='Maximum time that this command will'
+              ' wait for any operation to complete before raising an error')
+@click.pass_context
+def maintenance(ctx, timeout_sec, **kwargs):
+    ctx.obj['timeout_sec'] = timeout_sec
+    ctx.obj['command'] = MaintenanceAll()
+    return ctx.obj
+
+
+@cli.command(help='Move the cluster from maintenance back to normal mode.')
+@click.option('--all', is_flag=True, required=True)
+@click.option('--timeout-sec',
+              type=int,
+              default=120,
+              help='Maximum time that this command will'
+              ' wait for any operation to complete before raising an error')
+@click.pass_context
+def unmaintenance(ctx, timeout_sec, **kwargs):
+    ctx.obj['timeout_sec'] = timeout_sec
+    ctx.obj['command'] = UnmaintenanceAll()
+    return ctx.obj
+
+
+@cli.command(help='Put the given node into standby mode.')
+@click.option('--all',
+              default=False,
+              is_flag=True,
+              help='Put all the nodes in the cluster to standby mode (no node '
+              'name is required).')
+@click.argument('node', required=False)
+@click.pass_context
+def standby(ctx, all=False, node=None):
+    ensure_either_exists(ctx, '--all', 'node')
+    ctx.obj['command'] = StandbyAll() if all else Standby(node=node)
+    return ctx.obj
+
+
+@cli.command(help='Remove the given node from standby mode.')
+@click.option('--all',
+              default=False,
+              is_flag=True,
+              help='Remove all the nodes in the cluster from standby mode '
+              '(no node name is required).')
+@click.argument('node', required=False)
+@click.pass_context
+def unstandby(ctx, all=False, node=None):
+    ensure_either_exists(ctx, '--all', 'node')
+    ctx.obj['command'] = UnstandbyAll() if all else Unstandby(node=node)
+    return ctx.obj
+
+
+# This is a workaround for https://github.com/pallets/click/issues/347
+@click.command(cls=click.CommandCollection, sources=[cli])  # type: ignore
+@click.option('--verbose', default=False, is_flag=True)
+@click.option('--username')
+@click.option('--password')
+@click.pass_context
+def cli_main(ctx, verbose, username, password):
+    ctx.ensure_object(dict)
+    ctx.obj['verbose'] = verbose
+    ctx.obj['auth'] = None
+    ensure_if_first_then_second(ctx, 'username', 'password')
+    if username:
+        ctx.obj['auth'] = Credentials(username=username, password=password)
+    return ctx.obj
+
+
+def parse_opts(**kwargs) -> CLIContext:
+    result = cli_main(**kwargs)
+    if not isinstance(result, dict):
+        return CLIContext(command=NoOp(),
+                          auth=None,
+                          verbose=False,
+                          timeout_sec=0)
+
+    return CLIContext(command=result['command'],
+                      auth=result.get('auth', None),
+                      verbose=result['verbose'],
+                      timeout_sec=result['timeout_sec'])

--- a/ha/pcswrap/pcswrap/cli/types.py
+++ b/ha/pcswrap/pcswrap/cli/types.py
@@ -1,0 +1,51 @@
+from typing import NamedTuple, Optional
+from pcswrap.types import Credentials
+
+
+class Command():
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class CLIContext(NamedTuple):
+    command: Command
+    auth: Optional[Credentials]
+    verbose: bool
+    timeout_sec: int
+
+
+class MaintenanceAll(Command):
+    pass
+
+
+class UnmaintenanceAll(Command):
+    pass
+
+
+class StandbyAll(Command):
+    pass
+
+
+class Standby(Command):
+    node: str
+
+
+class UnstandbyAll(Command):
+    pass
+
+
+class Unstandby(Command):
+    node: str
+
+
+class Shutdown(Command):
+    node: str
+
+
+class Status(Command):
+    is_full: bool
+
+
+class NoOp(Command):
+    pass

--- a/ha/pcswrap/pcswrap/client.py
+++ b/ha/pcswrap/pcswrap/client.py
@@ -1,27 +1,16 @@
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-#
-# This program is free software: you can redistribute it and/or modify it under the
-# terms of the GNU Affero General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
-# about this software or licensing, please email opensource@seagate.com or
-# cortx-questions@seagate.com.
-
-import argparse
 import json
 import logging
 import os
 import sys
-from typing import Any, Callable, List, Optional
+from typing import Callable, List, Optional
 
+from click import ClickException
 from systemd import journal
 
+from pcswrap.cli import parse_opts
+from pcswrap.cli.types import (MaintenanceAll, NoOp, Shutdown, Standby,
+                               StandbyAll, Status, UnmaintenanceAll, Unstandby,
+                               UnstandbyAll)
 from pcswrap.exception import CliException, MaintenanceFailed, TimeoutException
 from pcswrap.internal.connector import CliConnector
 from pcswrap.internal.waiter import Waiter
@@ -221,167 +210,46 @@ class AppRunner:
     def __init__(self):
         self._get_client = self._get_client_default
 
-    def _get_client_default(self, args: Any) -> Client:
-        creds = None
-        if args.username:
-            if not args.password:
-                raise RuntimeError('--password argument is required'
-                                   ' when --username is given')
-            creds = Credentials(username=args.username[0],
-                                password=args.password[0])
-        return Client(credentials=creds)
+    def _get_client_default(self, auth: Optional[Credentials]) -> Client:
+        return Client(credentials=auth)
 
     def run(self, argv: List[str]) -> None:
-        args = self._parse_opts(argv)
+        prog_name = os.environ.get('PCSCLI_PROG_NAME')
+        ctx = parse_opts(args=argv,
+                         prog_name=prog_name,
+                         standalone_mode=False,
+                         obj={'timeout_sec': 120})
 
         def client() -> Client:
             # This function is added to shorten the code below (no need for
             # "self." prefix and no need to add parameters)
-            return self._get_client(args)
+            return self._get_client(ctx.auth)
 
-        is_verbose = args.verbose
-        _setup_logging(is_verbose)
-
-        if hasattr(args, 'standby_node'):
-            if args.standby_node_all:
-                client().standby_all()
-            else:
-                client().standby_node(args.standby_node)
-        elif hasattr(args, 'unstandby_node'):
-            if args.unstandby_node_all:
-                client().unstandby_all()
-            else:
-                client().unstandby_node(args.unstandby_node)
-        elif hasattr(args, 'show_status'):
-            print(client().get_status(is_full=args.full_status))
-        elif hasattr(args, 'shutdown_node'):
-            node = args.shutdown_node[0]
-            client().shutdown_node(node, timeout=args.timeout_sec)
-        elif hasattr(args, 'maintenance_all'):
-            client().cluster_maintenance(timeout=args.timeout_sec)
-        elif hasattr(args, 'unmaintenance_all'):
-            client().cluster_unmaintenance(timeout=args.timeout_sec)
-
-    def _parse_opts(self, argv: List[str]) -> Any:
-        prog_name = os.environ.get('PCSCLI_PROG_NAME')
-
-        p = argparse.ArgumentParser(
-            prog=prog_name, description='Manages the nodes in HA cluster.')
-        p.add_argument('--verbose',
-                       help='Be verbose while executing',
-                       action='store_true',
-                       default=False,
-                       dest='verbose')
-
-        p.add_argument('--username',
-                       help='Username for local authentication at pcsd.'
-                       f' This setting must be specified if {prog_name} is '
-                       ' invoked with non-root privileges.',
-                       dest='username',
-                       nargs=1,
-                       type=str)
-
-        p.add_argument('--password',
-                       help='Password for local authentication at pcsd.'
-                       ' Makes sense if --username is specified.',
-                       dest='password',
-                       nargs=1,
-                       type=str)
-
-        subparsers = p.add_subparsers()
-        status_parser = subparsers.add_parser(
-            'status',
-            help='Show status of all cluster nodes',
-        )
-        unstandby_parser = subparsers.add_parser(
-            'unstandby', help='Remove the given node from standby mode.')
-        standby_parser = subparsers.add_parser(
-            'standby', help='Put the given node into standby mode.')
-        shutdown_parser = subparsers.add_parser(
-            'shutdown', help='Shutdown (power off) the node by name.')
-
-        standby_parser.add_argument('standby_node',
-                                    type=str,
-                                    nargs='?',
-                                    help='Name of the node the operation must '
-                                    'be applied to.')
-        standby_parser.add_argument(
-            '--all',
-            action='store_true',
-            default=False,
-            dest='standby_node_all',
-            help='Put all the nodes in the cluster to standby mode (no node '
-            'name is required)')
-        unstandby_parser.add_argument('unstandby_node',
-                                      type=str,
-                                      nargs='?',
-                                      help='Name of the node the operation '
-                                      'must be applied to.')
-        unstandby_parser.add_argument(
-            '--all',
-            action='store_true',
-            default=False,
-            dest='unstandby_node_all',
-            help='Remove all the nodes in the cluster from standby mode '
-            '(no node name is required).')
-        status_parser.add_argument('--stub',
-                                   dest='show_status',
-                                   default=True,
-                                   help=argparse.SUPPRESS)
-        status_parser.add_argument(
-            '--full',
-            action='store_true',
-            dest='full_status',
-            default=False,
-            help='Show overall cluster status, so not only nodes '
-            'will be included')
-        shutdown_parser.add_argument('shutdown_node',
-                                     type=str,
-                                     nargs=1,
-                                     help='Name of the node to poweroff')
-        shutdown_parser.add_argument(
-            '--timeout-sec',
-            type=int,
-            dest='timeout_sec',
-            default=120,
-            help='Maximum time that this command will'
-            ' wait for any operation to complete before raising an error')
-
-        maintenance_parser = subparsers.add_parser(
-            'maintenance',
-            help='Switch the cluster to maintenance mode',
-        )
-        maintenance_parser.add_argument('--all',
-                                        dest='maintenance_all',
-                                        default=False,
-                                        action='store_true')
-
-        maintenance_parser.add_argument(
-            '--timeout-sec',
-            type=int,
-            dest='timeout_sec',
-            default=120,
-            help='Maximum time that this command will'
-            ' wait for any operation to complete before raising an error')
-
-        unmaintenance_parser = subparsers.add_parser(
-            'unmaintenance',
-            help='Move the cluster from maintenance back to normal mode',
-        )
-        unmaintenance_parser.add_argument('--all',
-                                          dest='unmaintenance_all',
-                                          default=False,
-                                          action='store_true')
-
-        unmaintenance_parser.add_argument(
-            '--timeout-sec',
-            type=int,
-            dest='timeout_sec',
-            default=120,
-            help='Maximum time that this command will'
-            ' wait for any operation to complete before raising an error')
-        opts = p.parse_args(argv)
-        return opts
+        _setup_logging(ctx.verbose)
+        cmd = ctx.command
+        if isinstance(cmd, Standby):
+            client().standby_node(cmd.node)
+        elif isinstance(cmd, StandbyAll):
+            client().standby_all(ctx.timeout_sec)
+        elif isinstance(cmd, Unstandby):
+            client().unstandby_node(cmd.node)
+        elif isinstance(cmd, UnstandbyAll):
+            client().unstandby_all(ctx.timeout_sec)
+        elif isinstance(cmd, Shutdown):
+            client().shutdown_node(cmd.node, timeout=ctx.timeout_sec)
+        elif isinstance(cmd, MaintenanceAll):
+            client().cluster_maintenance(ctx.timeout_sec)
+        elif isinstance(cmd, UnmaintenanceAll):
+            client().cluster_unmaintenance(ctx.timeout_sec)
+        elif isinstance(cmd, Status):
+            print(client().get_status(cmd.is_full))
+        elif isinstance(cmd, NoOp):
+            # --help or some other eager option was passed, nothing to
+            # process here
+            pass
+        else:
+            raise RuntimeError('Business logic error: unknown '
+                               f'command given - {cmd}')
 
 
 def main() -> None:
@@ -399,6 +267,9 @@ def main() -> None:
             ' the cluster to normal mode manually.', prog_name)
         sys.exit(1)
 
+    except ClickException as e:
+        e.show()
+        sys.exit(1)
     except CliException as e:
         logging.error('Exiting with FAILURE: %s', e)
         logging.debug('Detailed info', exc_info=True)

--- a/ha/pcswrap/pcswrap/exception.py
+++ b/ha/pcswrap/pcswrap/exception.py
@@ -1,17 +1,19 @@
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 #
-# This program is free software: you can redistribute it and/or modify it under the
-# terms of the GNU Affero General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+# for more details.
 #
-# You should have received a copy of the GNU Affero General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
-# about this software or licensing, please email opensource@seagate.com or
-# cortx-questions@seagate.com.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>. For
+# any questions about this software or licensing, please emai
+# opensource@seagate.com or cortx-questions@seagate.com.
 
 from dataclasses import dataclass
 

--- a/ha/pcswrap/pcswrap/internal/__init__.py
+++ b/ha/pcswrap/pcswrap/internal/__init__.py
@@ -1,15 +1,16 @@
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 #
-# This program is free software: you can redistribute it and/or modify it under the
-# terms of the GNU Affero General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+# for more details.
 #
-# You should have received a copy of the GNU Affero General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
-# about this software or licensing, please email opensource@seagate.com or
-# cortx-questions@seagate.com.
-
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>. For
+# any questions about this software or licensing, please emai
+# opensource@seagate.com or cortx-questions@seagate.com.

--- a/ha/pcswrap/pcswrap/internal/connector.py
+++ b/ha/pcswrap/pcswrap/internal/connector.py
@@ -1,17 +1,19 @@
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 #
-# This program is free software: you can redistribute it and/or modify it under the
-# terms of the GNU Affero General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+# for more details.
 #
-# You should have received a copy of the GNU Affero General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
-# about this software or licensing, please email opensource@seagate.com or
-# cortx-questions@seagate.com.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>. For
+# any questions about this software or licensing, please emai
+# opensource@seagate.com or cortx-questions@seagate.com.
 
 import logging
 import re

--- a/ha/pcswrap/pcswrap/internal/waiter.py
+++ b/ha/pcswrap/pcswrap/internal/waiter.py
@@ -1,17 +1,19 @@
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 #
-# This program is free software: you can redistribute it and/or modify it under the
-# terms of the GNU Affero General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+# for more details.
 #
-# You should have received a copy of the GNU Affero General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
-# about this software or licensing, please email opensource@seagate.com or
-# cortx-questions@seagate.com.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>. For
+# any questions about this software or licensing, please emai
+# opensource@seagate.com or cortx-questions@seagate.com.
 
 import logging
 from pcswrap.exception import TimeoutException

--- a/ha/pcswrap/pcswrap/types.py
+++ b/ha/pcswrap/pcswrap/types.py
@@ -1,17 +1,19 @@
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 #
-# This program is free software: you can redistribute it and/or modify it under the
-# terms of the GNU Affero General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+# for more details.
 #
-# You should have received a copy of the GNU Affero General Public License along
-# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
-# about this software or licensing, please email opensource@seagate.com or
-# cortx-questions@seagate.com.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>. For
+# any questions about this software or licensing, please emai
+# opensource@seagate.com or cortx-questions@seagate.com.
 
 from abc import ABC, abstractmethod
 from typing import List, NamedTuple, Optional

--- a/ha/pcswrap/requirements.txt
+++ b/ha/pcswrap/requirements.txt
@@ -1,8 +1,9 @@
+click
 dataclasses
 defusedxml
+systemd
 flake8
 mypy
 pkgconfig
 setuptools
-systemd
 wheel

--- a/ha/pcswrap/tests/status-xml-plain-resources.xml
+++ b/ha/pcswrap/tests/status-xml-plain-resources.xml
@@ -1,22 +1,3 @@
-<!--
-
- Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
- This program is free software: you can redistribute it and/or modify it under the
- terms of the GNU Affero General Public License as published by the Free Software
- Foundation, either version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful, but WITHOUT ANY
- WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License along
- with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
- about this software or licensing, please email opensource@seagate.com or
- cortx-questions@seagate.com.
-
--->
-
 <?xml version="1.0"?>
 <crm_mon version="1.1.20">
     <summary>

--- a/ha/pcswrap/tests/status-xml-w-clones.xml
+++ b/ha/pcswrap/tests/status-xml-w-clones.xml
@@ -1,22 +1,3 @@
-<!--
-
- Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
-
- This program is free software: you can redistribute it and/or modify it under the
- terms of the GNU Affero General Public License as published by the Free Software
- Foundation, either version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful, but WITHOUT ANY
- WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License along
- with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
- about this software or licensing, please email opensource@seagate.com or
- cortx-questions@seagate.com.
-
--->
-
 <?xml version="1.0"?>
 <crm_mon version="1.1.20">
     <summary>

--- a/ha/pcswrap/tests/test_cli_arguments.py
+++ b/ha/pcswrap/tests/test_cli_arguments.py
@@ -18,8 +18,10 @@ import sys
 sys.path.insert(0, '..')
 from unittest.mock import MagicMock, call
 from pcswrap.client import Client, AppRunner
+from pcswrap.types import Credentials
 from pcswrap.internal.connector import CliExecutor, CliConnector
 from typing import Tuple
+from click.exceptions import ClickException
 import unittest
 import os
 import inspect
@@ -70,7 +72,7 @@ class AppRunnerTest(unittest.TestCase):
         stub_client = mock_methods(stub_client)
 
         runner = AppRunner()
-        runner._get_client = lambda x: stub_client
+        runner._get_client = MagicMock(return_value=stub_client)
         return (stub_client, runner)
 
     def test_status_works(self):
@@ -82,6 +84,17 @@ class AppRunnerTest(unittest.TestCase):
 
         runner.run(['status'])
         self.assertTrue(stub_client.get_status.called)
+        self.assertEqual([call(False)],
+                         stub_client.get_status.call_args_list)
+
+    def test_status_full_works(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.get_status = MagicMock()
+
+        runner.run(['status', '--full'])
+        self.assertTrue(stub_client.get_status.called)
+        self.assertEqual([call(True)],
+                         stub_client.get_status.call_args_list)
 
     def test_standby_single_node_works(self):
         stub_client, runner = self._create_client_and_runner()
@@ -106,6 +119,25 @@ class AppRunnerTest(unittest.TestCase):
         self.assertTrue(stub_client.unstandby_node.called)
         self.assertEqual([call('mynode')],
                          stub_client.unstandby_node.call_args_list)
+
+    def test_credentials_parsed(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.unstandby_node = MagicMock()
+        runner.run(
+            ['--username=test', '--password=test2', 'unstandby', 'mynode'])
+        self.assertTrue(stub_client.unstandby_node.called)
+        self.assertEqual([call('mynode')],
+                         stub_client.unstandby_node.call_args_list)
+        self.assertEqual(
+            [call(Credentials(username='test', password='test2'))],
+            runner._get_client.call_args_list)
+
+    def test_if_username_given_password_required(self):
+        stub_client, runner = self._create_client_and_runner()
+        stub_client.unstandby_node = MagicMock()
+        with self.assertRaises(ClickException):
+            runner.run(['--username=test', 'unstandby', 'mynode'])
+        self.assertFalse(stub_client.unstandby_node.called)
 
     def test_unstandby_all_works(self):
         stub_client, runner = self._create_client_and_runner()
@@ -135,3 +167,15 @@ class AppRunnerTest(unittest.TestCase):
         self.assertTrue(stub_client.shutdown_node.called)
         self.assertEqual([call('node01', timeout=120)],
                          stub_client.shutdown_node.call_args_list)
+
+    def test_help_not_fails(self):
+        stub_client, runner = self._create_client_and_runner()
+
+        # No exception is expected
+        runner.run(['--help'])
+
+    def test_unknown_command_triggers_exception(self):
+        stub_client, runner = self._create_client_and_runner()
+
+        with self.assertRaises(ClickException):
+            runner.run(['unbeknownst'])


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
CLI parsing logic must be short, self-descriptive and easy to test.
  </code>
</pre>
Closes #57 

## Unit testing on RPM done
<pre>
  <code>
Yes, there are automated unit tests that are included into RPM build procedure
  </code>
</pre>
## Problem Description
<pre>
  <code>
CLI parsing logic is currently done with argparse library. pcswrap has
quite complex CLI structure which turns into long and not obvious
argparse-specific code and result processing is tricky as well. This
makes the code error-prone.

  </code>
</pre>
## Solution
<pre>
  <code>
use click library instead of argparse.
  </code>
</pre>
## Unit Test Cases
<pre>
See https://github.com/knekrasov/cortx-ha/tree/pcswrap-uses-click/ha/pcswrap/tests
</pre>
