### PR TITLE
Eos 15127 SW update failed at components.ha.iostack-ha.post_update

### DIFF
--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -137,7 +137,7 @@ stateful_demote() {
     sspl_pid=`/sbin/pidof -s /usr/bin/sspl_ll_d`
     sspl_state=`systemctl is-active sspl-ll`
     log "DEMOTE: pid=$sspl_pid curr_state=$sspl_state"
-    [ $sspl_state == 'active' -a $sspl_pid != '' ] ||
+    [[ $sspl_state == 'active' && $sspl_pid != '' ]] ||
         return $(stateful_monitor)
 
     stateful_update "slave"
@@ -156,7 +156,7 @@ stateful_promote() {
     sspl_pid=`/sbin/pidof -s /usr/bin/sspl_ll_d`
     sspl_state=`systemctl is-active sspl-ll`
     log "PROMOTE: pid=$sspl_pid curr_state=$sspl_state"
-    [ $sspl_state == 'active' -a $sspl_pid != '' ] ||
+    [[ $sspl_state == 'active' && $sspl_pid != '' ]] ||
         return $(stateful_monitor)
 
     stateful_update "master"


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
   Error was reported in update from build 454->463 using csm cli
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    SW update failed at components.ha.iostack-ha.post_update  from build 454->463 using csm cli
  </code>
</pre>
## Solution
<pre>
  <code>
    syntax error found in sspl resource promote and demote is fixed
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
  -
  </code>
</pre>
