### PR TITLE
EOS-15329: Move cluster into standby mode before deleting the resources 

### DIFF
--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -107,7 +107,6 @@ sudo pcs cluster standby --all
 reset_all
 
 sudo pcs cluster unstandby --all
-sleep 2
 sudo pcs resource cleanup
 
 sudo pcs cluster cib $cib_file

--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -102,12 +102,12 @@ if [[ -f $consul_kv_dump ]]; then
 fi
 $consul_bin/consul kv export > $consul_kv_dump
 
+# Move cluster into standby mode before deleting the resources
 sudo pcs cluster standby --all
 
 reset_all
 
 sudo pcs cluster unstandby --all
-sudo pcs resource cleanup
 
 sudo pcs cluster cib $cib_file
 

--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -103,7 +103,8 @@ fi
 $consul_bin/consul kv export > $consul_kv_dump
 
 # Move cluster into standby mode before deleting the resources
-sudo pcs cluster standby --all
+pcs_status=$(sudo pcs status)
+echo $pcs_status | grep "Node srvnode-1: standby" && echo $pcs_status | grep "Node srvnode-2: standby" || sudo pcs cluster standby --all
 
 reset_all
 

--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -111,6 +111,11 @@ $consul_bin/consul kv export > $consul_kv_dump
 sudo pcs cluster standby --all
 
 reset_all
+
+sudo pcs cluster unstandby --all
+sleep 2
+sudo pcs resource cleanup
+
 sudo pcs cluster cib $cib_file
 
 echo 'Updating ha resources for IO path, SSPL, CSM and UDS...'
@@ -130,10 +135,6 @@ sudo pcs cluster cib-push $cib_file --config
 
 $ha_script/build-cortx-ha init
 
-sudo pcs resource cleanup
-
-sudo pcs cluster unstandby --all
-sleep 2
 sudo pcs resource cleanup
 
 echo 'Importing Consul KV...'

--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -112,7 +112,7 @@ sudo pcs cluster unstandby --all
 
 while ! sudo pcs status | grep "Online: \[ srvnode-1 srvnode-2 ]"
 do
-    echo 'Waiting for cluster becomes online'
+    echo 'Waiting till cluster becomes online'
     sleep 1
 done
 

--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -14,10 +14,16 @@
 # with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
+HA_LOG="/var/log/seagate/cortx/ha"
 
 set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 # set -x
+
+# Add Log
+mkdir -p "${HA_LOG}"/
+exec &>> "${HA_LOG}"/${0##*/}.log
+exec &> >(stdbuf -oL gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
 
 PROG=${0##*/}
 
@@ -102,6 +108,8 @@ if [[ -f $consul_kv_dump ]]; then
 fi
 $consul_bin/consul kv export > $consul_kv_dump
 
+sudo pcs cluster standby --all
+
 reset_all
 sudo pcs cluster cib $cib_file
 
@@ -122,6 +130,10 @@ sudo pcs cluster cib-push $cib_file --config
 
 $ha_script/build-cortx-ha init
 
+sudo pcs resource cleanup
+
+sudo pcs cluster unstandby --all
+sleep 2
 sudo pcs resource cleanup
 
 echo 'Importing Consul KV...'

--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -14,16 +14,10 @@
 # with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
-HA_LOG="/var/log/seagate/cortx/ha"
 
 set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 # set -x
-
-# Add Log
-mkdir -p "${HA_LOG}"/
-exec &>> "${HA_LOG}"/${0##*/}.log
-exec &> >(stdbuf -oL gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
 
 PROG=${0##*/}
 

--- a/conf/script/build-ha-update
+++ b/conf/script/build-ha-update
@@ -110,6 +110,12 @@ reset_all
 
 sudo pcs cluster unstandby --all
 
+while ! sudo pcs status | grep "Online: \[ srvnode-1 srvnode-2 ]"
+do
+    echo 'Waiting for cluster becomes online'
+    sleep 1
+done
+
 sudo pcs cluster cib $cib_file
 
 echo 'Updating ha resources for IO path, SSPL, CSM and UDS...'


### PR DESCRIPTION
Signed-off-by: Vijay Thakkar <vijaykumar.thakkar@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-15329: Build 515: Unsuccessful update to build 529 after primary node replacement
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Observed build-ha-update script took more time to delete and recreate resources.
  </code>
</pre>
## Solution
<pre>
  <code>
    Did changes to move cluster into standby mode before deleting resources and moving back to unstandby mode after recreating resources again.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
