### PR TITLE
Problem: hax service start fails in absence of /var/motr/hax

### DIFF
--- a/conf/script/prov-m0-reset
+++ b/conf/script/prov-m0-reset
@@ -485,6 +485,8 @@ mkfs() {
     done
 
     log "${FUNCNAME[0]}: Starting Hax.."
+    run_cmd $node1 "sudo mkdir -p /var/motr1/hax"
+    run_cmd $node2 "sudo mkdir -p /var/motr2/hax"
     run_cmd $node1 "sudo systemctl start hare-hax-c1"
     run_cmd $node2 "sudo systemctl start hare-hax-c2"
 


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
hax service start fails in absence of /var/motr/hax
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes, tested on the hardware with local changes and confirmed by data recovery team.
  </code>
</pre>
## Problem Description
<pre>
  <code>
In case /var/motr is wiped off clean during data recovery then hare-hax
service fails to start due to absence of /var/motr/hax directory.
  </code>
</pre>
## Solution
<pre>
  <code>
Create /var/motr/hax directories if it does not exists on respective /var/motr
volumes before starting hare-hax services as part of mkfs operation.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
prov-m0-reset --mkfs-only must complete successfully with a clean /var/motr directory.
  </code>
</pre>
