### PR TITLE
EOS-15282: build-ha-csm fails to complete build-ha-csm-args.yaml file

### DIFF
--- a/conf/script/build-ha-csm
+++ b/conf/script/build-ha-csm
@@ -101,13 +101,14 @@ done
 argsfile=${1:-}
 
 if [[ -f $argsfile ]]; then
-    while IFS=': ' read name value; do
+    while IFS=': ' read name value || [[ $name =~ [a-zA-Z0-9] ]]; do
        case $name in
            vip)          vip=$value     ;;
            cidr)         cidr=$value    ;;
            interface)    iface=$value   ;;
            left-node)    lnode=$value   ;;
            right-node)   rnode=$value   ;;
+           '')                          ;;
            *) echo "Invalid parameter '$name' in $argsfile" >&2
               usage >&2; exit 1 ;;
        esac

--- a/conf/script/build-ha-sspl
+++ b/conf/script/build-ha-sspl
@@ -86,7 +86,7 @@ argsfile=${1:-}
 hare_dir=/var/lib/hare
 
 if [[ -f $argsfile ]]; then
-    while IFS=': ' read name value; do
+    while IFS=': ' read name value || [[ $name =~ [a-zA-Z0-9] ]]; do
        case $name in
            left-node)    lnode=$value   ;;
            right-node)   rnode=$value   ;;


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
build-ha-csm fails to complete build-ha-csm-args.yaml file
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    build-ha-csm uses IFS (bash internal field separator) set to `:` to read build-ha-csm-args.yaml
    file. The build-ha-csm-args.yaml file is read iteratively in while loop using read command, the
    read may fail if the line does not end with a newline character. This is what happens while reading
    build-ha-csm-args.yaml by build-ha-csm script. The last line not ending with a newline character
    is skipped and required data remains unread leading to failure of the build-ha-csm script.
  </code>
</pre>
## Solution
<pre>
  <code>
    - Use regEx along with the IFS to handle such situations.
    - Handle extra spaces and blank lines in the args file as well.
    - Fix build-ha-sspl script as well to handle the "no newline terminate" case.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Tested on sm21-r2.pun.seagate.com and sm13-r2.pun.seagate.com setup
  </code>
</pre>
