### PR TITLE
add_node_fix: Fix add node to cluster

### DIFF
--- a/ha/const.py
+++ b/ha/const.py
@@ -58,3 +58,6 @@ SERVICE_COMMAND="service"
 PCS_CLEANUP="pcs resource cleanup"
 PCS_FAILCOUNT_STATUS="pcs resource failcount show"
 PCS_STATUS="pcs status"
+
+NODE_DISCONNECTED="Disconnected"
+NODE_ONLINE="Online"


### PR DESCRIPTION
- Node retiries logic added

Signed-off-by: Ajay Paratmandali <ajay.paratmandali@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    https://jts.seagate.com/browse/EOS-13826
   add_node failing
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
        For add_node
             /opt/seagate/cortx/ha/conf/script/cluster_update add_node
            it is executed properly and node added to cluster
            but from log
            as it was async with pcs
            `opt/seagate/cortx/ha/conf/script/cluster_update add_node`
            not able to find node online but node part of cluster
             it may happen if node goes to unclean or standby or rebooted or pcs take time to add node to cluster
  </code>
</pre>
## Solution
<pre>
  <code>
    Add retry to check if node added to cluster
    if node online return good but if node added to cluster and not online then add it in log
    if still node not part of cluster return error
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    No unit testing but tested with rpm
  </code>
</pre>
