### PR TITLE
build-ha-io: fix bogus failure of prepare_var_motr_dirs()

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -264,8 +264,8 @@ prepare_var_motr_dirs() {
     ssh $rnode 'mountpoint -q /var/motr2 && sudo umount /var/motr2 || true'
 
     log "${FUNCNAME[0]}: check & upgrade old setups with /var/motr directories..."
-    [ -d /var/motr ] && ! [ -d /var/motr1 ] && mv /var/motr /var/motr1
-    ssh $rnode '[ -d /var/motr ] && ! [ -d /var/motr2 ] && mv /var/motr /var/motr2'
+    [ -d /var/motr ] && ! [ -d /var/motr1 ] && mv /var/motr /var/motr1 || true
+    ssh $rnode '[ -d /var/motr ] && ! [ -d /var/motr2 ] && mv /var/motr /var/motr2 || true'
 
     log "${FUNCNAME[0]}: prepare dirs..."
     run_on_both 'mkdir -p /var/motr{1,2}'


### PR DESCRIPTION
Currently, the commands which check for /var/motr dir present
at prepare_var_motr_dirs() (and run some upgrade logic if it
is) do not tolerate the situation when /var/motr directory
is not present - they would return non-zero status (thus,
failing the whole script which is wrong).

Solution: fix the commands by appending `|| true` to them.

Kudos to Mandar Sawant who caught this.