### PR TITLE
EOS-13932: HA: Build 146 : After single controller shutdown, failover…

### DIFF
--- a/conf/script/ha_setup
+++ b/conf/script/ha_setup
@@ -49,7 +49,7 @@ config() {
     mkdir -p ${HA_CONF}
 
     # TODO Add generation for rule engine to make rule engine schama
-    rule_engine_config
+    cp -rf ${SOURCE_HA_CONF}/rules_engine_schema_jbod.json ${HA_CONF}/${HA_CONF_RULE_FILE}
 
     # ha conf
     cp -rf ${SOURCE_HA_CONF}/ha.conf ${HA_CONF}/

--- a/conf/script/ha_setup
+++ b/conf/script/ha_setup
@@ -49,7 +49,7 @@ config() {
     mkdir -p ${HA_CONF}
 
     # TODO Add generation for rule engine to make rule engine schama
-    cp -rf ${SOURCE_HA_CONF}/rules_engine_schema_jbod.json ${HA_CONF}/${HA_CONF_RULE_FILE}
+    rule_engine_config
 
     # ha conf
     cp -rf ${SOURCE_HA_CONF}/ha.conf ${HA_CONF}/
@@ -183,16 +183,11 @@ consul_watcher_failback() {
 rule_engine_config() {
     rule_file=${HA_CROSS_CONNECT_RULE_FILE}
 
-    # Based on cross-connect check, load appropriate rule_engine
-    # file. If cross-connect - load rules_engine_schema.json
-    # If no cross-connect - load rules_engine_schema_without_crossconnect.json
-    [[ -f ${SYSTEM_CROSS_CONNECT_FILE} ]] && echo "Cross connect File Exists" || {
+    # Note: Cross-connect detection mechanism has been removed now. So, by dafault
+    # cross-connect rule engine file will be installed. Hence removed that check
+    # from here
 
-        echo "Cross connect file does not exist"
-        rule_file=${HA_NON_CROSS_CONNECT_RULE_FILE}
-    }
-
-    # Copy a relevant rule file to HA_CONF directory with name as
+    # Copy a rule file to HA_CONF directory with name as
     # 'rules_engine_schema.json' as HA component search for this specific name
     cp -rf ${SOURCE_HA_CONF}/${rule_file} ${HA_CONF}/${HA_CONF_RULE_FILE}
 }


### PR DESCRIPTION
… happening to secondary node

- Main branch PR
- Remove check to detect whether system is cross-connect or not
- Load cross-connect rule file by default

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-13932
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
        Stack failover happened after controller fault which was unexpected. The problem is that cortx-HA ends-up installing non- 
        cross connect rules engine schema file on a cross-connect setup since the provisioner has removed a logic to detect and 
        convey this information to other modules e.g. cortx-HA. So till this gets fixed in provisioner, cortx-HA will assume that it is 
        a cross-connect setup.

  </code>
</pre>
## Solution
<pre>
  <code>
   Remove check to detect whether system is cross-connect or not
   Load cross-connect rule file by default
   It is a straight-forward fix to always use cross-connect rule file  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
