### PR TITLE
sspl-ra: fix monitor result in master mode

### DIFF
--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -80,6 +80,10 @@ END
     exit $OCF_SUCCESS
 }
 
+log() {
+    logger -t sspl-ra "$*"
+}
+
 stateful_usage() {
     cat <<END
 usage: $0 {start|stop|promote|demote|monitor|validate-all|meta-data}
@@ -115,21 +119,27 @@ stateful_start() {
     stateful_check_state "master"
     if [ $? -eq 0 ]; then
         # CRM Error - Should never happen
+        log "START (master)..."
         systemctl start sspl-ll
+        log "START (master): $?"
         return $OCF_RUNNING_MASTER
     fi
     stateful_update "slave"
     "${HA_SBIN_DIR}/crm_master" -l reboot -v 1
+    log "START... (crm_reboot: $?)"
     systemctl start sspl-ll
+    log "START: $?"
+
     return $OCF_SUCCESS
 }
 
 stateful_demote() {
-    stateful_monitor
+    sspl_pid=`/sbin/pidof -s /usr/bin/sspl_ll_d`
     sspl_state=`systemctl is-active sspl-ll`
-    if [ $sspl_state != 'active' ]; then
-       systemctl start sspl-ll
-    fi
+    log "DEMOTE: pid=$sspl_pid curr_state=$sspl_state"
+    [ $sspl_state == 'active' -a $sspl_pid != '' ] ||
+        return $(stateful_monitor)
+
     stateful_update "slave"
 
     if [ -z $OCF_RESKEY_sspl_mode ]; then
@@ -137,19 +147,18 @@ stateful_demote() {
     fi
 
     echo "state=degrade" > /var/cortx/sspl/data/state.txt
+    /usr/bin/kill -s SIGHUP $sspl_pid
     return 0
 }
 
 stateful_promote() {
     sleep 5
     sspl_pid=`/sbin/pidof -s /usr/bin/sspl_ll_d`
-    if [ -z $sspl_pid ]; then
-        return $(stateful_monitor)
-    fi
     sspl_state=`systemctl is-active sspl-ll`
-    if [ $sspl_state != 'active' ]; then
-       systemctl start sspl-ll
-    fi
+    log "PROMOTE: pid=$sspl_pid curr_state=$sspl_state"
+    [ $sspl_state == 'active' -a $sspl_pid != '' ] ||
+        return $(stateful_monitor)
+
     stateful_update "master"
 
     if [ -z $OCF_RESKEY_sspl_mode ]; then
@@ -165,7 +174,9 @@ stateful_promote() {
 }
 
 stateful_stop() {
+    log "STOP..."
     systemctl stop sspl-ll
+    log "STOP: $?"
     return $OCF_SUCESS
 }
 
@@ -173,15 +184,16 @@ stateful_monitor() {
     sspl_state=`systemctl is-active sspl-ll`
     stateful_check_state "master"
     if [ $? -eq 0 ]; then
+        log "MONITOR (master): $sspl_state"
         # Restore the master setting during probes
         case "$sspl_state" in
               active) return $OCF_RUNNING_MASTER;;
               failed) return $OCF_FAILED_MASTER;;
-              inactive) return $OCF_NOT_RUNNING;;
-                     *) return $OCF_ERR_GENERIC;;
+                   *) return $OCF_NOT_RUNNING;;
         esac
     fi
 
+    log "MONITOR: $sspl_state"
     case "$sspl_state" in
            active) return $OCF_SUCCESS;;
            failed) return $OCF_ERR_GENERIC;;


### PR DESCRIPTION
In master mode, when sspl resource is not running, the resulting
code of monitor command returned by sspl resource agent would be
OCF_ERR_GENERIC which is wrong. Upon receiving such a code
Pacemaker would not try to restart the resource.

Solution: return OCF_NOT_RUNNING code instead.

To facilitate debugging, we add logging into the syslog also,
as a bonus.

Tested manually on the setup while debugging the problem
about SSPL promotion failure.