### PR TITLE
Remove 3rd party resources from pacemaker

### DIFF
--- a/conf/script/build-ha-csm
+++ b/conf/script/build-ha-csm
@@ -190,8 +190,6 @@ csm_rsc_add() {
 
     sudo pcs -f $cib_file constraint colocation add csm-kibana with els-search-clone \
         score=INFINITY
-    sudo pcs -f $cib_file constraint colocation add csm-kibana with rabbitmq-clone \
-        score=INFINITY
 }
 
 cib_init() {

--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -698,7 +698,6 @@ systemd_units_disable() {
     units_to_disable=(
         elasticsearch
         haproxy
-        rabbitmq-server
         statsd
         slapd
         s3authserver
@@ -752,12 +751,6 @@ get_s3_svc() {
         awk "/$svc.s3server@/ {print \$2}"
 }
 
-rabbitmq_rsc_add() {
-    log "${FUNCNAME[0]}: Adding rabbit-mq resources and constraints..."
-    sudo pcs -f $cib_file resource create rabbitmq systemd:rabbitmq-server clone op \
-        monitor interval=30s meta failure-timeout=20s
-}
-
 s3_systemd_update() {
 # Add and update node attribute for s3backgroundconsumer resource on both the
 # nodes. This will be used to define constraints for the resources depending
@@ -785,11 +778,8 @@ s3back_rsc_add() {
                           systemd:s3backgroundconsumer meta failure-timeout=300s
     sudo pcs -f $cib_file constraint location s3backcons-c1 avoids $rnode=INFINITY
     sudo pcs -f $cib_file constraint location s3backcons-c2 avoids $lnode=INFINITY
-    sudo pcs -f $cib_file constraint order rabbitmq-clone then s3backcons-c1
-    sudo pcs -f $cib_file constraint order rabbitmq-clone then s3backcons-c2
     sudo pcs -f $cib_file resource create s3backprod systemd:s3backgroundproducer op \
         monitor interval=30s
-    sudo pcs -f $cib_file constraint order rabbitmq-clone then s3backprod
     sudo pcs -f $cib_file constraint location s3backprod rule score=-INFINITY '#uname' \
         eq $lnode and s3backcons-running eq 0
     sudo pcs -f $cib_file constraint location s3backprod rule score=-INFINITY '#uname' \
@@ -886,7 +876,6 @@ ha_ops=(
     elastic_search_rsc_add
     statsd_rsc_add
     haproxy_rsc_add
-    rabbitmq_rsc_add
     s3_systemd_update
     s3back_rsc_add
     s3server_rsc_add
@@ -926,7 +915,6 @@ declare -A ha_ops_type=(
     [elastic_search_rsc_add]='bootstrap_update'
     [statsd_rsc_add]='bootstrap_update'
     [haproxy_rsc_add]='bootstrap_update'
-    [rabbitmq_rsc_add]='bootstrap_update'
     [s3_systemd_update]='bootstrap_update'
     [s3back_rsc_add]='bootstrap_update'
     [s3server_rsc_add]='bootstrap_update'

--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -696,7 +696,6 @@ clusterip_rsc_add() {
 systemd_units_disable() {
     log "${FUNCNAME[0]}: Disabling systemd units..."
     units_to_disable=(
-        elasticsearch
         haproxy
         statsd
         slapd
@@ -720,12 +719,6 @@ s3auth_rsc_add() {
         eq $lnode and hax-running eq 0
     sudo pcs -f $cib_file constraint location s3auth-clone rule score=-INFINITY '#uname' \
         eq $rnode and hax-running eq 0
-}
-
-elastic_search_rsc_add() {
-    log "${FUNCNAME[0]}: Adding elastic search to Pacemaker.."
-    sudo pcs -f $cib_file resource create els-search systemd:elasticsearch clone op \
-        monitor interval=30s
 }
 
 statsd_rsc_add() {
@@ -873,7 +866,6 @@ ha_ops=(
     clusterip_rsc_add
     systemd_units_disable
     s3auth_rsc_add
-    elastic_search_rsc_add
     statsd_rsc_add
     haproxy_rsc_add
     s3_systemd_update
@@ -912,7 +904,6 @@ declare -A ha_ops_type=(
     [clusterip_rsc_add]='bootstrap_update'
     [systemd_units_disable]='bootstrap_update'
     [s3auth_rsc_add]='bootstrap_update'
-    [elastic_search_rsc_add]='bootstrap_update'
     [statsd_rsc_add]='bootstrap_update'
     [haproxy_rsc_add]='bootstrap_update'
     [s3_systemd_update]='bootstrap_update'

--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -697,7 +697,6 @@ systemd_units_disable() {
     log "${FUNCNAME[0]}: Disabling systemd units..."
     units_to_disable=(
         haproxy
-        statsd
         slapd
         s3authserver
     )
@@ -719,12 +718,6 @@ s3auth_rsc_add() {
         eq $lnode and hax-running eq 0
     sudo pcs -f $cib_file constraint location s3auth-clone rule score=-INFINITY '#uname' \
         eq $rnode and hax-running eq 0
-}
-
-statsd_rsc_add() {
-    log "${FUNCNAME[0]}: Adding statsd to Pacemaker..."
-    sudo pcs -f $cib_file resource create statsd systemd:statsd clone op monitor interval=30s
-    sudo pcs -f $cib_file constraint order els-search-clone then statsd-clone
 }
 
 haproxy_rsc_add() {
@@ -866,7 +859,6 @@ ha_ops=(
     clusterip_rsc_add
     systemd_units_disable
     s3auth_rsc_add
-    statsd_rsc_add
     haproxy_rsc_add
     s3_systemd_update
     s3back_rsc_add
@@ -904,7 +896,6 @@ declare -A ha_ops_type=(
     [clusterip_rsc_add]='bootstrap_update'
     [systemd_units_disable]='bootstrap_update'
     [s3auth_rsc_add]='bootstrap_update'
-    [statsd_rsc_add]='bootstrap_update'
     [haproxy_rsc_add]='bootstrap_update'
     [s3_systemd_update]='bootstrap_update'
     [s3back_rsc_add]='bootstrap_update'

--- a/conf/script/build-ha-io
+++ b/conf/script/build-ha-io
@@ -709,16 +709,10 @@ systemd_units_disable() {
     done
 }
 
-ldap_rsc_add() {
-    log "${FUNCNAME[0]}: Adding ldap to Pacemaker..."
-    sudo pcs -f $cib_file resource create ldap systemd:slapd clone op monitor interval=30s
-}
-
 s3auth_rsc_add() {
     log "${FUNCNAME[0]}: Adding s3authserver to Pacemaker..."
     sudo pcs -f $cib_file resource create s3auth systemd:s3authserver clone op \
         monitor interval=30
-    sudo pcs -f $cib_file constraint order ldap-clone then s3auth-clone
     sudo pcs -f $cib_file constraint order motr-ios-c1 then s3auth-clone
     sudo pcs -f $cib_file constraint order motr-ios-c2 then s3auth-clone
     # Make s3auth resource to run only on nodes where motr and hax are present.
@@ -888,7 +882,6 @@ ha_ops=(
     motr_rsc_add
     clusterip_rsc_add
     systemd_units_disable
-    ldap_rsc_add
     s3auth_rsc_add
     elastic_search_rsc_add
     statsd_rsc_add
@@ -929,7 +922,6 @@ declare -A ha_ops_type=(
     [motr_rsc_add]='bootstrap_update'
     [clusterip_rsc_add]='bootstrap_update'
     [systemd_units_disable]='bootstrap_update'
-    [ldap_rsc_add]='bootstrap_update'
     [s3auth_rsc_add]='bootstrap_update'
     [elastic_search_rsc_add]='bootstrap_update'
     [statsd_rsc_add]='bootstrap_update'


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
https://jts.seagate.com/browse/EOS-15271
Removal of 3rd-party resource from Pacemaker. Except haproxy which is deleted in separate PR.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
No
  </code>
</pre>
## Problem Description
<pre>
  <code>
ldap, rabbitmq, elasticsearch, statsd resource are supposed to be managed by systemd from now. Provisioning component is responsible for configuring systemd units and autostart. Need to remove pacemaker resource creation from HA bootstrap scripts.
  </code>
</pre>
## Solution
<pre>
  <code>
1 commit per resource. Remove resource creation functions but keep teardown scripts as is to not break update procedure when cluster still has all those resource.
Also delete resource from "disable-list" - it is no longer needed  - systemd shall have those services enabled.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
No unit tests.
  </code>
</pre>
