### PR TITLE
Problem: Pacemaker manages 3rd party software haproxy

### DIFF
--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -701,7 +701,6 @@ systemd_units_disable() {
     log "${FUNCNAME[0]}: Disabling systemd units..."
     units_to_disable=(
         elasticsearch
-        haproxy
         rabbitmq-server
         statsd
         slapd
@@ -743,16 +742,6 @@ statsd_rsc_add() {
     log "${FUNCNAME[0]}: Adding statsd to Pacemaker..."
     sudo pcs -f $cib_file resource create statsd systemd:statsd clone op monitor interval=30s
     sudo pcs -f $cib_file constraint order els-search-clone then statsd-clone
-}
-
-haproxy_rsc_add() {
-    log "${FUNCNAME[0]}: Adding haproxy to pacemaker..."
-    sudo pcs -f $cib_file resource create haproxy-c1 systemd:haproxy op monitor interval=30s meta failure-timeout=60s
-    sudo pcs -f $cib_file resource create haproxy-c2 systemd:haproxy op monitor interval=30s meta failure-timeout=60s
-    sudo pcs -f $cib_file constraint location haproxy-c1 prefers $lnode=INFINITY
-    sudo pcs -f $cib_file constraint location haproxy-c1 avoids $rnode=INFINITY
-    sudo pcs -f $cib_file constraint location haproxy-c2 prefers $rnode=INFINITY
-    sudo pcs -f $cib_file constraint location haproxy-c2 avoids $lnode=INFINITY
 }
 
 get_s3_svc() {
@@ -846,8 +835,6 @@ _s3server_rsc_add() {
 
    sudo pcs -f $cib_file constraint order set $s3servers require-all=false \
        sequential=false set s3backcons-$suffix
-   sudo pcs -f $cib_file constraint order set $s3servers require-all=false \
-       sequential=false set haproxy-$suffix
 }
 
 s3server_rsc_add() {
@@ -896,7 +883,6 @@ ha_ops=(
     s3auth_rsc_add
     elastic_search_rsc_add
     statsd_rsc_add
-    haproxy_rsc_add
     rabbitmq_rsc_add
     s3_systemd_update
     s3back_rsc_add
@@ -937,7 +923,6 @@ declare -A ha_ops_type=(
     [s3auth_rsc_add]='bootstrap_update'
     [elastic_search_rsc_add]='bootstrap_update'
     [statsd_rsc_add]='bootstrap_update'
-    [haproxy_rsc_add]='bootstrap_update'
     [rabbitmq_rsc_add]='bootstrap_update'
     [s3_systemd_update]='bootstrap_update'
     [s3back_rsc_add]='bootstrap_update'


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
Pacemaker manages 3rd party software haproxy
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Haproxy being a 3rd party software, it need not be managed by pacemaker
along with the Seagate cortx stack.
  </code>
</pre>
## Solution
<pre>
  <code>
    Do not configure haproxy as a pacemaker resource.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    None
  </code>
</pre>
