### PR TITLE
EOS-15043: Make cidr_netmask parameter configurable for kibana-vip resource

### DIFF
--- a/conf/script/build-ha-csm
+++ b/conf/script/build-ha-csm
@@ -52,6 +52,7 @@ Mandatory parameters:
   --right-node    <n2>  Right node hostname (default: pod-c2)
 
 Optional parameters:
+  --cidr                Cidr netmask for CSM roaming IP address
   --cib-file            Pacemaker configuration file.
   --update              Preserve Consul and Motr state, reconfigure Pacemaker only.
 
@@ -66,7 +67,7 @@ EOF
 }
 
 TEMP=$(getopt --options h,i: \
-              --longoptions help,vip:,interface:,left-node:,right-node: \
+              --longoptions help,vip:,interface:,cidr:,left-node:,right-node: \
               --longoptions cib-file:,update \
               --name "$PROG" -- "$@" || true)
 
@@ -75,6 +76,7 @@ TEMP=$(getopt --options h,i: \
 eval set -- "$TEMP"
 
 vip=
+cidr=24
 iface=eth1
 lnode=pod-c1
 rnode=pod-c2
@@ -85,6 +87,7 @@ while true; do
     case "$1" in
         -h|--help)           usage; exit ;;
         --vip)               vip=$2; shift 2 ;;
+        --cidr)              cidr=$2; shift 2 ;;
         -i|--interface)      iface=$2; shift 2 ;;
         --left-node)         lnode=$2; shift 2 ;;
         --right-node)        rnode=$2; shift 2 ;;
@@ -101,6 +104,7 @@ if [[ -f $argsfile ]]; then
     while IFS=': ' read name value; do
        case $name in
            vip)          vip=$value     ;;
+           cidr)         cidr=$value    ;;
            interface)    iface=$value   ;;
            left-node)    lnode=$value   ;;
            right-node)   rnode=$value   ;;
@@ -159,7 +163,7 @@ systemd_disable() {
 kibana_rsc_add() {
     echo 'Adding kibana resources...'
     sudo pcs -f $cib_file resource create kibana-vip ocf:heartbeat:IPaddr2 \
-        ip=$vip cidr_netmask=24 nic=$iface iflabel=v1 \
+        ip=$vip cidr_netmask=$cidr nic=$iface iflabel=v1 \
         op start   interval=0s timeout=60s \
         op monitor interval=5s timeout=20s \
         op stop    interval=0s timeout=60s


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
cidr_netmask parameter is hardcoded for kibana-vip resource 
https://jts.seagate.com/browse/EOS-15043
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No. 
  </code>
</pre>
## Problem Description
<pre>
  <code>
Provisioner component is missing the capability to specify netmask that shall be set on kibana-vip IP created in build-ha-csm script. This causes EOS-15043 bug where netmask is set incorrectly.
  </code>
</pre>
## Solution
<pre>
  <code>
Add cidr parameter for build-ha-csm script  
</code>
</pre>
## Unit Test Cases
<pre>
  <code>
Script is launched on local setup.
  </code>
</pre>
