### PR TITLE
Problem: wrong /var/motr links created if restore executed from secon…

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -260,19 +260,19 @@ net_config_check() {
 # rvolume is mounted at /var/motr2.
 prepare_var_motr_dirs() {
     log "${FUNCNAME[0]}: make sure there are no stale mounts hanging..."
-    mountpoint -q /var/motr1 && sudo umount /var/motr1 || true
+    ssh $lnode 'mountpoint -q /var/motr1 && sudo umount /var/motr1 || true'
     ssh $rnode 'mountpoint -q /var/motr2 && sudo umount /var/motr2 || true'
 
     log "${FUNCNAME[0]}: check & upgrade old setups with /var/motr directories..."
-    [ -d /var/motr ] && ! [ -d /var/motr1 ] && mv /var/motr /var/motr1 || true
+    ssh $lnode '[ -d /var/motr ] && ! [ -d /var/motr1 ] && mv /var/motr /var/motr1 || true'
     ssh $rnode '[ -d /var/motr ] && ! [ -d /var/motr2 ] && mv /var/motr /var/motr2 || true'
 
     log "${FUNCNAME[0]}: prepare dirs..."
     run_on_both 'mkdir -p /var/motr{1,2}'
-    ln -sf /var/motr1 /var/motr
+    ssh $lnode 'ln -sf /var/motr1 /var/motr'
     ssh $rnode 'ln -sf /var/motr2 /var/motr'
 
-    sudo mount $lvolume /var/motr1 || true
+    ssh $lnode "sudo mount $lvolume /var/motr1 || true"
     ssh $rnode "sudo mount $rvolume /var/motr2 || true"
 }
 
@@ -920,7 +920,7 @@ declare -A ha_ops_type=(
     [hax_systemd_prepare]='bootstrap_update_restore'
     [hax_systemd_update]='bootstrap_update_restore'
     [hax_rsc_add]='bootstrap_update'
-    [motr_systemd_update]='bootstrap_update'
+    [motr_systemd_update]='bootstrap_update_restore'
     [motr_rsc_add]='bootstrap_update'
     [clusterip_rsc_add]='bootstrap_update'
     [systemd_units_disable]='bootstrap_update'


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
Problem: wrong /var/motr links created if restore executed from secondary node
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
prepare_var_motr_dirs() is also executed to restore /var/motr directories
post node replacement. But the function presently assumes it to be executed
from primary node only which may not be the case during restore as restore
can be executed from secondary node as well. This creates wrong /var/motr
links.
Also motr systemd unit file is not updated on restore.
  </code>
</pre>
## Solution
<pre>
  <code>
- Run /var/motr creation commands over ssh for both the nodes to handle the
  execution from any of the nodes.
- Update motr systemd unit on restore as well.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
 Server failback must work post node restore operation.
  </code>
</pre>