### PR TITLE
Problem: ClusterIP resource may sporadically fail and migrate to another node

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -685,6 +685,11 @@ clusterip_rsc_add() {
             score=-INFINITY '#uname' eq $lnode and hax-running eq 0
         sudo pcs -f $cib_file constraint location ClusterIP-clone rule \
             score=-INFINITY '#uname' eq $rnode and hax-running eq 0
+        # Make ClusterIP to retry to start on original node after specified
+        # timeout since last failure. This is supposed to recover resource in
+        # case of sporadic failures, but will clean errors in 'pcs status'
+        # output.
+        sudo pcs -f $cib_file resource meta ClusterIP-clone failure-timeout=300
     fi
 }
 


### PR DESCRIPTION

## Problem Statement
<pre>
  <code>
ClusterIP resource may sporadically fail and migrate to another node
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Empty.
  </code>
</pre>
## Solution
<pre>
  <code>
Since the reason is unknown so far, this patch is supposed to mitigate
the problem making pacemaker to retry ClusterIP resource on banned node
once in 5 minutes.
Nothing depends from ClusterIP resource, so it is not supposed to cause
restart of other resources.
Timeout value is chosen in order to not disturb cluster too frequently.

The consequences of suggested patch are:
* Once in 5 minutes ClusterIP failures will be cleaned from 'pcs status'
  log. However they persist in syslog and corosync log.
  In case resource is not recovered successfully 'pcs status' will
  continue to show failed status soon.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
Not applicable.
Patch tested manually on real HW:

Resource migration due to caused failure:
Oct 07 15:23:32 sm6-r23.pun.seagate.com pengine[6570]:  warning: Processing failed start of ClusterIP:0 on srvnode-1: not running
Oct 07 15:23:32 sm6-r23.pun.seagate.com pengine[6570]:  warning: Forcing ClusterIP:0 away from srvnode-1 after 1000000 failures (max=1000000)
Oct 07 15:23:32 sm6-r23.pun.seagate.com pengine[6570]:  warning: Forcing kibana-vip away from srvnode-1 after 1000000 failures (max=1000000)
Oct 07 15:23:32 sm6-r23.pun.seagate.com pengine[6570]:   notice:  * Recover    ClusterIP:0             (      srvnode-1 -> srvnode-2 )

Failure record expiration in 5 minues due to added failure-timeout meta attribute:
Oct 07 15:28:35 sm6-r23.pun.seagate.com pengine[6570]:   notice: Ignoring expired calculated failure ClusterIP:0_start_0 (rc=7, magic=0:7;78:205:0:6de12191-d0a1-423e-acec-9aaade3221af) on srvnode-1
Oct 07 15:28:35 sm6-r23.pun.seagate.com pengine[6570]:   notice:  * Move       ClusterIP:1             (      srvnode-2 -> srvnode-1 )

Succesfull start on the origin node:
Oct 07 15:28:35 sm6-r23.pun.seagate.com crmd[6572]:   notice: Initiating start operation ClusterIP:1_start_0 locally on srvnode-1
Oct 07 15:28:36 sm6-r23.pun.seagate.com IPaddr2(ClusterIP:1)[232383]: INFO: Adding inet address 172.19.223.6/16 with broadcast address 172.19.255.255 to device enp175s0f0
Oct 07 15:28:36 sm6-r23.pun.seagate.com IPaddr2(ClusterIP:1)[232392]: INFO: Bringing device enp175s0f0 up
Oct 07 15:28:36 sm6-r23.pun.seagate.com IPaddr2(ClusterIP:1)[232403]: INFO: /usr/libexec/heartbeat/send_arp  -i 200 -r 5 -p /var/run/resource-agents/send_arp-172.19.223.6 enp175s0f0 172.19.223.6 01005e0c42a1 not_used not_used
Oct 07 15:28:36 sm6-r23.pun.seagate.com crmd[6572]:   notice: Result of start operation for ClusterIP:1 on srvnode-1: 0 (ok)
Oct 07 15:28:36 sm6-r23.pun.seagate.com crmd[6572]:   notice: Initiating monitor operation ClusterIP:1_monitor_30000 locally on srvnode-1
Oct 07 15:28:36 sm6-r23.pun.seagate.com IPaddr2(ClusterIP:1)[232417]: INFO: send_arp.linux: Gratuitous ARPs are not sent in the Cluster IP configuration
  </code>
</pre>
