### PR TITLE
EOS-14447 motr: update motr config post update

### DIFF
--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -88,6 +88,11 @@ $consul_bin/consul kv export > $hare_dir/consul-conf-exported.json
 reset_all
 sudo pcs cluster cib $cib_file
 
+# motr setup.yaml post_update is not called currently, until then it
+# needs to be called from HA after update is done.
+/usr/sbin/m0provision config
+/usr/sbin/m0provision be_log_resize
+
 echo 'Updating ha resources for IO path, SSPL, CSM and UDS...'
 $ha_script/build-ha-io $cdf $ioargsfile --cib-file $cib_file --update
 $ha_script/build-ha-csm $csmargsfile --cib-file $cib_file --update


### PR DESCRIPTION
Currently after motr rpm is updated, motr config is not updated,
and new motr rpm installation will over-write the changes done
during deployment through "m0provision congig".

The solution is to add the motr post update steps in build-ees-ha-update
Also some LDR R1 specific changes like motr be log resize too can be
added here.

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    Your Problem statement here...
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Your Problem decription here...
  </code>
</pre>
## Solution
<pre>
  <code>
    Your Problem solution here...
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
