### PR TITLE
Problem: prepare_var_motr_dirs() may fail thus exiting the script

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -264,8 +264,8 @@ prepare_var_motr_dirs() {
     ssh $rnode 'mountpoint -q /var/motr2 && sudo umount /var/motr2 || true'
 
     log "${FUNCNAME[0]}: check & upgrade old setups with /var/motr directories..."
-    [ -d /var/motr ] && ! [ -d /var/motr1 ] && mv /var/motr /var/motr1
-    ssh $rnode '[ -d /var/motr ] && ! [ -d /var/motr2 ] && mv /var/motr /var/motr2'
+    [ -d /var/motr ] && ! [ -d /var/motr1 ] && mv /var/motr /var/motr1 || true
+    ssh $rnode '[ -d /var/motr ] && ! [ -d /var/motr2 ] && mv /var/motr /var/motr2 || true'
 
     log "${FUNCNAME[0]}: prepare dirs..."
     run_on_both 'mkdir -p /var/motr{1,2}'


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
prepare_var_motr_dirs() may fail thus exiting the script
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes, directly on hardware system
  </code>
</pre>
## Problem Description
<pre>
  <code>
prepare_var_motr_dirs() checks on both the nodes if /var/motr1 and
/var/motr2 dirs are present, if not then renames the /var/motr to
/var/motr1 or /var/motr2 on respecive nodes.
While executing this command on the peer node the check condition
may fail if directories already exist thus leads to failure of the
ssh command for the peer node. This leads to script exit as `pipefail`
is set for the script.
  </code>
</pre>
## Solution
<pre>
  <code>
Make the directory creation command no-op by returning true in case of
check condition failure to continue the build script.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
build-ha-io script must succeed
  </code>
</pre>
