### PR TITLE
EOS-13393: fix nodes fencing issue on sporadic hax stop timeouts (#144)

### DIFF
--- a/conf/script/build-cortx-ha
+++ b/conf/script/build-cortx-ha
@@ -27,8 +27,14 @@ init() {
     host2=$(echo $node_list | jq '.["local"][1]' | sed s/\"//g)
 
     # Restart csm to enable decision maker changes
-    pcs resource restart csm-agent
+    echo "Restart csm-agent..."
+    cnt=10
+    while ! pcs resource restart csm-agent && ((cnt-- > 0)); do
+        sleep 1
+        echo "Re-try to restart csm-agent..."
+    done
 
+    echo "Create io_path_health resources..."
     pcs cluster cib hw_cfg
     # Hardware io stack resource
     pcs -f hw_cfg resource create io_path_health-c1 ocf:seagate:hw_comp_ra \

--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -230,17 +230,32 @@ net_config_check() {
       die "LNet endpoint $ip2 doesn't appear to be configured at $rnode. $check_msg"
 }
 
+# On both nodes:
+# lvolume is mounted at /var/motr1,
+# rvolume is mounted at /var/motr2.
+prepare_var_motr_dirs() {
+    log "${FUNCNAME[0]}: make sure there are no stale mounts hanging..."
+    mountpoint -q /var/motr1 && sudo umount /var/motr1 || true
+    ssh $rnode 'mountpoint -q /var/motr2 && sudo umount /var/motr2 || true'
+
+    log "${FUNCNAME[0]}: check & upgrade old setups with /var/motr directories..."
+    [ -d /var/motr ] && ! [ -d /var/motr1 ] && mv /var/motr /var/motr1
+    ssh $rnode '[ -d /var/motr ] && ! [ -d /var/motr2 ] && mv /var/motr /var/motr2'
+
+    log "${FUNCNAME[0]}: prepare dirs..."
+    run_on_both 'mkdir -p /var/motr{1,2}'
+    ln -sf /var/motr1 /var/motr
+    ssh $rnode 'ln -sf /var/motr2 /var/motr'
+
+    sudo mount $lvolume /var/motr1 || true
+    ssh $rnode "sudo mount $rvolume /var/motr2 || true"
+}
+
 bootstrap() {
     if ! $skip_mkfs; then
         sudo mkfs.ext4 -q $lvolume >/dev/null <<< y
         sudo mkfs.ext4 -q $rvolume >/dev/null <<< y
     fi
-
-    # Mount /var/motr (if not mounted).
-    mkdir -p /var/motr &&
-      ! mountpoint -q /var/motr && sudo mount $lvolume /var/motr || true
-    ssh $rnode "mkdir -p /var/motr &&
-      ! mountpoint -q /var/motr && sudo mount $rvolume /var/motr || true"
 
     log "${FUNCNAME[0]}: Preparing Hare configuration files..."
 
@@ -280,19 +295,11 @@ bootstrap() {
     run_on_both 'sudo systemctl reset-failed hare\* m0d\*'
     hctl bootstrap --conf-dir $hare_dir
     hctl shutdown
-
-# Create /var/motr dirs for the foreign data-stacks:
-    sudo mkdir -p /var/motr2
-    ssh $rnode 'sudo mkdir -p /var/motr1'
 }
 
 # Runs hctl bootstrap to update hare configuration changes.
 # Note: This modifies consul kv which needs to be explicitly restored.
 bootstrap_update_only() {
-    mkdir -p /var/motr &&
-      ! mountpoint -q /var/motr && sudo mount $lvolume /var/motr || true
-    ssh $rnode "mkdir -p /var/motr &&
-      ! mountpoint -q /var/motr && sudo mount $rvolume /var/motr || true"
     hctl bootstrap --conf-dir $hare_dir
     hctl shutdown
 }
@@ -518,6 +525,16 @@ motr_kernel_rsc_add() {
                                            kind=Optional symmetrical=false
 }
 
+var_motr_rsc_add() {
+    log "${FUNCNAME[0]}: Adding var-motr mounts to Pacemaker..."
+    sudo pcs -f $cib_file resource create var-motr1 ocf:heartbeat:Filesystem \
+        device=$lvolume directory=/var/motr1 \
+        fstype=ext4 --group c1 op stop timeout=30
+    sudo pcs -f $cib_file resource create var-motr2 ocf:heartbeat:Filesystem \
+        device=$rvolume directory=/var/motr2 \
+        fstype=ext4 --group c2 op stop timeout=30
+}
+
 hax_systemd_prepare() {
     log "${FUNCNAME[0]}: Installing hax systemd units..."
     sudo cp -f /usr/lib/systemd/system/hare-hax.service \
@@ -529,18 +546,16 @@ hax_systemd_prepare() {
 hax_systemd_update() {
     log "${FUNCNAME[0]}: Updating hax systemd units..."
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/' \
-             -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr || /bin/mount $lvolume /var/motr'" \
-             -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr || while ! /bin/umount /var/motr; do lsof +D /var/motr; sleep 1; done'" \
              -e "/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running" \
              -e "/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running" \
+             -e "/ExecStart=/aTimeoutStopSec=5sec" \
              -i /usr/lib/systemd/system/hare-hax-c1.service
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/' \
              -e 's;ExecStart.*cd /var/motr;&2;' \
              -e "/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c2" \
-             -e "/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr2 || /bin/mount $rvolume /var/motr2'" \
-             -e "/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr2 || while ! /bin/umount /var/motr2; do lsof +D /var/motr2; sleep 1; done'" \
              -e "/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running" \
              -e "/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running" \
+             -e "/ExecStart=/aTimeoutStopSec=5sec" \
              -i /usr/lib/systemd/system/hare-hax-c2.service
     echo "HARE_HAX_NODE_NAME=$rnode" | sudo tee $hare_dir/hax-env-c2 > /dev/null
 
@@ -550,18 +565,16 @@ hax_systemd_update() {
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c1.service/'
              -e 's;ExecStart.*cd /var/motr;&1;' \
              -e '/ExecStart/iEnvironmentFile=$hare_dir/hax-env-c1'
-             -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr1 || /bin/mount $lvolume /var/motr1'\"
-             -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr1 || while ! /bin/umount /var/motr1; do lsof +D /var/motr1; sleep 1; done'\"
              -e \"/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running\"
              -e \"/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running\"
+             -e \"/ExecStart=/aTimeoutStopSec=5sec\"
              -i /usr/lib/systemd/system/hare-hax-c1.service &&
     sudo cp -f /usr/lib/systemd/system/hare-hax.service
             /usr/lib/systemd/system/hare-hax-c2.service &&
     sudo sed -e 's/hare-consul-agent.service/hare-consul-agent-c2.service/'
-             -e \"/ExecStart=/iExecStartPre=/bin/sh -c 'mountpoint /var/motr || /bin/mount $rvolume /var/motr'\"
-             -e \"/ExecStart=/aExecStopPost=/bin/sh -c '! mountpoint /var/motr || while ! /bin/umount /var/motr; do lsof +D /var/motr; sleep 1; done'\"
              -e \"/ExecStart=/aExecStopPost=/usr/sbin/attrd_updater -U 0 -n hax-running\"
              -e \"/ExecStart=/aExecStartPost=/usr/sbin/attrd_updater -U 1 -n hax-running\"
+             -e \"/ExecStart=/aTimeoutStopSec=5sec\"
              -i /usr/lib/systemd/system/hare-hax-c2.service &&
     echo 'HARE_HAX_NODE_NAME=$lnode' | sudo tee $hare_dir/hax-env-c1 > /dev/null"
     ssh $rnode $cmd
@@ -569,8 +582,8 @@ hax_systemd_update() {
 
 hax_rsc_add() {
     log "${FUNCNAME[0]}: Adding hax to Pacemaker..."
-    sudo pcs -f $cib_file resource create hax-c1 systemd:hare-hax-c1 op stop timeout=30
-    sudo pcs -f $cib_file resource create hax-c2 systemd:hare-hax-c2 op stop timeout=30
+    sudo pcs -f $cib_file resource create hax-c1 systemd:hare-hax-c1
+    sudo pcs -f $cib_file resource create hax-c2 systemd:hare-hax-c2
     sudo pcs -f $cib_file resource group add c1 hax-c1
     sudo pcs -f $cib_file resource group add c2 hax-c2
     sudo pcs -f $cib_file constraint order motr-kernel-clone then hax-c1
@@ -821,10 +834,13 @@ cib_commit() {
 }
 
 # HA operations table.
+# The order of the functions is important here - it defines the
+# order of the resources added into the Pacemaker's groups.
 ha_ops=(
     ip_addr_rsc_add
     lnet_rsc_add
     net_config_check
+    prepare_var_motr_dirs
     bootstrap
     bootstrap_update_only
     motr_config
@@ -834,6 +850,7 @@ ha_ops=(
     consul_conf_prepare
     consul_rsc_add
     motr_kernel_rsc_add
+    var_motr_rsc_add
     hax_systemd_prepare
     hax_systemd_update
     hax_rsc_add
@@ -864,6 +881,7 @@ declare -A ha_ops_type=(
     [ip_addr_rsc_add]='bootstrap_update'
     [lnet_rsc_add]='bootstrap_update'
     [net_config_check]='bootstrap'
+    [prepare_var_motr_dirs]='bootstrap_update_restore'
     [bootstrap]='bootstrap'
     [bootstrap_update_only]='update-only'
     [motr_config]='bootstrap'
@@ -873,6 +891,7 @@ declare -A ha_ops_type=(
     [consul_conf_prepare]='bootstrap'
     [consul_rsc_add]='bootstrap_update'
     [motr_kernel_rsc_add]='bootstrap_update'
+    [var_motr_rsc_add]='bootstrap_update'
     [hax_systemd_prepare]='bootstrap_update_restore'
     [hax_systemd_update]='bootstrap_update_restore'
     [hax_rsc_add]='bootstrap_update'


### PR DESCRIPTION
Currently, /var/motr is mounted before hax service startup and
unmounted after hax service stop. This mounting/unmounting is done
in hax systemd service unit file. So when hax fails to stop within
30 secs timeout (configured in Pacemaker), the node will be fenced
by Pacemaker to avoid the situation when /var/motr is mounted on
both nodes at the same time (which would lead to data corruption).

Hax stopping can be delayed for different reasons, mainly due to
bugs in Motr which are not easy to fix quickly (for example, hax
calls rconfc_start in fs-stats thread and it may get stuck if confd
process dies and does not come up during the node shutdown). So
we are solving it from another side:

1) Create separate resource in Pacemaker for /var/motr mgmt and
   stop doing it from hax systemd unit file.
2) Add this resource into the Motr Pacemaker group just before hax
   so that /var/motr mount is ready before hax startup (and unmounts
   after hax is stopped).
3) Set 5 seconds systemd stop timeout for hax (in similar way to
   all the rest Motr systemd services stop timeout) so that hax is
   killed by systemd if it cannot stop within this timeframe (for
   whatever reason) and it's not affecting the cluster state.

Tested manually:
 - build-ha-io PASS;
 - failback/failover PASS;
 - build-ees-ha-update PASS (with a minor fix related to #123).

Reviewed-by: Mandar Sawant <mandar.sawant@seagate.com>
Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>
(cherry picked from commit 7b7197cd8f2ec3a53dd7166ec4e4d2d6741d6e30)
