### PR TITLE
EOS-13296: haproxy service does not restart automatically on failure

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -738,8 +738,10 @@ statsd_rsc_add() {
 
 haproxy_rsc_add() {
     log "${FUNCNAME[0]}: Adding haproxy to pacemaker..."
-    sudo pcs -f $cib_file resource create haproxy-c1 systemd:haproxy op monitor interval=30s
-    sudo pcs -f $cib_file resource create haproxy-c2 systemd:haproxy op monitor interval=30s
+    sudo pcs -f $cib_file resource create haproxy-c1 systemd:haproxy op monitor interval=30s \
+        meta failure-timeout=10s
+    sudo pcs -f $cib_file resource create haproxy-c2 systemd:haproxy op monitor interval=30s \
+        meta failure-timeout=10s
     sudo pcs -f $cib_file constraint location haproxy-c1 prefers $lnode=INFINITY
     sudo pcs -f $cib_file constraint location haproxy-c1 avoids $rnode=INFINITY
     sudo pcs -f $cib_file constraint location haproxy-c2 prefers $rnode=INFINITY


### PR DESCRIPTION


Solution:

## Problem Statement
<pre>
  <code>
haproxy service does not restart automatically on failure
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Not rpm but tried the command on LDR1 hw setup.
  </code>
</pre>
## Problem Description
<pre>
  <code>
If a pacemaker resource fails, pacemaker will try to restart the resource but if the
resource fails repeatedly then the failcount set by the pacemaker for the resource
needs to be cleared using `pcs resource cleanup`.
Setting failure-timeout meta attribute allows failcounts to expire automatically so
pacemaker tries to restart the resource.
  </code>
</pre>
## Solution
<pre>
  <code>
Set failure-timeout meta attribute of the haproxy pacemaker resource inorder to allow
automatic expiration of haproxy failcounts to trigger restart.
Note: Resource start and stop failures are treated as fatal by default by pacemaker and
in which case the resource failcount is set to -INFINITY and cannot be reset by
failure-timeout.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- fail haproxy pacemaker resource
- verify it is failed in pacemaker
- pacemaker will try to restart haproxy after 10s.
  </code>
</pre>
