### PR TITLE
EOS-16006: Disruptive Upgrade: Support pre-requisite operations and c…

### DIFF
--- a/conf/script/pre_disruptive_upgrade.sh
+++ b/conf/script/pre_disruptive_upgrade.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+set -eu -o pipefail
+
+BACKUP_SOURCE_DIR=/etc/cortx/ha
+BACKUP_DEST_DIR=/opt/seagate/cortx/ha_conf_backup
+
+# Take the backup of configuration files
+cp -r $BACKUP_SOURCE_DIR $BACKUP_DEST_DIR
+
+# Keep cluster in maintainence mode
+pcs property set maintenance-mode=true
+
+# Remove all the resources from the cluster
+
+# Get only the name of the resource
+resource_list=( `crm_resource --list-raw` )
+
+# Remove each one by one
+for resource in "${resource_list[@]}"
+do
+    echo Deleteing the resource: "${resource}"
+    pcs resource delete "${resource}" --force
+done
+
+

--- a/conf/script/pre_disruptive_upgrade.sh
+++ b/conf/script/pre_disruptive_upgrade.sh
@@ -46,7 +46,7 @@ cluster_standby_mode(){
 
     standby_mode=$(crm_standby -G  | awk '{print $3}' | cut -d '=' -f 2)
 
-    if [ $standby_mode == "on" ]
+    if [ "$standby_mode" == "on" ]
     then
         echo "cluster is already in a standby mode"
     else

--- a/conf/script/pre_disruptive_upgrade.sh
+++ b/conf/script/pre_disruptive_upgrade.sh
@@ -117,12 +117,12 @@ delete_resources(){
             # In case of clone or master-slave resource, resource gets
             # displayed as rabbitmq:0, sspl:1 etc. So, remove :0 in such
             # case and perform delete operation only once.
-	        resource="${resource%:*}"
+            resource="${resource%:*}"
 
             # If same resource is in the list, that means it is already deleted.
             if [ "$prev_resource" != "$resource" ]; then
                 echo -e "\e[1;32mDeleting the resource: ${resource}\e[0m"
-            	$pcs resource delete "${resource}" --force
+                $pcs resource delete "${resource}" --force
             fi
 
             # For clone resources, in order to avoid repeatative delete,

--- a/conf/script/pre_disruptive_upgrade.sh
+++ b/conf/script/pre_disruptive_upgrade.sh
@@ -43,10 +43,17 @@ backup_consul(){
     echo "Taking the backup of consul"
     consul_kv_dump=$HARE_DIR/consul-kv-dump.json
     if [[ -f $consul_kv_dump ]]; then
-        cat $consul_kv_dump | xz > ${consul_kv_dump%.json}-$(date '+%Y%m%d%H%M%S').json.xz
+        # Facing one codacy issue with below line. Hence, compressing the file in a
+        # different way
+        #cat $consul_kv_dump | xz > ${consul_kv_dump%.json}-$(date '+%Y%m%d%H%M%S').json.xz
+
+        tar -czf ${consul_kv_dump%.json}-$(date '+%Y%m%d%H%M%S').json.tar.gz $consul_kv_dump
     fi
     $consul kv export > $consul_kv_dump
-
+    [ $? != 0 ] && {
+        echo "Consul backup failed"
+        exit 1
+    }
 }
 
 backup_conf(){
@@ -110,7 +117,6 @@ delete_resources(){
         done
     fi
 }
-
 
 while [ $# -gt 0 ]; do
     case $1 in

--- a/conf/script/pre_disruptive_upgrade.sh
+++ b/conf/script/pre_disruptive_upgrade.sh
@@ -27,7 +27,7 @@ backup_consul(){
     echo "Taking the backup of consul"
     consul_kv_dump=$HARE_DIR/consul-kv-dump.json
     if [[ -f $consul_kv_dump ]]; then
-        cat $consul_kv_dump | xz > ${consul_kv_dump%.json}-$(date '+%Y%m%d%H%M%S').json.xz
+        cmd < $consul_kv_dump | xz > ${consul_kv_dump%.json}-$(date '+%Y%m%d%H%M%S').json.xz
     fi
     $consul kv export > $consul_kv_dump
 

--- a/conf/script/pre_disruptive_upgrade.sh
+++ b/conf/script/pre_disruptive_upgrade.sh
@@ -46,7 +46,7 @@ cluster_standby_mode(){
 
     standby_mode=$(crm_standby -G  | awk '{print $3}' | cut -d '=' -f 2)
 
-    if [ $standby_mode == 'on' ]
+    if [ $standby_mode == "on" ]
     then
         echo "cluster is already in a standby mode"
     else
@@ -65,7 +65,9 @@ delete_resources(){
     echo "deleting the resources from the cluster"
 
     # Get only the name of the resource
-    resource_list=( `/usr/sbin/crm_resource --list-raw` )
+    resource_list=$(/usr/sbin/crm_resource --list-raw)
+
+    resource_list=( $resource_list )
 
     # Remove each one by one
     for resource in "${resource_list[@]}"

--- a/conf/script/pre_disruptive_upgrade.sh
+++ b/conf/script/pre_disruptive_upgrade.sh
@@ -33,7 +33,8 @@ backup_conf(){
 
     [ -d $BACKUP_DEST_DIR ]  && {
         rm -rf $BACKUP_DEST_DIR
-    } || mkdir -p $BACKUP_DEST_DIR
+        mkdir -p $BACKUP_DEST_DIR
+    }
 
     # Take the backup of configuration files
     cp -r $BACKUP_SOURCE_DIR $BACKUP_DEST_DIR
@@ -43,13 +44,20 @@ cluster_standby_mode(){
 
     echo "standby mode ON"
 
-    # Keep cluster (nodes and resources) on standby mode
-    /usr/sbin/pcs node standby --all --wait=10
-    [ $? == 0 ] || {
+    standby_mode=$(crm_standby -G  | awk '{print $3}' | cut -d '=' -f 2)
 
-        echo "some problem occured to keep cluster in standby mode, Hence exiting"
-        exit 1
-    }
+    if [ $standby_mode == 'on' ]
+    then
+        echo "cluster is already in a standby mode"
+    else
+        # Keep cluster (nodes and resources) on standby mode
+        /usr/sbin/pcs node standby --all --wait=10
+        [ $? == 0 ] || {
+
+            echo "some problem occured to keep cluster in standby mode, Hence exiting"
+            exit 1
+        }
+    fi
 }
 
 delete_resources(){

--- a/conf/script/pre_disruptive_upgrade.sh
+++ b/conf/script/pre_disruptive_upgrade.sh
@@ -43,7 +43,7 @@ backup_consul(){
     echo "Taking the backup of consul"
     consul_kv_dump=$HARE_DIR/consul-kv-dump.json
     if [[ -f $consul_kv_dump ]]; then
-        cmd < $consul_kv_dump | xz > ${consul_kv_dump%.json}-$(date '+%Y%m%d%H%M%S').json.xz
+        cat $consul_kv_dump | xz > ${consul_kv_dump%.json}-$(date '+%Y%m%d%H%M%S').json.xz
     fi
     $consul kv export > $consul_kv_dump
 

--- a/conf/script/v2/pre_disruptive_upgrade
+++ b/conf/script/v2/pre_disruptive_upgrade
@@ -68,7 +68,7 @@ backup_consul(){
         log "${FUNCNAME[0]}: Consul KV export failed. Hence, exiting"
         exit 1
     }
-    log "Backup is taken successfully"
+    log "Consul Backup is taken successfully"
 }
 
 backup_conf(){
@@ -88,7 +88,7 @@ backup_conf(){
         log "${FUNCNAME[0]}: Failed to create backup of HA config. Hence, exiting"
         exit 1
     }
-
+    log "HA config backup is taken successfully"
 }
 
 cluster_standby_mode(){

--- a/conf/script/v2/pre_disruptive_upgrade
+++ b/conf/script/v2/pre_disruptive_upgrade
@@ -17,6 +17,7 @@
 
 set -eu -o pipefail
 
+log_file=/var/log/cortx-ha.log
 BACKUP_SOURCE_DIR=/etc/cortx/ha
 BACKUP_DEST_DIR=/opt/seagate/cortx/ha_conf_backup
 consul=/usr/bin/consul
@@ -24,6 +25,17 @@ HARE_DIR=/var/lib/hare
 pcs=/usr/sbin/pcs
 crm_resource=/usr/sbin/crm_resource
 crm_standby=/usr/sbin/crm_standby
+
+exec &>> $log_file
+exec &> >(stdbuf -oL gawk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0 }')
+
+log() {
+    logger --stderr --tag pre_disruptive_upgrade "$*"
+}
+
+log "****************************************************************"
+log "${0##*/}"
+log "****************************************************************"
 
 PROG=${0##*/}
 
@@ -41,6 +53,8 @@ EOF
 backup_consul(){
 
     echo "Taking the backup of consul"
+    log "${FUNCNAME[0]}: Exporting the Consul KV"
+
     consul_kv_dump=$HARE_DIR/consul-kv-dump.json
     if [[ -f $consul_kv_dump ]]; then
         # Facing one codacy issue with below line. Hence, compressing the file in a
@@ -51,14 +65,16 @@ backup_consul(){
     fi
     $consul kv export > $consul_kv_dump
     [ $? != 0 ] && {
-        echo "Consul backup failed"
+        log "${FUNCNAME[0]}: Consul KV export failed. Hence, exiting"
         exit 1
     }
+    log "Backup is taken successfully"
 }
 
 backup_conf(){
 
     echo "Taking the backup of ha conf directory"
+    log "${FUNCNAME[0]}: Taking the backup of HA configuration"
 
     [ -d $BACKUP_DEST_DIR ]  && {
         rm -rf $BACKUP_DEST_DIR
@@ -68,6 +84,11 @@ backup_conf(){
 
     # Take the backup of configuration files
     cp -r $BACKUP_SOURCE_DIR $BACKUP_DEST_DIR
+    [ $? != 0 ] && {
+        log "${FUNCNAME[0]}: Failed to create backup of HA config. Hence, exiting"
+        exit 1
+    }
+
 }
 
 cluster_standby_mode(){
@@ -77,7 +98,7 @@ cluster_standby_mode(){
 
     if [ "$standby_mode" == "on" ]
     then
-        echo "cluster is already in a standby mode"
+        log "${FUNCNAME[0]}: Cluster is already in a standby mode"
     else
         # Keep cluster (nodes and resources) on standby mode
         $pcs node standby --all --wait=30
@@ -85,10 +106,10 @@ cluster_standby_mode(){
             retry_count=$(( $1 + 1 ))
             if [ $retry_count -le $final_count ];
             then
-                echo "Some problem occured to keep the cluster in standby mode, Retrying.."
+                log "${FUNCNAME[0]}: Some problem occured to keep the cluster in standby mode, Retrying.."
                 cluster_standby_mode $retry_count
             else
-                echo "Retry count exceeded for cluster standby mode. Hence, exiting.."
+                log "${FUNCNAME[0]}: Retry count exceeded for cluster standby mode. Hence, exiting.."
                 exit 1
             fi
         }
@@ -97,12 +118,13 @@ cluster_standby_mode(){
 
 delete_resources(){
 
-    echo "deleting the resources from the cluster"
+    echo "Deleting the resources from the cluster"
+    log "${FUNCNAME[0]}: Deleting the resources from the cluster"
 
     resources=$($pcs resource show)
     if [ "$resources" == "NO resources configured" ];
     then
-        echo "No resources are configured. Hence, skipping this"
+        log "${FUNCNAME[0]}: No resources are configured. Hence, skipping this"
     else
 	    prev_resource=""
 
@@ -121,7 +143,7 @@ delete_resources(){
 
             # If same resource is in the list, that means it is already deleted.
             if [ "$prev_resource" != "$resource" ]; then
-                echo -e "\e[1;32mDeleting the resource: ${resource}\e[0m"
+                log "${FUNCNAME[0]}: Deleting the resource: ${resource}"
                 $pcs resource delete "${resource}" --force
             fi
 
@@ -150,6 +172,7 @@ done
 backup_conf
 
 retry_count=0
+log "Putting the cluster in standby mode"
 echo "Putting the cluster in standby mode"
 cluster_standby_mode $retry_count
 

--- a/conf/script/v2/pre_disruptive_upgrade
+++ b/conf/script/v2/pre_disruptive_upgrade
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 #
 # This program is free software: you can redistribute it and/or modify it under the
 # terms of the GNU Affero General Public License as published by the Free Software

--- a/conf/script/v2/pre_disruptive_upgrade
+++ b/conf/script/v2/pre_disruptive_upgrade
@@ -61,6 +61,8 @@ backup_consul(){
         # different way
         #cat $consul_kv_dump | xz > ${consul_kv_dump%.json}-$(date '+%Y%m%d%H%M%S').json.xz
 
+        # First remove the older dump
+        rm -f *.json.tar.gz
         tar -czf ${consul_kv_dump%.json}-$(date '+%Y%m%d%H%M%S').json.tar.gz $consul_kv_dump
     fi
     $consul kv export > $consul_kv_dump
@@ -101,7 +103,7 @@ cluster_standby_mode(){
         log "${FUNCNAME[0]}: Cluster is already in a standby mode"
     else
         # Keep cluster (nodes and resources) on standby mode
-        $pcs node standby --all --wait=30
+        $pcs node standby --all --wait=600
         [ $? == 0 ] || {
             retry_count=$(( $1 + 1 ))
             if [ $retry_count -le $final_count ];


### PR DESCRIPTION
…luster stop

This is the first step before we start the disruptive upgrade.
- Take the back up of HA conf file
- Keep the cluster in Maintainance mode
- REmove all the resources from the cluster

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-16006  
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes.
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Perform pre-requisite steps before disruptive upgrade starts
  </code>
</pre>
## Solution
<pre>
  <code>
    Take the backup of ha conf directory
    Keep cluster in maintainance mode
    remove all the resources from the cluster
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    1. Check backup of ha conf directory takes place or not.
    2 Check standby mode
    3. Check resource deletion. 
  </code>
</pre>
