### PR TITLE
Changes for EOS-13061: SSPL and HA should use cortx-py-utils rpms inst…

### DIFF
--- a/jenkins/cicd/cortx-ha-dep.sh
+++ b/jenkins/cicd/cortx-ha-dep.sh
@@ -56,13 +56,13 @@ else
     source "${VENV}/bin/activate"
 
     echo "Installing python packages..."
-    pip install --upgrade pip
-    pip install git+https://"${TOKEN}"@github.com/Seagate/cortx-py-utils.git
+    python3 -m pip install --upgrade pip
+    python3 -m pip install git+https://"${TOKEN}"@github.com/Seagate/cortx-utils.git#subdirectory=py-utils
     req_file=${BASE_DIR}/jenkins/pyinstaller/requirements.txt
-    pip install -r "$req_file" || {
+    python3 -m pip install -r "$req_file" || {
         echo "Unable to install package from $req_file"; exit 1;
     };
-    deavtivate
+    deactivate
 
     echo "Execute:"
     echo "**************************************"


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    HA was using the older repository location to get the cortx-py-utils
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
     HA was using the older repository location to get the cortx-py-utils
  </code>
</pre>
## Solution
<pre>
  <code>
    Modified the HA code to use the new repo location for cortx-py-utils
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Executed the modified file on VM, confirmed that its able to pickup the utility from the new location
  </code>
</pre>
