### PR TITLE
EOS-13393: fix nodes fencing issue on sporadic hax stop timeouts

### DIFF
--- a/conf/script/build-cortx-ha
+++ b/conf/script/build-cortx-ha
@@ -27,7 +27,10 @@ init() {
     host2=$(echo $node_list | jq '.["local"][1]' | sed s/\"//g)
 
     # Restart csm to enable decision maker changes
-    pcs resource restart csm-agent
+    cnt=10
+    while ! pcs resource restart csm-agent && ((cnt-- > 0)); do
+        sleep 1
+    done
 
     pcs cluster cib hw_cfg
     # Hardware io stack resource

--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -230,17 +230,34 @@ net_config_check() {
       die "LNet endpoint $ip2 doesn't appear to be configured at $rnode. $check_msg"
 }
 
+# On both nodes:
+# lvolume is mounted at /var/motr1,
+# rvolume is mounted at /var/motr2.
+mount_var_motr_dirs() {
+    log "${FUNCNAME[0]}: make sure there are no stale mounts hanging..."
+    mountpoint -q /var/motr1 && sudo umount /var/motr1 || true
+    ssh $rnode 'mountpoint -q /var/motr2 && sudo umount /var/motr2 || true'
+
+    log "${FUNCNAME[0]}: check & upgrade old setups with /var/motr directories..."
+    [ -d /var/motr ] && ! [ -d /var/motr1 ] && mv /var/motr /var/motr1
+    ssh $rnode '[ -d /var/motr ] && ! [ -d /var/motr2 ] && mv /var/motr /var/motr2'
+
+    log "${FUNCNAME[0]}: prepare dirs..."
+    run_on_both 'mkdir -p /var/motr{1,2}'
+    ln -sf /var/motr1 /var/motr
+    ssh $rnode 'ln -sf /var/motr2 /var/motr'
+
+    sudo mount $lvolume /var/motr1 || true
+    ssh $rnode "sudo mount $rvolume /var/motr2 || true"
+}
+
 bootstrap() {
     if ! $skip_mkfs; then
         sudo mkfs.ext4 -q $lvolume >/dev/null <<< y
         sudo mkfs.ext4 -q $rvolume >/dev/null <<< y
     fi
 
-    # Mount /var/motr (if not mounted).
-    mkdir -p /var/motr &&
-      ! mountpoint -q /var/motr && sudo mount $lvolume /var/motr || true
-    ssh $rnode "mkdir -p /var/motr &&
-      ! mountpoint -q /var/motr && sudo mount $rvolume /var/motr || true"
+    mount_var_motr_dirs
 
     log "${FUNCNAME[0]}: Preparing Hare configuration files..."
 
@@ -280,19 +297,12 @@ bootstrap() {
     run_on_both 'sudo systemctl reset-failed hare\* m0d\*'
     hctl bootstrap --conf-dir $hare_dir
     hctl shutdown
-
-# Create /var/motr dirs for the foreign data-stacks:
-    sudo mkdir -p /var/motr2
-    ssh $rnode 'sudo mkdir -p /var/motr1'
 }
 
 # Runs hctl bootstrap to update hare configuration changes.
 # Note: This modifies consul kv which needs to be explicitly restored.
 bootstrap_update_only() {
-    mkdir -p /var/motr &&
-      ! mountpoint -q /var/motr && sudo mount $lvolume /var/motr || true
-    ssh $rnode "mkdir -p /var/motr &&
-      ! mountpoint -q /var/motr && sudo mount $rvolume /var/motr || true"
+    mount_var_motr_dirs
     hctl bootstrap --conf-dir $hare_dir
     hctl shutdown
 }
@@ -517,6 +527,16 @@ motr_kernel_rsc_add() {
                                            kind=Optional symmetrical=false
 }
 
+var_motr_rsc_add() {
+    log "${FUNCNAME[0]}: Adding var-motr mounts to Pacemaker..."
+    sudo pcs -f $cib_file resource create var-motr1 ocf:heartbeat:Filesystem \
+        device=$lvolume directory=/var/motr1 \
+        fstype=ext4 --group c1 op stop timeout=30
+    sudo pcs -f $cib_file resource create var-motr2 ocf:heartbeat:Filesystem \
+        device=$rvolume directory=/var/motr2 \
+        fstype=ext4 --group c2 op stop timeout=30
+}
+
 hax_systemd_prepare() {
     log "${FUNCNAME[0]}: Installing hax systemd units..."
     sudo cp -f /usr/lib/systemd/system/hare-hax.service \
@@ -528,14 +548,12 @@ hax_systemd_prepare() {
 hax_systemd_update() {
     log "${FUNCNAME[0]}: Updating hax systemd units..."
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/' \
-             -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr || /bin/mount $lvolume /var/motr'" \
-             -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr || while ! /bin/umount /var/motr; do lsof +D /var/motr; sleep 1; done'" \
+             -e "/ExecStart=/aTimeoutStopSec=5sec" \
              -i /usr/lib/systemd/system/hare-hax-c1.service
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
              -e 's;ExecStart.*cd /var/motr;&2;' \
              -e "/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c2" \
-             -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr2 || /bin/mount $rvolume /var/motr2'" \
-             -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr2 || while ! /bin/umount /var/motr2; do lsof +D /var/motr2; sleep 1; done'" \
+             -e "/ExecStart=/aTimeoutStopSec=5sec" \
              -i /usr/lib/systemd/system/hare-hax-c2.service
     echo "HARE_HAX_NODE_NAME=$rnode" | sudo tee $hare_dir/hax-env-c2 > /dev/null
 
@@ -545,14 +563,12 @@ hax_systemd_update() {
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/'
              -e 's;ExecStart.*cd /var/motr;&1;' \
              -e '/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c1'
-             -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr1 || /bin/mount $lvolume /var/motr1'\"
-             -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr1 || while ! /bin/umount /var/motr1; do lsof +D /var/motr1; sleep 1; done'\"
+             -e \"/ExecStart=/aTimeoutStopSec=5sec\"
              -i /usr/lib/systemd/system/hare-hax-c1.service &&
     sudo cp -f /usr/lib/systemd/system/hare-hax.service
             /usr/lib/systemd/system/hare-hax-c2.service &&
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/'
-             -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr || /bin/mount $rvolume /var/motr'\"
-             -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr || while ! /bin/umount /var/motr; do lsof +D /var/motr; sleep 1; done'\"
+             -e \"/ExecStart=/aTimeoutStopSec=5sec\"
              -i /usr/lib/systemd/system/hare-hax-c2.service &&
     echo 'HARE_HAX_NODE_NAME=$lnode' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
     ssh $rnode $cmd
@@ -560,8 +576,8 @@ hax_systemd_update() {
 
 hax_rsc_add() {
     log "${FUNCNAME[0]}: Adding hax to Pacemaker..."
-    sudo pcs -f $cib_file resource create hax-c1 systemd:hare-hax-c1 op stop timeout=30
-    sudo pcs -f $cib_file resource create hax-c2 systemd:hare-hax-c2 op stop timeout=30
+    sudo pcs -f $cib_file resource create hax-c1 systemd:hare-hax-c1
+    sudo pcs -f $cib_file resource create hax-c2 systemd:hare-hax-c2
     sudo pcs -f $cib_file resource group add c1 hax-c1
     sudo pcs -f $cib_file resource group add c2 hax-c2
     sudo pcs -f $cib_file constraint order motr-kernel-clone then hax-c1
@@ -813,6 +829,7 @@ ha_ops=(
     consul_conf_prepare
     consul_rsc_add
     motr_kernel_rsc_add
+    var_motr_rsc_add
     hax_systemd_prepare
     hax_systemd_update
     hax_rsc_add
@@ -854,6 +871,7 @@ declare -A ha_ops_type=(
     [motr_kernel_rsc_add]='bootstrap_update'
     [hax_systemd_prepare]='bootstrap_update_restore'
     [hax_systemd_update]='bootstrap_update_restore'
+    [var_motr_rsc_add]='bootstrap_update'
     [hax_rsc_add]='bootstrap_update'
     [motr_systemd_update]='bootstrap_update'
     [motr_rsc_add]='bootstrap_update'


### PR DESCRIPTION
Currently, /var/motr is mounted before hax service startup and
unmounted after hax service stop. This mounting/unmounting is done
in hax systemd service unit file. So when hax fails to stop within
30 secs timeout (configured in Pacemaker), the node will be fenced
by Pacemaker to avoid the situation when /var/motr is mounted on
both nodes at the same time (which would lead to data corruption).

Hax stopping can be delayed for different reasons, mainly due to
bugs in Motr which are not easy to fix quickly (for example, hax
calls rconfc_start in fs-stats thread and it may get stuck if confd
process dies and does not come up during the node shutdown). So
we are solving it from another side:

1) Create separate resource in Pacemaker for /var/motr mgmt and
   stop doing it from hax systemd unit file.
2) Add this resource into the Motr Pacemaker group just before hax
   so that /var/motr mount is ready before hax startup (and unmounts
   after hax is stopped).
3) Set 5 seconds systemd stop timeout for hax (in similar way to
   all the rest Motr systemd services stop timeout) so that hax is
   killed by systemd if it cannot stop within this timeframe (for
   whatever reason) and it's not affecting the cluster state.

Tested manually on sm10/11-r20.pun setup:
 - build-ha-io PASS
 - failback/failover PASS
 - build-ees-ha-update PASS (with a small timing fix related to #123).