### PR TITLE
build-ha-io: support different interfaces on the nodes (#145)

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -46,7 +46,10 @@ Mandatory parameters:
         <CDF>          Hare Cluster Description File
 
 Optional parameters:
-  -i, --interface <if>  Data network interface (default: eth1)
+  -i, --interface <if>  Data network interface (when they are the same
+                        on both nodes, default: eth1)
+  --left-iface    <if>  Left node data nw interface (default: eth1)
+  --right-iface   <if>  Right node data nw interface (default: eth1)
   --left-node     <n1>  Left  node hostname (default: pod-c1)
   --right-node    <n2>  Right node hostname (default: pod-c2)
   --left-volume   <lv>  Left  node /var/motr volume (default: /dev/sdb)
@@ -65,6 +68,8 @@ or via a yaml file, e.g.:
   ip1: <ip>
   ip2: <ip2>
   interface: <iface>
+  left-iface: <iface>
+  right-iface: <iface>
   left-node: <lnode>
   right-node: <rnode>
   left-volume: <lvolume>
@@ -75,7 +80,8 @@ EOF
 }
 
 TEMP=$(getopt --options h,i: \
-              --longoptions help,ip1:,ip2:,interface:,left-node:,right-node: \
+              --longoptions help,ip1:,ip2:,interface:,left-iface:,right-iface: \
+              --longoptions left-node:,right-node: \
               --longoptions left-volume:,right-volume:,skip-mkfs,net-type: \
               --longoptions cib-file:,restore-conf,update \
               --name "$PROG" -- "$@" || true)
@@ -87,6 +93,8 @@ eval set -- "$TEMP"
 ip1=
 ip2=
 iface=eth1
+left_iface=
+right_iface=
 lnode=pod-c1
 rnode=pod-c2
 lvolume=/dev/sdb
@@ -103,6 +111,8 @@ while true; do
         --ip1)               ip1=$2; shift 2 ;;
         --ip2)               ip2=$2; shift 2 ;;
         -i|--interface)      iface=$2; shift 2 ;;
+        --left-iface)        left_iface=$2; shift 2 ;;
+        --right-iface)       right_iface=$2; shift 2 ;;
         --left-node)         lnode=$2; shift 2 ;;
         --right-node)        rnode=$2; shift 2 ;;
         --left-volume)       lvolume=$2; shift 2 ;;
@@ -134,6 +144,8 @@ if [[ -f $argsfile ]]; then
            ip1)          ip1=$value     ;;
            ip2)          ip2=$value     ;;
            interface)    iface=$value   ;;
+           left_iface)   left_iface=$value   ;;
+           right_iface)  right_iface=$value   ;;
            left-node)    lnode=$value   ;;
            right-node)   rnode=$value   ;;
            left-volume)  lvolume=$value ;;
@@ -151,6 +163,10 @@ Supported values: true, false'
     done < $argsfile
 fi
 
+# Set left/right_iface if they are not set explicitly by user:
+[[ $left_iface ]] || left_iface=$iface
+[[ $right_iface ]] || right_iface=$iface
+
 [[ $ip1 ]] && [[ $ip2 ]] && [[ $cdf ]]  || {
     usage >&2
     exit 1
@@ -161,10 +177,19 @@ fi
 
 # Sample output:
 #   $ ip -oneline -4 address show dev eno1
-#   2: eno1    inet 10.230.249.241/20 brd 10.230.255.255 scope global noprefixroute dynamic eno1\       valid_lft 327971sec preferred_lft 327971sec
-#   2: eno1    inet 10.230.255.1/24 brd 10.230.255.255 scope global eno1:v1\       valid_lft forever preferred_lft forever
-netmask=$(ip -oneline -4 address show dev $iface |
-              awk '{print $4}' | cut -d/ -f2 | head -1)
+#   2: eno1    inet 10.230.249.241/20 brd 10.230.255.255 scope global noprefixroute dynamic eno1
+#       valid_lft 327971sec preferred_lft 327971sec
+#   2: eno1    inet 10.230.255.1/24 brd 10.230.255.255 scope global eno1:v1
+#       valid_lft forever preferred_lft forever
+
+# Check the netmask on the nodes - they must be the same.
+netmaskl=$(ip -oneline -4 address show dev $left_iface | head -1 |
+              awk '{print $4}' | cut -d/ -f2)
+netmaskr=$(ssh $rnode ip -oneline -4 address show dev $right_iface | head -1 |
+              awk '{print $4}' | cut -d/ -f2)
+[[ $netmaskl == $netmaskr ]] ||
+    die "Data network interfaces netmask differs between the nodes."
+netmask=$netmaskl
 
 run_on_both() {
     local cmd=$*
@@ -192,9 +217,9 @@ lnet_rsc_add() {
     sudo pcs -f $cib_file resource create lnet systemd:lnet
     sudo pcs -f $cib_file resource clone lnet
     sudo pcs -f $cib_file resource create lnet-c1 ocf:cortx:lnet \
-             iface=$iface:c1 nettype=$net_type op monitor interval=30s
+             ip=$ip1 nettype=$net_type op monitor interval=30s
     sudo pcs -f $cib_file resource create lnet-c2 ocf:cortx:lnet \
-             iface=$iface:c2 nettype=$net_type op monitor interval=30s
+             ip=$ip2 nettype=$net_type op monitor interval=30s
     sudo pcs -f $cib_file resource group add c1 ip-c1 lnet-c1
     sudo pcs -f $cib_file resource group add c2 ip-c2 lnet-c2
     sudo pcs -f $cib_file constraint order lnet-clone then lnet-c1
@@ -213,7 +238,7 @@ net_config_check() {
     # Check the IPs
     check_msg="
     Check the following:
-     1) Make sure the netmask of the main IP on $iface interface is <= 24 bits.
+     1) Make sure the netmask of the main IP on data interface is <= 24 bits.
      2) Run 'pcs status' and make sure LNet is configured.
      3) STONITH is configured or disabled in Pacemaker."
 
@@ -259,18 +284,18 @@ bootstrap() {
 
     log "${FUNCNAME[0]}: Preparing Hare configuration files..."
 
-# Update data_iface values in CDF: 1st data_iface will be `${iface}_c1`,
-#                                  2nd data_iface will be `${iface}_c2`.
+# Update data_iface values in CDF: 1st data_iface will be `${left_iface}_c1`,
+#                                  2nd data_iface will be `${right_iface}_c2`.
     sudo sed -r -e "/[#].*data_iface/b ; # skip commented out data_iface lines
                     /data_iface: *[a-z0-9]+[_:]c[12]/b ; # skip already updated
-                    0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c1/ ;
-                    0,/(data_iface: *)[a-z0-9]+\b/s//\1${iface}_c2/" \
+                    0,/(data_iface: *)[a-z0-9]+\b/s//\1${left_iface}_c1/ ;
+                    0,/(data_iface: *)[a-z0-9]+\b/s//\1${right_iface}_c2/" \
                 -i $cdf
 
     if facter --version | grep -q ^3; then
         # New facter-3 requires colons (:) for interface aliases.
         sudo sed -r -e "/[#].*data_iface/b ; # skip commented out data_iface lines
-                        s/(data_iface: *${iface})_(c[12])/\1:\2/" \
+                        s/(data_iface: *(${left_iface}|${right_iface}))_(c[12])/\1:\2/" \
                     -i $cdf
     fi
 

--- a/ha/resource/lnet
+++ b/ha/resource/lnet
@@ -32,10 +32,10 @@
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 
 # Defaults
-OCF_RESKEY_iface_default=""
+OCF_RESKEY_ip_default=""
 OCF_RESKEY_nettype_default="tcp"
 
-: ${OCF_RESKEY_iface=${OCF_RESKEY_iface_default}}
+: ${OCF_RESKEY_ip=${OCF_RESKEY_ip_default}}
 : ${OCF_RESKEY_nettype=${OCF_RESKEY_nettype_default}}
 
 #######################################################################
@@ -53,12 +53,12 @@ This is LNet Resource Agent. It configures NID over TCP.
 <shortdesc lang="en">LNet over TCP resource agent</shortdesc>
 
 <parameters>
-<parameter name="iface" unique="1" required="1">
+<parameter name="ip" unique="1" required="1">
 <longdesc lang="en">
-The network interface to add NID to.
+The network IP address for LNet NID.
 </longdesc>
-<shortdesc lang="en">Network interface</shortdesc>
-<content type="string" default="${OCF_RESKEY_iface_default}" />
+<shortdesc lang="en">Network IP</shortdesc>
+<content type="string" default="${OCF_RESKEY_ip_default}" />
 </parameter>
 <parameter name="nettype" unique="0" required="0">
 <longdesc lang="en">
@@ -94,19 +94,22 @@ END
 }
 
 lnet_start() {
-    lnet_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
+	lnet_monitor && return $OCF_SUCCESS
+	iface=$(ip a | grep $OCF_RESKEY_ip | awk '{print $NF}')
+	[[ $iface ]] || {
+		ocf_exit_reason "IP address $OCF_RESKEY_ip is not configured"
+		return $OCF_ERR_INSTALLED
+	}
+	lnetctl net add --net ${OCF_RESKEY_nettype} --if $iface ||
+		return $OCF_ERR_INSTALLED
 	return $OCF_SUCCESS
-    fi
-    lnetctl net add --net ${OCF_RESKEY_nettype} --if ${OCF_RESKEY_iface}
 }
 
 lnet_stop() {
-    lnet_monitor
-    if [ $? =  $OCF_SUCCESS ]; then
-        lnetctl net del --net ${OCF_RESKEY_nettype} --if ${OCF_RESKEY_iface}
-    fi
-    return $OCF_SUCCESS
+	lnet_monitor || return $OCF_SUCCESS
+	iface=$(lnetctl net show | grep -A4 $OCF_RESKEY_ip | tail -1 | awk '{print $2}')
+	[[ $iface ]] && lnetctl net del --net ${OCF_RESKEY_nettype} --if $iface
+	return $OCF_SUCCESS
 }
 
 lnet_monitor() {
@@ -115,7 +118,7 @@ lnet_monitor() {
 	# That is THREE states, not just yes/no.
 	
 	if systemctl is-active --quiet lnet &&
-           lnetctl net show | grep -q ${OCF_RESKEY_iface}; then
+           lnetctl net show | grep -q ${OCF_RESKEY_ip}; then
 	    return $OCF_SUCCESS
 	fi
 	if false ; then
@@ -124,19 +127,23 @@ lnet_monitor() {
 
 	if ! ocf_is_probe && [ "$__OCF_ACTION" = "monitor" ]; then
 		# set exit string only when NOT_RUNNING occurs during an actual monitor operation.
-		ocf_exit_reason "LNet is not started"
+		if ! systemctl is-active --quiet lnet; then
+			ocf_exit_reason "LNet is not started"
+		elif ! lnetctl net show | grep -q ${OCF_RESKEY_ip}; then
+			ocf_exit_reason "LNet NID for ${OCF_RESKEY_ip} is not set"
+		fi
 	fi
 	return $OCF_NOT_RUNNING
 }
 
 lnet_validate() {
-    if [ -z ${OCF_RESKEY_iface} ]; then
-	ocf_exit_reason "Network interface is not set"
+    if [ -z ${OCF_RESKEY_ip} ]; then
+	ocf_exit_reason "Network IP address is not set"
 	return $OCF_ERR_ARGS
     fi
 
-    if ! ip a | grep -q ${OCF_RESKEY_iface}; then
-	ocf_exit_reason "Network interface is not available"
+    if ! ip a | grep -q ${OCF_RESKEY_ip}; then
+	ocf_exit_reason "Network is not configured"
 	return $OCF_ERR_ARGS
     fi
 


### PR DESCRIPTION
Currently, the build-ha-io script expects that the name of the
data network interface is the same on both nodes, which sometimes
may not be the case when the underlying HW is different. (Which
may happen, for example, when the old failed node is replaced
with the new one.)

Solution: add support for different interface names via the
two new configuration options: `--left-iface` and `--right-iface`.
If the options are not explicitly set by user, the value of
the old `--iface` option is used for both interfaces.

Closes EOS-13356.

Reviewed-by: Ajay Srivastava <ajay.srivastava@seagate.com>
Reviewed-by: Mandar Sawant <mandar.sawant@seagate.com>
Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>
(cherry picked from commit e185aa25323413b6f134c7ab184dd32485971e8d)
