### PR TITLE
EOS-13695: build-ha-io: fix regression in CDF update code (#160)

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -295,7 +295,7 @@ bootstrap() {
     if facter --version | grep -q ^3; then
         # New facter-3 requires colons (:) for interface aliases.
         sudo sed -r -e "/[#].*data_iface/b ; # skip commented out data_iface lines
-                        s/(data_iface: *(${left_iface}|${right_iface}))_(c[12])/\1:\2/" \
+                        s/(data_iface: *(${left_iface}|${right_iface}))_(c[12])/\1:\3/" \
                     -i $cdf
     fi
 


### PR DESCRIPTION
The patch for "support different interfaces on the nodes"
introduced the regression in CDF update code, so that interface
names would become like "enp179s0f1:enp179s0f1" instead of
"enp179s0f1:c1" or "enp179s0f1:c2".

Solution: fix the code in the sed expression.

Kudos to Madhav Vemuri for excellent initial investigation.

Reviewed-by: Madhav Vemuri <madhav.vemuri@seagate.com>
Signed-off-by: Andriy Tkachuk <andriy.tkachuk@seagate.com>
(cherry picked from commit 41783b704ea05957425a2038e08fa364b806fb55)
