### PR TITLE
Problem: Failback not happens for csm_web since failure-timeout not set

### DIFF
--- a/conf/script/build-ha-csm
+++ b/conf/script/build-ha-csm
@@ -170,9 +170,9 @@ csm_rsc_add() {
     echo 'Adding csm resources and constraints...'
 
     sudo pcs -f $cib_file resource create csm-agent systemd:csm_agent op \
-        monitor interval=30s
+        monitor interval=30s meta failure-timeout=60s
     sudo pcs -f $cib_file resource create csm-web systemd:csm_web op \
-        monitor interval=30s
+        monitor interval=30s meta failure-timeout=60s
 
     sudo pcs -f $cib_file resource group add \
         csm-kibana kibana-vip kibana csm-web csm-agent


### PR DESCRIPTION
Failback was not successful since pacemaker remember last attempt
to start resource which was failed. It required to set failure-timeout
for resource. Pacemaker will able to attempt starting of failed
resource after failure-timeout.

Solution:
Add failure-timeout for csm_web.

Ref: EOS-15013