### PR TITLE
Time improve

### DIFF
--- a/ha/resource/resource_agent.py
+++ b/ha/resource/resource_agent.py
@@ -192,14 +192,8 @@ class HardwareResourceAgent(ResourceAgent):
         Log.debug(f"In stop for {filename}")
         if os.path.exists(const.HA_INIT_DIR + filename):
             os.remove(const.HA_INIT_DIR + filename)
-        while True:
-            if self.monitor() == const.OCF_NOT_RUNNING:
-                time.sleep(2)
-                break
-        if self.monitor(state=const.STATE_STOP) == Action.RESTART:
-            Log.debug(f"Restarting {filename} resource")
-            time.sleep(2)
-            return const.OCF_SUCCESS
+            Log.debug(f"Stopping {filename} resource")
+        Log.debug(f"Stopped {filename} resource return success")
         return const.OCF_SUCCESS
 
     def metadata(self):
@@ -298,14 +292,8 @@ class IEMResourceAgent(ResourceAgent):
         Log.debug(f"In stop for {filename}")
         if os.path.exists(const.HA_INIT_DIR + filename):
             os.remove(const.HA_INIT_DIR + filename)
-        while True:
-            if self.monitor() == const.OCF_NOT_RUNNING:
-                time.sleep(2)
-                break
-        if self.monitor(state=const.STATE_STOP) == Action.RESTART:
-            Log.debug(f"Restarting {filename} resource")
-            time.sleep(2)
-            return const.OCF_SUCCESS
+            Log.debug(f"Stopping {filename} resource")
+        Log.debug(f"Stopped {filename} resource return success")
         return const.OCF_SUCCESS
 
     def metadata(self):


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    Improve M4 resource time
    https://jts.seagate.com/browse/EOS-13330
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    During node crash there is sleep time and while loop. When pacemaker calling sleep time as there some monitor call remaining pacemaker waiting more like upto 23 sec to complete stop call.
  </code>
</pre>
## Solution
<pre>
  <code>
    Your Problem solution here...
             Remove unwanted code as not required.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
         Integration testing done unit testing not provided
  </code>
</pre>
