### PR TITLE
failback: Add support for failback

### DIFF
--- a/conf/etc/consul_watcher_failback.json
+++ b/conf/etc/consul_watcher_failback.json
@@ -1,0 +1,9 @@
+{
+    "watches": [
+          {
+            "type": "keyprefix",
+            "prefix": "cortx/base/ha/",
+            "args": ["/usr/bin/cortxha", "node", "refresh", "--soft"]
+          }
+    ]
+}

--- a/conf/etc/ha.conf
+++ b/conf/etc/ha.conf
@@ -1,0 +1,3 @@
+LOG:
+    path: /var/log/seagate/cortx/ha
+    level: INFO

--- a/conf/script/ha_setup
+++ b/conf/script/ha_setup
@@ -28,6 +28,11 @@ HA_NON_CROSS_CONNECT_RULE_FILE='rules_engine_schema_without_crossconnect.json'
 HA_CROSS_CONNECT_RULE_FILE='rules_engine_schema_with_crossconnect.json'
 HA_CONF_RULE_FILE='rules_engine_schema.json'
 
+# Add Log
+mkdir -p /var/log/seagate/cortx/ha/
+exec &>> /var/log/seagate/cortx/ha/${0##*/}.log
+exec &> >(stdbuf -oL gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
+
 post_install() {
     echo "post_install"
     mkdir -p ${LOGROTATE_CONF}
@@ -37,20 +42,11 @@ post_install() {
 config() {
     echo "config"
 
-    rule_file=${HA_CROSS_CONNECT_RULE_FILE}
+    # Move ha conf
+    cp -rf ${SOURCE_HA_CONF}/ha.conf ${HA_CONF}/ha.conf
 
-    # Based on cross-connect check, load appropriate rule_engine
-    # file. If cross-connect - load rules_engine_schema.json
-    # If no cross-connect - load rules_engine_schema_without_crossconnect.json
-    [[ -f ${SYSTEM_CROSS_CONNECT_FILE} ]] && echo "Cross connect File Exists" || {
-
-        echo "Cross connect file does not exist"
-        rule_file=${HA_NON_CROSS_CONNECT_RULE_FILE}
-    }
-
-    # Copy a relevant rule file to HA_CONF directory with name as
-    # 'rules_engine_schema.json' as HA component search for this specific name
-    cp -rf ${SOURCE_HA_CONF}/${rule_file} ${HA_CONF}/${HA_CONF_RULE_FILE}
+    # Configure rule engine
+    config_rule_engine
 
     # Configure database.json
     config_database
@@ -61,6 +57,8 @@ config() {
 
 init() {
     echo "init"
+    # Add consul watcher
+    consul_watcher_failback
 }
 
 test() {
@@ -99,10 +97,27 @@ replace_node() {
     fi
 
     echo "Detected Faulty node $faulty_node"
-    /usr/bin/cortxha cleanup db --node $faulty_node
+    /usr/bin/cortxha node refresh --hard --data-only --node $faulty_node
 }
 
 # Helping function
+
+config_rule_engine(){
+    rule_file=${HA_CROSS_CONNECT_RULE_FILE}
+
+    # Based on cross-connect check, load appropriate rule_engine
+    # file. If cross-connect - load rules_engine_schema.json
+    # If no cross-connect - load rules_engine_schema_without_crossconnect.json
+    [[ -f ${SYSTEM_CROSS_CONNECT_FILE} ]] && echo "Cross connect File Exists" || {
+
+        echo "Cross connect file does not exist"
+        rule_file=${HA_NON_CROSS_CONNECT_RULE_FILE}
+    }
+
+    # Copy a relevant rule file to HA_CONF directory with name as
+    # 'rules_engine_schema.json' as HA component search for this specific name
+    cp -rf ${SOURCE_HA_CONF}/${rule_file} ${HA_CONF}/${HA_CONF_RULE_FILE}
+}
 
 config_database() {
     # Config database.json
@@ -113,6 +128,15 @@ config_database() {
         cluster:$LOCAL_NODE_MINION_ID:network:data_nw:roaming_ip \
         --output=json | jq '.["local"]' | sed s/\"//g)
     sed -i -e "s|<CONSUL_HOST>|${CONSUL_HOST}|g" ${HA_CONF}/database.json
+}
+
+consul_watcher_failback() {
+    echo "Copy consul watcher files..."
+    mkdir -p /var/lib/hare/consul-server-c1-conf/ /var/lib/hare/consul-server-c2-conf/
+    cp -rf ${SOURCE_HA_CONF}/consul_watcher_failback.json /var/lib/hare/consul-server-c1-conf/
+    cp -rf ${SOURCE_HA_CONF}/consul_watcher_failback.json /var/lib/hare/consul-server-c2-conf/
+    echo 'Reloading Consul...'
+    /opt/seagate/cortx/hare/bin/consul reload
 }
 
 config_decision_maker() {

--- a/ha/cli/command_factory.py
+++ b/ha/cli/command_factory.py
@@ -15,31 +15,25 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
+import inspect
 
-"""
- ****************************************************************************
- Description:       Cleanup Event
- ****************************************************************************
-"""
+from ha.cli import commands
 
-import sys
+class CommandFactory:
+    """
+    Factory for representing and creating command objects using
+    a generic skeleton.
+    """
 
-from cortx.utils.schema.conf import Conf
-from cortx.utils.ha.dm.decision_monitor import DecisionMonitor
-
-from ha import const
-
-class Cleanup:
-    def __init__(self, args):
-        self._args = args
-        self._decision_monitor = DecisionMonitor()
-
-    def cleanup_db(self):
+    @staticmethod
+    def get_command(component_parser):
         """
-        {'entity': 'enclosure', 'entity_id': '0',
-        'component': 'controller', 'component_id': 'srvnode-1'}
+        Get command from command factory
+
+        Args:
+            component_parser (<class 'argparse._SubParsersAction'>): argparse to add subparser.
         """
-        resources = Conf.get(const.RESOURCE_GLOBAL_INDEX, "resources")
-        for key in resources.keys():
-            if self._args.node in key:
-                self._decision_monitor.acknowledge_resource(key, True)
+        command_class = inspect.getmembers(commands, inspect.isclass)
+        for cmd_name, cmd in command_class:
+            if cmd_name != "Command" and "Command" in cmd_name:
+                cmd.add_args(component_parser)

--- a/ha/cli/commands.py
+++ b/ha/cli/commands.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+from ha.core.error import HAUnimplemented
+
+class Command:
+    @staticmethod
+    def add_args(component_parser):
+        raise HAUnimplemented()
+
+class NodeCommand(Command):
+    @staticmethod
+    def add_args(component_parser):
+        """
+        Add parser for cleanup command
+
+        Args:
+            component_parser (<class 'argparse._SubParsersAction'>): argparse to add subparser.
+        """
+        node_parser = component_parser.add_parser("node",
+            help = "Node management")
+        action_subparser = node_parser.add_subparsers(
+            title="Node Actions",
+            dest="node_action")
+
+        refresh_parser = action_subparser.add_parser("refresh",
+            help = "Refresh nodes")
+        refresh_parser.add_argument("--node",
+            help="Refresh services for given node")
+        refresh_parser.add_argument("--soft", action='store_true',
+            help="Check status and then perform refresh")
+        refresh_parser.add_argument("--hard", action='store_true',
+            help="Perform refresh forcefully")
+        refresh_parser.add_argument("--data-only", action='store_true',
+            help="Perform refresh forcefully")
+
+class ClusterCommand(Command):
+    @staticmethod
+    def add_args(component_parser):
+        """
+        Add parser for cluster command
+
+        Args:
+            component_parser (<class 'argparse._SubParsersAction'>): argparse to add subparser.
+        """
+        cluster_parser =  component_parser.add_parser("cluster",
+            help = "Manage cluster")
+        action_subparser = cluster_parser.add_subparsers(
+            title="Cluster Actions",
+            dest="cluster_action")
+
+        add_node_parser = action_subparser.add_parser("add_node",
+            help = "Add node to cluster")
+        add_node_parser.add_argument("node",
+            help="Node name", action="store")
+
+        remove_node_parser = action_subparser.add_parser("remove_node",
+            help = "Remove node to cluster")
+        remove_node_parser.add_argument("node",
+            help="Node name", action="store")
+
+        start_parser = action_subparser.add_parser("start",
+            help = "Start cluster")
+
+        stop_parser = action_subparser.add_parser("stop",
+            help = "Stop cluster")
+
+        status_parser = action_subparser.add_parser("status",
+            help = "cluster status")
+
+        shutdown_parser = action_subparser.add_parser("shutdown",
+            help = "shutdown cluster")
+
+class ServiceCommand(Command):
+    @staticmethod
+    def add_args(component_parser):
+        """
+        Add parser for cluster command
+
+        Args:
+            component_parser (<class 'argparse._SubParsersAction'>): argparse to add subparser.
+        """
+        service_parser =  component_parser.add_parser("service",
+                    help = "Manage service")
+        action_subparser = service_parser.add_subparsers(
+            title="Service Actions",
+            dest="service_action")
+
+        start_parser = action_subparser.add_parser("start",
+            help = "Start Service")
+        start_parser.add_argument("service_name",
+            help="Service name", action="store")
+        start_parser.add_argument("--node",
+            help="Node name")
+
+        stop_parser = action_subparser.add_parser("stop",
+            help = "Stop Service")
+        stop_parser.add_argument("service_name",
+            help="Service name", action="store")
+        stop_parser.add_argument("--node",
+            help="Node name")
+
+        status_parser = action_subparser.add_parser("status",
+            help = "Status of service")
+        status_parser.add_argument("service_name",
+            help="Service name", action="store")
+        status_parser.add_argument("--node",
+            help="Node name")

--- a/ha/cli/cortxha.py
+++ b/ha/cli/cortxha.py
@@ -15,13 +15,6 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
-
-"""
- ****************************************************************************
- Description:       Entry point for cortxha CLI
- ****************************************************************************
-"""
-
 import os
 import sys
 import traceback
@@ -32,29 +25,48 @@ from cortx.utils.schema.conf import Conf
 from cortx.utils.log import Log
 from cortx.utils.schema.payload import *
 
-#TODO - Move the cli to cortxcli framework once cortxcli is created as a separate module.
-class HACli:
-
+class Output:
     def __init__(self):
         """
-        Initialize HACLI
+        Provide output for cluster command
         """
-        self._provider = {
-            "cleanup": ""
-        }
+        self._output = "Success"
+        self._rc = 0
+
+    def output(self, output):
+        self._output = output
+
+    def rc(self, rc):
+        self._rc = rc
+
+    def get_output(self):
+        return self._output
+
+    def get_rc(self):
+        return self._rc
+
+#TODO - Move the cli to cortxcli framework once cortxcli is created as a separate module.
+class HACli:
+    """
+    HACLI
+    """
+    def __init__(self):
+        """
+        Initialization of HA CLI.
+        """
+        # TODO Check product env and load specific conf
         Conf.init()
         Conf.load(const.RESOURCE_GLOBAL_INDEX, Json(const.RESOURCE_SCHEMA))
-        log_level = Conf.get(const.RESOURCE_GLOBAL_INDEX, "log", "INFO")
-        Log.init(service_name='cortxha', log_path=const.RA_LOG_DIR, level=log_level)
+        Conf.load(const.HA_GLOBAL_INDEX, Yaml(const.HA_CONFIG_FILE))
+        log_path = Conf.get(const.HA_GLOBAL_INDEX, "LOG.path")
+        log_level = Conf.get(const.HA_GLOBAL_INDEX, "LOG.level")
+        Log.init(service_name='cortxha', log_path=log_path, level=log_level)
 
     @staticmethod
     def _usage():
         return """
-
-    Example:
-    cortxha cleanup db --node <node_minion_id>
-    cortxha cluster add_node <node_minion_id>
-    cortxha cluster remove_node <node_minion_id>
+    Use below command for more detail
+    cortxha --help
     """
 
     def command(self):
@@ -64,49 +76,33 @@ class HACli:
                 formatter_class = argparse.RawDescriptionHelpFormatter)
 
             component_parser = argParser.add_subparsers(
-                help = "Select one of given component.")
+                help = "Select one of given component.",
+                dest = "cortxha_action")
 
-            # Cleanup
-            cleanup_parser = component_parser.add_parser("cleanup",
-                                help = "Cleanup db and resource")
-            cleanup_parser.add_argument("cleanup",
-                help = "Select singlenode or multinode.",
-                choices = ["db"])
-
-            cleanup_parser.add_argument("-n", "--node",
-                help="Cleanup data for node")
-
-            # Cluster
-            cluster_parser =  component_parser.add_parser("cluster",
-                                help = "Manage cluster")
-            cluster_parser.add_argument("cluster",
-                help = "Cluster add remove node",
-                choices = ["add_node", "remove_node"])
-            cluster_parser.add_argument("node",
-                help="Node name", action="store")
-
+            CommandFactory.get_command(component_parser)
             args = argParser.parse_args()
 
+            Log.info(f"Executing: {' '.join(sys.argv)}")
             if len(sys.argv) <= 1:
                 argParser.print_help(sys.stderr)
-            elif sys.argv[1] == "cluster":
-                cluster = PcsCluster()
-                if args.cluster == "add_node":
-                    cluster.add_node(args.node)
-                elif args.cluster == "remove_node":
-                    cluster.remove_node(args.node)
-            elif sys.argv[1] == "cleanup":
-                Cleanup(args).cleanup_db()
             else:
-                argParser.print_help(sys.stderr)
+                output = Output()
+                cluster = PcsClusterManager()
+                cluster.process_request(args.cortxha_action, args, output)
+                sys.stdout.write(f"{output.get_output()}\n")
+                sys.exit(output.get_rc())
         except Exception as e:
+            sys.stderr.write(f"{e}\n")
             Log.error(f"{traceback.format_exc()}, {e}")
             sys.exit(1)
 
 if __name__ == '__main__':
+    """
+    Entry point for cortxha CLI
+    """
     sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..'))
     from ha import const
-    from ha.core.cleanup import Cleanup
-    from ha.core.cluster import PcsCluster
+    from ha.cli.command_factory import CommandFactory
+    from ha.core.cluster.cluster_manager import PcsClusterManager
     ha_cli = HACli()
     ha_cli.command()

--- a/ha/const.py
+++ b/ha/const.py
@@ -13,25 +13,30 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
-HA_INIT_DIR='/var/cortx/ha/'
-RA_LOG_DIR='/var/log/seagate/cortx/ha'
-RESOURCE_SCHEMA='/etc/cortx/ha/decision_monitor_conf.json'
+HA_INIT_DIR="/var/cortx/ha/"
+RA_LOG_DIR="/var/log/seagate/cortx/ha"
 
-RESOURCE_GLOBAL_INDEX='decision_monitor'
+CONFIG_DIR="/etc/cortx/ha"
+RESOURCE_SCHEMA="{}/decision_monitor_conf.json".format(CONFIG_DIR)
+RESOURCE_GLOBAL_INDEX="decision_monitor"
+RULE_ENGINE_SCHAMA="{}/rules_engine_schema.json".format(CONFIG_DIR)
+RULE_GLOBAL_INDEX="rules_engine"
+HA_CONFIG_FILE="{}/ha.conf".format(CONFIG_DIR)
+HA_GLOBAL_INDEX="ha_conf"
 
-CURRENT_NODE_STATUS='self_node_status'
-OTHER_NODE_STATUS='other_node_status'
-CURRENT_NODE='self_node'
-NODE_LIST='nodes'
-LOCALHOST_KEY='local'
+CURRENT_NODE_STATUS="self_node_status"
+OTHER_NODE_STATUS="other_node_status"
+CURRENT_NODE="self_node"
+NODE_LIST="nodes"
+LOCALHOST_KEY="local"
 
-FILENAME_KEY='filename'
-OCF_FILENAME='OCF_RESKEY_{}'.format(FILENAME_KEY)
-PATH_KEY='path'
-OCF_PATH='OCF_RESKEY_{}'.format(PATH_KEY)
-OCF_NODE='OCF_RESKEY_node'
-SERVICE_KEY='service'
-OCF_SERVICE='OCF_RESKEY_{}'.format(SERVICE_KEY)
+FILENAME_KEY="filename"
+OCF_FILENAME="OCF_RESKEY_{}".format(FILENAME_KEY)
+PATH_KEY="path"
+OCF_PATH="OCF_RESKEY_{}".format(PATH_KEY)
+OCF_NODE="OCF_RESKEY_node"
+SERVICE_KEY="service"
+OCF_SERVICE="OCF_RESKEY_{}".format(SERVICE_KEY)
 
 STATE_RUNNING="monitoring"
 STATE_START="starting"
@@ -45,3 +50,11 @@ OCF_ERR_PERM=4
 OCF_ERR_INSTALLED=5
 OCF_ERR_CONFIGURED=6
 OCF_NOT_RUNNING=7
+
+CLUSTER_COMMAND="cluster"
+NODE_COMMAND="node"
+SERVICE_COMMAND="service"
+
+PCS_CLEANUP="pcs resource cleanup"
+PCS_FAILCOUNT_STATUS="pcs resource failcount show"
+PCS_STATUS="pcs status"

--- a/ha/core/error.py
+++ b/ha/core/error.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+import inspect
+
+from cortx.utils.errors import BaseError
+from cortx.utils.log import Log
+
+HA_BASIC_ERROR                  = 0x0000
+HA_UNIMPLEMENTED_ERROR          = 0x0001
+HA_INVALID_NODE_ERROR           = 0x0002
+HA_COMMAND_TERMINATION_ERROR    = 0x0003
+HA_TEST_FAILED                  = 0x0004
+
+class HAError(BaseError):
+    def __init__(self, rc=1, desc=None, message_id=HA_BASIC_ERROR, message_args=None):
+        """
+        Parent class for the HA error classes
+        """
+        super(HAError, self).__init__(rc=rc, desc=desc, message_id=message_id,
+                                       message_args=message_args)
+        Log.error(f"error({self._message_id}):rc({self._rc}):{self._desc}:{self._message_args}")
+
+class HAUnimplemented(HAError):
+    def __init__(self, desc=None):
+        """
+        Handle unimplemented function error.
+        """
+        _desc = f"Unimplemented Feature. stack: {inspect.stack()[1]}" if desc is None else desc
+        _message_id = HA_UNIMPLEMENTED_ERROR
+        _rc = 1
+        super(HAUnimplemented, self).__init__(rc=_rc, desc=_desc, message_id=_message_id)
+
+class HAInvalidNode(HAError):
+    def __init__(self, desc=None):
+        """
+        Handle invalid node error.
+        """
+        _desc = '[%s] %s' %(inspect.stack()[1][3], desc)
+        _message_id = HA_INVALID_NODE_ERROR
+        _rc = 1
+        super(HAInvalidNode, self).__init__(rc=_rc, desc=_desc, message_id=_message_id)
+
+class HACommandTerminated(HAError):
+    def __init__(self, desc=None):
+        """
+        Handle command terminamation error.
+        """
+        _desc = '[%s] %s' %(inspect.stack()[1][3], desc)
+        _message_id = HA_COMMAND_TERMINATION_ERROR
+        _rc = 1
+        super(HACommandTerminated, self).__init__(rc=_rc, desc=_desc, message_id=_message_id)
+
+class HAInvalidCommand(HAError):
+    def __init__(self, desc=None):
+        """
+        Handle command terminamation error.
+        """
+        _desc = '[%s] %s' %(inspect.stack()[1][3], desc)
+        _message_id = HA_COMMAND_TERMINATION_ERROR
+        _rc = 1
+        super(HAInvalidCommand, self).__init__(rc=_rc, desc=_desc, message_id=_message_id)
+
+class HATestFailedError(HAError):
+    def __init__(self, desc=None):
+        """
+        Handle Test Failed Error.
+        """
+        _desc = '[%s] %s' %(inspect.stack()[1][3], desc)
+        _message_id = HA_TEST_FAILED
+        _rc = 1
+        super(HATestFailedError, self).__init__(rc=_rc, desc=_desc, message_id=_message_id)

--- a/ha/core/node/replacement/refresh_context.py
+++ b/ha/core/node/replacement/refresh_context.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+from cortx.utils.log import Log
+from cortx.utils.schema.conf import Conf
+from cortx.utils.ha.dm.actions import Action
+
+from ha import const
+from ha.execute import SimpleCommand
+from ha.core.error import HAUnimplemented, HAInvalidCommand
+
+class Cleanup:
+    def __init__(self, decision_monitor):
+        """
+        Description: Cleanup Event
+        """
+        self._decision_monitor = decision_monitor
+        self._execute = SimpleCommand()
+
+    def cleanup_db(self, node, data_only):
+        """
+        Args:
+            node ([string]): Node name.
+            data_only ([boolean]): Remove data only.
+
+        Action:
+            consul data:
+                {'entity': 'enclosure', 'entity_id': '0',
+                'component': 'controller', 'component_id': 'node1'}
+            if data_only is True then remove data else remove
+            data and perform cleanup.
+        """
+        resources = Conf.get(const.RESOURCE_GLOBAL_INDEX, "resources")
+        node = "all" if node is None else node
+        Log.debug(f"Performing cleanup for {node} node")
+        for key in resources.keys():
+            if node == "all":
+                self._decision_monitor.acknowledge_resource(key, data_only)
+            elif node in key:
+                self._decision_monitor.acknowledge_resource(key, data_only)
+            else:
+                pass
+        if not data_only:
+            Log.info(f"Reseting HA decision event for {node}")
+            self.reset_failover(node)
+
+    def is_cleanup_required(self, node=None):
+        """
+        Check if all alert resolved
+
+        Args:
+            node ([type]): [description]
+        """
+        node = "all" if node is None else node
+        Log.debug(f"Performing failback on {node}")
+        resource_list = Conf.get(const.RESOURCE_GLOBAL_INDEX, "resources")
+        status_list = {}
+        for resource in resource_list:
+            if node == "all":
+                status_list[resource] = self._decision_monitor.get_resource_status(resource)
+            elif node in resource:
+                status_list[resource] = self._decision_monitor.get_resource_status(resource)
+            else:
+                pass
+        Log.info(f"Resource status for node {node} is {status_list}")
+        if Action.FAILED in status_list.values():
+            Log.debug("Some component are not yet recovered skipping failback")
+        elif Action.RESOLVED in status_list.values():
+            Log.info("Failback is required as some of alert are resolved.")
+            return True
+        else:
+            Log.debug(f"{node} node already in good state no need for failback")
+        return False
+
+    def reset_failover(self, node=None, soft_cleanup=False):
+        """
+        Cleanup pacemaker failcount to allow failback.
+        """
+        node = "all" if node is None else node
+        cmd = const.PCS_CLEANUP if node == "all" else const.PCS_CLEANUP + f" --node {node}"
+        if soft_cleanup:
+            if self.is_cleanup_required(node):
+                _output, _err, _rc = self._execute.run_cmd(const.PCS_FAILCOUNT_STATUS)
+                Log.info(f"Resource failcount before Failback: {_output}, Error:{_err}, RC:{_rc}")
+                _output, _err, _rc = self._execute.run_cmd(cmd)
+                Log.info(f"Failback is happened, Output:{_output}, Error:{_err}, RC:{_rc}")
+                _output, _err, _rc = self._execute.run_cmd(const.PCS_FAILCOUNT_STATUS)
+                Log.info(f"Resource failcount after Failback: {_output}, Error:{_err}, RC:{_rc}")
+            else:
+                Log.debug("cleanup is not required alerts are not yet resolved.")
+        else:
+            self._execute.run_cmd(cmd)
+        Log.debug(f"Status: {self._execute.run_cmd(const.PCS_STATUS)}")
+
+class RefreshContex:
+    def __init__(self, decision_monitor):
+        pass
+
+    def process_request(self, action, args):
+        """
+        Generic method to handle process request
+
+        Args:
+            action ([string]): Take cluster action for each request.
+            args ([dict]): Parameter pass to request to process.
+        """
+        raise HAUnimplemented()
+
+class PcsRefreshContex(RefreshContex):
+    def __init__(self, decision_monitor):
+        self._decision_monitor = decision_monitor
+        self._cleanup = Cleanup(self._decision_monitor)
+
+    def process_request(self, action, args):
+        """
+        Generic method to handle process request
+
+        Args:
+            action ([string]): Take cluster action for each request.
+            args ([dict]): Parameter pass to request to process.
+
+        Action:
+            Cleanup resource history            : default
+            Remove old consul keys              : --hard --data-only
+            Remove old consul key and cleanup   : --hard
+            Check Alert and perform cleanup     : --soft
+        """
+        if args.hard == False and args.soft == False and args.data_only == False:
+            self._cleanup.reset_failover(args.node)
+        elif args.hard == True and args.soft == True:
+            raise HAInvalidCommand("Select one of hard or soft option only.")
+        elif args.hard == True:
+            self._cleanup.cleanup_db(args.node, args.data_only)
+        elif args.soft == True:
+            # Failback trigger
+            self._cleanup.reset_failover(args.node, args.soft)
+        else:
+            raise HAUnimplemented()

--- a/ha/execute.py
+++ b/ha/execute.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+from cortx.utils.log import Log
+from cortx.utils.process import SimpleProcess
+from ha.core.error import HACommandTerminated
+
+# TODO: Move to utils package in SimpleProcess
+class SimpleCommand:
+    def __init__(self):
+        pass
+
+    def run_cmd(self, cmd, check_error=True):
+        """
+        Run command and throw error if cmd failed
+
+        Args:
+            cmd ([string]): Command to execute on system.
+
+        Raises:
+            Exception: raise command failed exception.
+            HACommandTerminated: Command termineted exception
+
+        Returns:
+            string: Command output.
+        """
+        try:
+            _err = ""
+            _proc = SimpleProcess(cmd)
+            _output, _err, _rc = _proc.run(universal_newlines=True)
+            Log.debug(f"cmd: {cmd}, output: {_output}, err: {_err}, rc: {_rc}")
+            if _rc != 0 and check_error:
+                Log.error(f"cmd: {cmd}, output: {_output}, err: {_err}, rc: {_rc}")
+                raise Exception(f"Failed to execute {cmd}")
+            return _output, _err, _rc
+        except Exception as e:
+            Log.error("Failed to execute  %s Error: %s %s" %(cmd,e,_err))
+            raise HACommandTerminated("Failed to execute %s Error: %s %s" %(cmd,e,_err))

--- a/jenkins/cicd/cortx-ha-cicd.sh
+++ b/jenkins/cicd/cortx-ha-cicd.sh
@@ -26,13 +26,10 @@ rm -rf "${TMPHA}"
 mkdir -p "${TMPHA}"
 cp -rs "$BASE_DIR"/ha/* "${TMPHA}"
 
-mkdir -p /etc/cortx/ha/
-cp -rf "${BASE_DIR}"/jenkins/cicd/etc/decision_monitor_conf.json /etc/cortx/ha/decision_monitor_conf.json
-cp -rf "${BASE_DIR}"/jenkins/cicd/etc/database.json /etc/cortx/ha/database.json
+mkdir -p /etc/cortx/ha/ /var/log/seagate/cortx/ha
+cp -rf "${BASE_DIR}"/jenkins/cicd/etc/* /etc/cortx/ha/
 
 # Perform unit test
 python3 "${TMPHA}"/test/main.py "${TMPHA}"/test/unit
-
-cortxha cleanup db --node srvnode-1 || exit 1
 
 /usr/lib/ocf/resource.d/seagate/hw_comp_ra meta-data

--- a/jenkins/cicd/etc/ha.conf
+++ b/jenkins/cicd/etc/ha.conf
@@ -1,0 +1,3 @@
+LOG:
+    path: /var/log/seagate/cortx/ha
+    level: INFO


### PR DESCRIPTION
- Added CLI
- Added error logic
- Added Cluster managment
- Added Cleanup

Signed-off-by: Ajay Paratmandali <ajay.paratmandali@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-11314 | HA: Provide program to trigger failback and handle action
    Provide failback support for HA
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    After fault resolved cluster should go to normal state.
  </code>
</pre>
## Solution
<pre>
  <code>
    Detect alert and provide cleanup from consul watcher
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Testing done with sas fault and resolved:
     io_path failed after sas fault and after reolve cluster moved to normal state
log
2020-09-25 05:22:26 cortxha INFO [reset_failover] Resource failcount before Failback: Failcounts for resource 'io_path_health-c1'
  srvnode-1: INFINITY
, Error:, RC:0
2020-09-25 05:22:26 cortxha INFO [reset_failover] Failback is happened, Output:Cleaned up all resources on all nodes
Waiting for 1 reply from the CRMd. OK
, Error:, RC:0
2020-09-25 05:22:26 cortxha INFO [reset_failover] Failback is happened, Output:Cleaned up all resources on all nodes
Waiting for 1 reply from the CRMd. OK
, Error:, RC:0
2020-09-25 05:22:27 cortxha INFO [reset_failover] Resource failcount after Failback: No failcounts
, Error:, RC:0
  </code>
</pre>