### PR TITLE
EOS-15165: Add failure timeout to haproxy

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -747,8 +747,8 @@ statsd_rsc_add() {
 
 haproxy_rsc_add() {
     log "${FUNCNAME[0]}: Adding haproxy to pacemaker..."
-    sudo pcs -f $cib_file resource create haproxy-c1 systemd:haproxy op monitor interval=30s
-    sudo pcs -f $cib_file resource create haproxy-c2 systemd:haproxy op monitor interval=30s
+    sudo pcs -f $cib_file resource create haproxy-c1 systemd:haproxy op monitor interval=30s meta failure-timeout=60s
+    sudo pcs -f $cib_file resource create haproxy-c2 systemd:haproxy op monitor interval=30s meta failure-timeout=60s
     sudo pcs -f $cib_file constraint location haproxy-c1 prefers $lnode=INFINITY
     sudo pcs -f $cib_file constraint location haproxy-c1 avoids $rnode=INFINITY
     sudo pcs -f $cib_file constraint location haproxy-c2 prefers $rnode=INFINITY


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
https://jts.seagate.com/browse/EOS-15165
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
haproxy depends on ClusterIP resource because it has bind requirement in
configuration.
During cluster update it happens that haproxy starts when ClusterIP is
being restarted. So haproxy fails immediately (on both nodes) and nodes
became banned.
  </code>
</pre>
## Solution
<pre>
  <code>
Solution: add retry feature to haproxy-c1/2 resource (failure-timeout=60s)
This won't fix an issue but mitigates it making haproxy to restart when
ClusterIP is present

Notes: we may want to consider ordering constraint as well to implement
following ordering:
ClusterIP-clone |
s3servers-c1/2  | -> haproxy
So, restart/stop of ClusterIP-clone will cause haproxy restart/stop.
This approach requires some testing to be performed.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
No testing performed. Manually applied and checked on HW cluster.
  </code>
</pre>
