### PR TITLE
[EOS-14191] To reduce failover/failback time kill m0d processes

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -621,8 +621,10 @@ motr_systemd_update() {
     log "${FUNCNAME[0]}: Adding Motr to Pacemaker..."
 
     cmd='
-    sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=5sec/"
-        -i /usr/lib/systemd/system/m0d@.service &&
+    sudo sed -e "s/TimeoutStopSec=.*/TimeoutStopSec=5sec/"
+             -e "/ExecStart=/aExecStop=/bin/kill -9 $MAIN_PID" \
+             -e "/ExecStart=/aExecStop=/usr/bin/echo 'shutting down process : ${MAINPID}'" \
+             -i /usr/lib/systemd/system/m0d@.service &&
     sudo systemctl daemon-reload'
     run_on_both $cmd
 }

--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -620,12 +620,14 @@ hax_rsc_add() {
 motr_systemd_update() {
     log "${FUNCNAME[0]}: Adding Motr to Pacemaker..."
 
-    cmd='
-    sudo sed -e "s/TimeoutStopSec=.*/TimeoutStopSec=5sec/"
-             -e "/ExecStart=/aExecStop=/bin/kill -9 $MAIN_PID" \
-             -e "/ExecStart=/aExecStop=/usr/bin/echo 'shutting down process : ${MAINPID}'" \
+    cmd="
+    sudo sed -e '/ExecStart=/a#Killing m0d to reduce stop time in case of failover' \
+             -e '/ExecStart=/a#thus overriding the systemd timeout.' \
+             -e '/ExecStart=/aExecStop=/usr/bin/echo \"shutting down process : \${MAINPID}\"' \
+             -e '/ExecStart=/aExecStop=/bin/kill -9 \$MAINPID' \
+             -e 's/TimeoutStopSec=.*/TimeoutStopSec=5sec/' \
              -i /usr/lib/systemd/system/m0d@.service &&
-    sudo systemctl daemon-reload'
+    sudo systemctl daemon-reload"
     run_on_both $cmd
 }
 


### PR DESCRIPTION
 - updating m0d@service using kill -9 from build-ha-io

Signed-off-by: Vinoth <vinoth.v@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    To reduce failover/failback time kill m0d processes
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Tested on HW with the changes on m0d@service
  </code>
</pre>