### PR TITLE
fix: disable auto-close issues/PR feature of stale-bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 4
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:
   - feature


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

Disable stale-bot feature of auto-close issues/PR after 7 days of inactivity.
