### PR TITLE
Fix mandatory arguments handling in `build-ha-update`

### DIFF
--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -23,7 +23,7 @@ PROG=${0##*/}
 
 usage() {
     cat <<EOF
-Usage: $PROG [OPTS] <CDF> <params.yaml>
+Usage: $PROG [OPTS] <CDF> <params.yaml> <csm-params.yaml>
 
 Update HA instructions for IO path, SSPL, CSM and UDS
 Caveats:
@@ -42,6 +42,11 @@ Mandatory parameters:
 Note: parameters can be specified either directly via command line options
 or via YAML file, e.g.:
 EOF
+}
+
+die() {
+    echo >&2 "$PROG: $*"
+    exit 1
 }
 
 TEMP=$(getopt --options h: \
@@ -64,20 +69,29 @@ cdf=${1:-}
 ioargsfile=${2:-}
 csmargsfile=${3:-}
 
-if [[ -f $ioargsfile ]]; then
-    while IFS=': ' read name value; do
-       case $name in
-           left-node)    lnode=$value   ;;
-           right-node)   rnode=$value   ;;
-           '')           ;;
-       esac
-    done < $ioargsfile
-fi
-
 [[ $cdf ]] && [[ $ioargsfile ]] && [[ $csmargsfile ]] || {
     usage >&2
     exit 1
 }
+
+for arg in $cdf $ioargsfile $csmargsfile ; do
+    [[ -e $arg ]] ||
+        die "configuration file '$arg' doesn't exist"
+done
+
+while IFS=': ' read name value; do
+    case $name in
+        left-node)    lnode=$value   ;;
+        right-node)   rnode=$value   ;;
+        '')           ;;
+    esac
+done < $ioargsfile
+
+[[ -v lnode ]] ||
+    die "'left-node' is not defined in '$ioargsfile' configuration file"
+
+[[ -v rnode ]] ||
+    die "'right-node' is not defined in '$ioargsfile' configuration file"
 
 hare_dir=/var/lib/hare
 cib_file=/var/lib/hare/cib_cortx_cluster.xml


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    `build-ha-update` script may hang indefinitely.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
`build-ha-update` script expects three configuration files to be
provided as command line argments but it didn't check whether the files
existed or not.

That could lead to the use of uninitilized variables. For example
'lnode' and 'rnode' variables, that are used in 'wait4consul()' might've
been unbound, which resulted in the inifinite 'while' loop.
  </code>
</pre>
## Solution
<pre>
  <code>
    Fix mandatory arguments handling in `build-ha-update` script. Verify that configuration files exist.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    NONE
  </code>
</pre>
