### PR TITLE
Problem: build-ees-ha-update fails

### DIFF
--- a/conf/script/build-ees-ha-update
+++ b/conf/script/build-ees-ha-update
@@ -82,9 +82,8 @@ fi
 hare_dir=/var/lib/hare
 cib_file=/var/lib/hare/cib_cortx_cluster.xml
 ha_script=/opt/seagate/cortx/ha/conf/script
-hare_bin=/opt/seagate/cortx/hare/bin
-sudo export PATH=$PATH:$hare_bin
-sudo export PATH=$PATH:/usr/bin
+
+export PATH=/opt/seagate/cortx/hare/bin:$PATH
 
 reset_all() {
     $ha_script/prov-ha-uds-reset


### PR DESCRIPTION
`build-ees-ha-update` tries to execute Bash builtin command directly.
```
$ sudo export PATH=$PATH:/usr/bin
sudo: export: command not found
```

Solution: remove unneeded `sudo`.

Jira: [EOS-12635](https://jts.seagate.com/browse/EOS-12635)