### PR TITLE
EOS-13167 - SSPL state file access issue

### DIFF
--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -216,4 +216,7 @@ usage|help)     stateful_usage $OCF_SUCCESS;;
 *)              stateful_usage $OCF_ERR_UNIMPLEMENTED;;
 esac
 
+chown sspl-ll:sspl-ll /var/cortx/sspl/data/state.txt
+chmod 644 /var/cortx/sspl/data/state.txt
+
 exit $?


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
EOS-13167 - SSPL state file access issue
SSPL cannot access the state.txt file:
Sep 11 11:27:32 localhost sspl-ll[30797]: WARNING Error in reading state file: [Errno 13] Permission denied: '/var/cortx/sspl/data/state.txt' (sspl_ll_d:625)

This needs to be fixed in SSPL resource agent script where sspl-ll user needs to be added as an owner of this file too.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Your Problem decription here...
  </code>
</pre>
## Solution
<pre>
  <code>
    Your Problem solution here...
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
