### PR TITLE
EOS-13529: components.ha.iostack-ha.refresh_config fails

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -450,8 +450,8 @@ consul_conf_prepare() {
 
 # Required in case of node replacement.
 node_backup() {
-    to=$1
-    from=$2
+    from=$1
+    to=$2
 
     ssh $to "sudo mkdir -p /var/lib/hare/$from"
     ssh $to "sudo mkdir -p /etc/sysconfig/$from"
@@ -470,25 +470,26 @@ conf_backup() {
 
 # Required in case of node replacement.
 node_restore() {
-    to=$1
-    from=$2
+    from=$1
+    to=$2
 
-    if ssh $to "[ -d /var/lib/hare/$from ]"; then
+    if ssh $from "[ -d /var/lib/hare/$to ]"; then
+        ssh $to "sudo mkdir -p /var/lib/hare"
         # Restore files on lnode from rnode
-        sudo scp -r "$to:/var/lib/hare/$from/consul-*" $from:/var/lib/hare
-        sudo scp "$to:/var/lib/hare/$from/node-name" $from:/var/lib/hare
-        sudo scp "$to:/var/lib/hare/$from/hax-env-*" $from:/var/lib/hare
-        sudo scp "$to:/etc/sysconfig/$from/m0d-*" $from:/etc/sysconfig
-        sudo scp "$to:/etc/sysconfig/$from/s3server-*" $from:/etc/sysconfig
+        sudo scp -r "$from:/var/lib/hare/$to/consul-*" $to:/var/lib/hare/
+        sudo scp "$from:/var/lib/hare/$to/node-name" $to:/var/lib/hare/
+        sudo scp "$from:/var/lib/hare/$to/hax-env-*" $to:/var/lib/hare/
+        sudo scp "$from:/etc/sysconfig/$to/m0d-*" $to:/etc/sysconfig/
+        sudo scp "$from:/etc/sysconfig/$to/s3server-*" $to:/etc/sysconfig/
     fi
-
-   # Backup from each node on each node again.
-   conf_backup
 }
 
 conf_restore() {
     node_restore $lnode $rnode
     node_restore $rnode $lnode
+
+   # Backup from each node on each node again.
+   conf_backup
 }
 
 consul_rsc_add() {


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
 iostack refresh config fails during node replacement
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Not on rpm, but explicitly on the hardware with local changes.
 Executed
```
/opt/seagate/cortx/provisioner/cli/src/replace_node/deploy-replacement -S srvnode-2
```
  </code>
</pre>
## Problem Description
<pre>
  <code>
As part of the node restore operation, backup of peer node was also being
created during restore. This was triggering restore from replaced node
to the active node as well. As during restore operation consul db is
restored, this leads to consul crash if consul is active on the node
leading to other service failures.
  </code>
</pre>
## Solution
<pre>
  <code>
- During restore perform backup only after completing the restore operation.
- Simplify node_backup() and node_restore()
- Create /var/lib/hare/ on replaced node if does not exists already during
  restore.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- Start 2 node cluster 
- Stop node, cleanup configuration
- Run backup/restore functions explicitly on local 2 node cluster setup.
- Start node
  </code>
</pre>
