### PR TITLE
EOS-15043: add validation for input --cidr parameter

### DIFF
--- a/conf/script/build-ha-csm
+++ b/conf/script/build-ha-csm
@@ -146,6 +146,18 @@ precheck() {
         die 'No active rabbitmq instance found'
     ssh $rnode "systemctl is-active --quiet rabbitmq-server" ||
         die 'No active rabbitmq instance found'
+
+    local iface_cidr_lnode=
+    local iface_cidr_rnode=
+    local cmd="ip addr show $iface | grep -m 1 \"inet\b\" | awk '{print \$2}' | cut -d '/' -f2"
+
+    iface_cidr_lnode=$(eval $cmd)
+    [[ $iface_cidr_lnode == $cidr ]] ||
+        die "Input cidr:$cidr does not match existing cidr:$iface_cidr_lnode on interface:$iface on node: $lnode"
+
+    iface_cidr_rnode=$(ssh $rnode $cmd)
+    [[ $iface_cidr_rnode == $cidr ]] ||
+        die "Input cidr:$cidr does not match existing cidr:$iface_cidr_rnode on interface:$iface on node: $rnode"
 }
 
 systemd_disable() {


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
EOS-15043. 
No validation for incorrect --cidr value
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 No
  </code>
</pre>
## Problem description
<pre>
  <code>
    --cidr parameter denotes netmask to be set for kibana-vip resource.
That netmask shall be the same as on phisical management interface
otherwise it causes problems like it happened in EOS-15292 where
incorrect netmask was just applied.
  </code>
</pre>
## Solution
<pre>
  <code>
Solution: retrieve netmask from existing management and compare against
input. Fail with adequate log message if they are different.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
Tested the same code in simple test script on real HW cluster
  </code>
</pre>
