### PR TITLE
Problem: --single-node option fails

### DIFF
--- a/conf/script/prov-m0-reset
+++ b/conf/script/prov-m0-reset
@@ -71,7 +71,7 @@ TEMP=$(getopt --options h,i: \
               --longoptions help,ip1:,ip2:,interface:,left-iface:,right-iface: \
               --longoptions left-node:,right-node: \
               --longoptions left-volume:,right-volume: \
-              --longoptions mkfs-only,single-node: \
+              --longoptions mkfs-only,single-node \
               --name "$PROG" -- "$@" || true)
 
 (($? == 0)) || { usage >&2; exit 1; }
@@ -105,7 +105,7 @@ while true; do
         --left-volume)       lvolume=$2; shift 2 ;;
         --right-volume)      rvolume=$2; shift 2 ;;
         --mkfs-only)         mkfs_only=true; shift ;;
-        --single-node)       single_node=true; shift 2 ;;
+        --single-node)       single_node=true; shift ;;
         --)                  shift; break ;;
         *)                   break ;;
     esac


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
--single-node option to prov-m0-reset fails
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
As part of the implementation to support single as well as dual node mkfs,
singlenode option implementation got missed to be updated to not expect any
value as part of the final version of the script.
  </code>
</pre>
## Solution
<pre>
  <code>
    Fix --single-node option to the prov-m0-reset script to not expect any value.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    prov-m0-reset must run for single node with --single-node option.
  </code>
</pre>
