### PR TITLE
Problem: S3 resources do not stop when motr stack migrated to another node

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -530,12 +530,16 @@ hax_systemd_update() {
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/' \
              -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr || /bin/mount $lvolume /var/motr'" \
              -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr || while ! /bin/umount /var/motr; do lsof +D /var/motr; sleep 1; done'" \
+             -e "/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running" \
+             -e "/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running" \
              -i /usr/lib/systemd/system/hare-hax-c1.service
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
              -e 's;ExecStart.*cd /var/motr;&2;' \
              -e "/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c2" \
              -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr2 || /bin/mount $rvolume /var/motr2'" \
              -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr2 || while ! /bin/umount /var/motr2; do lsof +D /var/motr2; sleep 1; done'" \
+             -e "/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running" \
+             -e "/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running" \
              -i /usr/lib/systemd/system/hare-hax-c2.service
     echo "HARE_HAX_NODE_NAME=$rnode" | sudo tee $hare_dir/hax-env-c2 > /dev/null
 
@@ -547,12 +551,16 @@ hax_systemd_update() {
              -e '/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c1'
              -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr1 || /bin/mount $lvolume /var/motr1'\"
              -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr1 || while ! /bin/umount /var/motr1; do lsof +D /var/motr1; sleep 1; done'\"
+             -e \"/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running\"
+             -e \"/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running\"
              -i /usr/lib/systemd/system/hare-hax-c1.service &&
     sudo cp -f /usr/lib/systemd/system/hare-hax.service
             /usr/lib/systemd/system/hare-hax-c2.service &&
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/'
              -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr || /bin/mount $rvolume /var/motr'\"
              -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr || while ! /bin/umount /var/motr; do lsof +D /var/motr; sleep 1; done'\"
+             -e \"/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running\"
+             -e \"/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running\"
              -i /usr/lib/systemd/system/hare-hax-c2.service &&
     echo 'HARE_HAX_NODE_NAME=$lnode' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
     ssh $rnode $cmd
@@ -632,6 +640,12 @@ clusterip_rsc_add() {
         log "${FUNCNAME[0]}: Adding ClusterIP constraints in Pacemaker..."
         sudo pcs -f $cib_file constraint order c1 then ClusterIP-clone
         sudo pcs -f $cib_file constraint order c2 then ClusterIP-clone
+        # Make ClusterIP to run only on nodes where motr and S3 stack are
+        # present. S3 stack shall follow the same constraint.
+        sudo pcs -f $cib_file constraint location ClusterIP-clone rule \
+            score=-INFINITY '#uname' eq $lnode and hax-running eq 0
+        sudo pcs -f $cib_file constraint location ClusterIP-clone rule \
+            score=-INFINITY '#uname' eq $rnode and hax-running eq 0
     fi
 }
 
@@ -663,6 +677,12 @@ s3auth_rsc_add() {
     sudo pcs -f $cib_file constraint order ldap-clone then s3auth-clone
     sudo pcs -f $cib_file constraint order motr-ios-c1 then s3auth-clone
     sudo pcs -f $cib_file constraint order motr-ios-c2 then s3auth-clone
+    # Make s3auth resource to run only on nodes where motr and hax are present.
+    # All s3server resources shall follow s3auth due to colocation constraint.
+    sudo pcs -f $cib_file constraint location s3auth-clone rule score=-INFINITY '#uname' \
+        eq $lnode and hax-running eq 0
+    sudo pcs -f $cib_file constraint location s3auth-clone rule score=-INFINITY '#uname' \
+        eq $rnode and hax-running eq 0
 }
 
 elastic_search_rsc_add() {


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
S3 resources do not stop when motr stack migrated to another node
Jira issue: https://jts.seagate.com/browse/EOS-9758 
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No. Checked manually on HW setup.
  </code>
</pre>
## Problem Description
<pre>
  <code>

This makes s3server to fail and produce a lot of traces which consume
disk space on shared partition affecting another node.
ClusterIP resource shall also migrate after motr-stack since "failed"
node can't serve requests anymore.
  </code>
</pre>
## Solution
<pre>
  <code>
* Add hax-running attribute which is set to 1 when hax is
  started on current node and set to 0 when hax is stopped (Exec Post-hooks
  in systemd file).
* Add location constrains for ClusterIP-clone and s3auth-clone resources
  to make them migrate/stop when hax (i.e. motr-stack) is not running on
  current node. Since s3server-cN resources are colocated with s3auth
  and can't work on opposite nodes - they will be stopped on "failed"
  node.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit testing is not applicable - only integration testing.
    Need to check that s3server-cN and s3auth resources are stopped on node A when failover to node B happened.
    Need to check that failback happens without errors or fencing events.
  </code>
</pre>
