### PR TITLE
EOS-14827: Revert "EOS-14162: collocate ClusterIP with haproxy (#237)"

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -689,10 +689,6 @@ clusterip_rsc_add() {
             score=-INFINITY '#uname' eq $lnode and hax-running eq 0
         sudo pcs -f $cib_file constraint location ClusterIP-clone rule \
             score=-INFINITY '#uname' eq $rnode and hax-running eq 0
-        sudo pcs -f $cib_file constraint location ClusterIP-clone rule \
-            score=-INFINITY '#uname' eq $lnode and haproxy-running eq 0
-        sudo pcs -f $cib_file constraint location ClusterIP-clone rule \
-            score=-INFINITY '#uname' eq $rnode and haproxy-running eq 0
         # Make ClusterIP to retry to start on original node after specified
         # timeout since last failure. This is supposed to recover resource in
         # case of sporadic failures, but will clean errors in 'pcs status'
@@ -757,19 +753,6 @@ haproxy_rsc_add() {
     sudo pcs -f $cib_file constraint location haproxy-c1 avoids $rnode=INFINITY
     sudo pcs -f $cib_file constraint location haproxy-c2 prefers $rnode=INFINITY
     sudo pcs -f $cib_file constraint location haproxy-c2 avoids $lnode=INFINITY
-
-    # Update haproxy.service config to toggle 'haproxy-running' pacemaker
-    # attribute on service start/stop.
-    #
-    # NOTE: formatting using tabs is essential
-    sudo mkdir -p /etc/systemd/system/haproxy.service.d/
-    cat <<-EOF_HAPROXY | sudo tee /etc/systemd/system/haproxy.service.d/override.conf >/dev/null
-	[Service]
-	ExecStopPost=/usr/sbin/attrd_updater -U 0 -n haproxy-running
-	ExecStartPost=/usr/sbin/attrd_updater -U 1 -n haproxy-running
-	EOF_HAPROXY
-
-    sudo systemctl daemon-reload
 }
 
 get_s3_svc() {


### PR DESCRIPTION
This reverts commit 321e0d94eceb4d4f4e66594444d0ad808a48680d.

Revert is caused by regression documented in EOS-15004 and EOS-14827:
haproxy-running attribute dependency between ClusterIP and haproxy
resources caused deadlock because haproxy can't start without running
ClusterIP.

Signed-off-by: Andrei Zheregelia <andrei.zheregelia@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    Your Problem statement here...
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Your Problem decription here...
  </code>
</pre>
## Solution
<pre>
  <code>
    Your Problem solution here...
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
