### PR TITLE
Problem: Motr clients start before Motr IOS process starts functional

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -620,10 +620,11 @@ hax_rsc_add() {
 motr_systemd_update() {
     log "${FUNCNAME[0]}: Adding Motr to Pacemaker..."
 
-    cmd='
-    sudo sed "s/TimeoutStopSec=.*/TimeoutStopSec=5sec/"
-        -i /usr/lib/systemd/system/m0d@.service &&
-    sudo systemctl daemon-reload'
+    cmd="
+    sudo sed -e "s/TimeoutStopSec=.*/TimeoutStopSec=5sec/"
+             -e \"/ExecStart=/aExecStartPost=/bin/sh -c 'while [[ \$\(/opt/seagate/cortx/hare/libexec/get-process-state %i\) != M0_CONF_HA_PROCESS_STARTED ]]\; do sleep 1\; done'\"
+             -i /usr/lib/systemd/system/m0d@.service &&
+    sudo systemctl daemon-reload"
     run_on_both $cmd
 }
 


### PR DESCRIPTION
Problem: Motr clients start before Motr IOS process starts functional

Pacemaker starts Motr clients after Motr servers processes, but since
pacemaker returns success after systemd process successfully starts.
In this case Motr server may not be started fully and functional to
cater requests and accepts requests from Motr client.

When Motr process starts and functional, it sends PROCESS_STARTED
HA event to Hax and that state is persisted in consul kv.

Solution:
Add check for PROCESS_STARTED HA state at Motr systemd unit file using
ExecStartPost script. This will make sure Pacemaker starts Motr clients
after Motr servers fully started and functional.

Ref: EOS-13872

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    Your Problem statement here...
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Your Problem decription here...
  </code>
</pre>
## Solution
<pre>
  <code>
    Your Problem solution here...
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
