### PR TITLE
EOS-16480: create pacemaker resources on VM

### DIFF
--- a/ha/setup/create_cluster.py
+++ b/ha/setup/create_cluster.py
@@ -1,0 +1,126 @@
+#!/bin/python3
+
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+import argparse
+from ha.execute import SimpleCommand
+from cortx.utils.log import Log
+
+class ClusterCreateError(Exception):
+
+    """Exception to indicate that cluster can't be created due to some error."""
+
+class ClusterAuthError(ClusterCreateError):
+
+    """Exception to indicate that authorization procedure failed."""
+
+class ClusterSetupError(ClusterCreateError):
+
+    """Exception to indicate that cluster setup procedure failed."""
+
+
+def cluster_auth(username, password, nodelist):
+    """Authorizes cluster nodes.
+
+    Parameters:
+            username - just a user name to make cluster authorization
+            password - just a password for aforementioned user
+            nodelist - List with nodes which to authorize
+
+    Returns: None.
+
+    Exceptions:
+        ClusterCreateError: generic exception to catch all creation-related
+        problems.
+        ClusterAuthError: failure happened during setup operation.
+    """
+    nodes = " ".join(nodelist)
+    cmd_auth = f"pcs cluster auth -u {username} -p {password} {nodes}"
+    try:
+        SimpleCommand().run_cmd(cmd_auth)
+    except Exception:
+        raise ClusterAuthError("Failed to authorize the node")
+
+
+def cluster_create(cluster_name, nodelist, enable=True, put_standby=True):
+    """Creates cluster on given nodes. Enables and starts cluster if needed.
+
+    Parameters:
+        cluster_name    - name of the cluster to be created
+        nodelist        - List with nodes where setup the cluster
+        enable          - whether cluster service shall start on boot
+        put_standby     - whether [nodeslist] shall be put to standby mode
+
+    Returns: None.
+
+    Exceptions:
+        ClusterCreateError: generic exception to catch all creation-related
+        problems.
+        ClusterSetupError: failure happened during setup operation.
+    """
+    nodes = " ".join(nodelist)
+    cmd_setup = f"pcs cluster setup --start --name {cluster_name} {nodes}"
+    cmd_standby = f"pcs node standby {nodes}"
+    cmd_stonith = "pcs property set stonith-enabled=False"
+    cmd_enable = f"pcs cluster enable {nodes}"
+
+    cmdlist = [ cmd_setup ]
+    if enable:
+        cmdlist.append(cmd_enable)
+    if put_standby:
+        cmdlist.append(cmd_standby)
+    cmdlist.append(cmd_stonith)
+    try:
+        for s in cmdlist:
+            SimpleCommand().run_cmd(s)
+    except Exception:
+        raise ClusterSetupError("Failed to setup the cluster")
+
+def _parse_input_args():
+    """Parse and validate input arguments passed by mini-provisioner or CLI.
+    
+    Returns dictonary with context."""
+    parser = argparse.ArgumentParser(description="Creates pacemaker cluster")
+    parser.add_argument("--cluster", default="cortx-lr2", type=str, help="Cluster name")
+    parser.add_argument("--username", required=True, type=str, help="User to be used for cluster auth")
+    parser.add_argument("--password", required=True, type=str, help="Password to be used for cluster auth")
+    parser.add_argument("--standby", action='store_true', help="Put nodes into standby on cluster creation")
+    # Nodes to setup cluster can be entered via file or via parameters
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("nodelist", type=str, nargs="*", default=[], help="List of nodes where cluster can be created")
+    group.add_argument("--nodefile", required=False, type=str, help="File with list of nodes")
+    return parser.parse_args()
+
+def _read_file_list(filename):
+    nodelist = []
+    with open(filename, "r") as f:
+        nodelist = f.read().splitlines()
+    return nodelist
+
+def _main():
+    # Workaround to make SimpleCommand work, not crash
+    Log.init(service_name="create_cluster",
+             log_path="/var/log/seagate/cortx/ha", level="INFO")
+
+    args = _parse_input_args()
+    nodelist = args.nodelist if args.nodelist else _read_file_list(args.nodefile)
+    if not nodelist:
+        raise ValueError("node list shall not be empty")
+    cluster_auth(args.username, args.password, nodelist)
+    cluster_create(args.cluster, nodelist, put_standby=args.standby)
+
+if __name__ == "__main__":
+    _main()

--- a/ha/setup/create_cluster.py
+++ b/ha/setup/create_cluster.py
@@ -52,7 +52,7 @@ def cluster_auth(username, password, nodelist):
     try:
         SimpleCommand().run_cmd(cmd_auth)
     except Exception:
-        raise ClusterAuthError("Failed to authorize the node")
+        raise ClusterAuthError(f"Failed to authorize the nodes: {nodes}")
 
 
 def cluster_create(cluster_name, nodelist, enable=True, put_standby=True):

--- a/ha/setup/create_cluster.py
+++ b/ha/setup/create_cluster.py
@@ -21,19 +21,29 @@ from cortx.utils.log import Log
 
 
 class ClusterCreateError(Exception):
-    """Exception to indicate that cluster can't be created due to some error."""
+    """
+    Exception to indicate that cluster can't be created due to some error.
+    """
+    pass
 
 
 class ClusterAuthError(ClusterCreateError):
-    """Exception to indicate that authorization procedure failed."""
+    """
+    Exception to indicate that authorization procedure failed.
+    """
+    pass
 
 
 class ClusterSetupError(ClusterCreateError):
-    """Exception to indicate that cluster setup procedure failed."""
+    """
+    Exception to indicate that cluster setup procedure failed.
+    """
+    pass
 
 
 def cluster_auth(username, password, nodelist):
-    """Authorize cluster nodes.
+    """
+    Authorize cluster nodes.
 
     Parameters:
             username - just a user name to make cluster authorization
@@ -56,7 +66,8 @@ def cluster_auth(username, password, nodelist):
 
 
 def cluster_create(cluster_name, nodelist, enable=True, put_standby=True):
-    """Create cluster on given nodes. Enables and starts cluster if needed.
+    """
+    Create cluster on given nodes. Enables and starts cluster if needed.
 
     Parameters:
         cluster_name    - name of the cluster to be created

--- a/ha/setup/create_cluster.py
+++ b/ha/setup/create_cluster.py
@@ -19,21 +19,21 @@ import argparse
 from ha.execute import SimpleCommand
 from cortx.utils.log import Log
 
-class ClusterCreateError(Exception):
 
+class ClusterCreateError(Exception):
     """Exception to indicate that cluster can't be created due to some error."""
 
-class ClusterAuthError(ClusterCreateError):
 
+class ClusterAuthError(ClusterCreateError):
     """Exception to indicate that authorization procedure failed."""
 
-class ClusterSetupError(ClusterCreateError):
 
+class ClusterSetupError(ClusterCreateError):
     """Exception to indicate that cluster setup procedure failed."""
 
 
 def cluster_auth(username, password, nodelist):
-    """Authorizes cluster nodes.
+    """Authorize cluster nodes.
 
     Parameters:
             username - just a user name to make cluster authorization
@@ -56,7 +56,7 @@ def cluster_auth(username, password, nodelist):
 
 
 def cluster_create(cluster_name, nodelist, enable=True, put_standby=True):
-    """Creates cluster on given nodes. Enables and starts cluster if needed.
+    """Create cluster on given nodes. Enables and starts cluster if needed.
 
     Parameters:
         cluster_name    - name of the cluster to be created
@@ -77,7 +77,7 @@ def cluster_create(cluster_name, nodelist, enable=True, put_standby=True):
     cmd_stonith = "pcs property set stonith-enabled=False"
     cmd_enable = f"pcs cluster enable {nodes}"
 
-    cmdlist = [ cmd_setup ]
+    cmdlist = [cmd_setup]
     if enable:
         cmdlist.append(cmd_enable)
     if put_standby:
@@ -89,10 +89,13 @@ def cluster_create(cluster_name, nodelist, enable=True, put_standby=True):
     except Exception:
         raise ClusterSetupError("Failed to setup the cluster")
 
+
 def _parse_input_args():
-    """Parse and validate input arguments passed by mini-provisioner or CLI.
-    
-    Returns dictonary with context."""
+    """
+    Parse and validate input arguments passed by mini-provisioner or CLI.
+
+    Returns dictonary with context.
+    """
     parser = argparse.ArgumentParser(description="Creates pacemaker cluster")
     parser.add_argument("--cluster", default="cortx-lr2", type=str, help="Cluster name")
     parser.add_argument("--username", required=True, type=str, help="User to be used for cluster auth")
@@ -104,11 +107,13 @@ def _parse_input_args():
     group.add_argument("--nodefile", required=False, type=str, help="File with list of nodes")
     return parser.parse_args()
 
+
 def _read_file_list(filename):
     nodelist = []
     with open(filename, "r") as f:
         nodelist = f.read().splitlines()
     return nodelist
+
 
 def _main():
     # Workaround to make SimpleCommand work, not crash
@@ -121,6 +126,7 @@ def _main():
         raise ValueError("node list shall not be empty")
     cluster_auth(args.username, args.password, nodelist)
     cluster_create(args.cluster, nodelist, put_standby=args.standby)
+
 
 if __name__ == "__main__":
     _main()

--- a/ha/setup/create_pacemaker_resources.py
+++ b/ha/setup/create_pacemaker_resources.py
@@ -1,0 +1,269 @@
+#!/bin/python3
+
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+import argparse
+from ha.execute import SimpleCommand
+from cortx.utils.log import Log
+
+class CreateResourceError(Exception):
+
+    """Exception to indicate any failure happened during resource creation."""
+
+class CreateResourceConfigError(CreateResourceError):
+
+    """Exception to indicate that given resource configuration is incorrect or
+    incomplete.""" 
+
+def cib_push(cib_xml):
+    """Shortcut to avoid boilerplate pushing CIB file."""
+    cmd_push = f"pcs cluster cib-push {cib_xml} --config"
+    SimpleCommand().run_cmd(cmd_push)
+
+
+def cib_get(cib_xml):
+    """Generate CIB file using pcs."""
+    cmd= f"pcs cluster cib {cib_xml}"
+    SimpleCommand().run_cmd(cmd)
+
+    return cib_xml
+
+
+def motr_hax(cib_xml, push=False):
+    """Create resources that belong to motr group and clone the group."""
+    cmd_hax = f"pcs -f {cib_xml} resource create hax systemd:hare-hax --group io_group"
+    cmd_confd = f"pcs -f {cib_xml} resource create motr-confd ocf:seagate:dynamic_fid_service_ra service=m0d fid_service_name=confd --group io_group"
+    cmd_ios = f"pcs -f {cib_xml} resource create motr-ios ocf:seagate:dynamic_fid_service_ra service=m0d fid_service_name=ios --group io_group"
+
+    for s in (cmd_hax, cmd_confd, cmd_ios):
+        SimpleCommand().run_cmd(s)
+
+    if push:
+        cib_push(cib_xml)
+
+
+def free_space_monitor(cib_xml, push=False):
+    """Create free space monitor resource. 1 per cluster, no affinity."""
+    cmd_fsm = f"pcs -f {cib_xml} resource create motr-free-space-mon systemd:motr-free-space-monitor op monitor interval=30s meta failure-timeout=300s"
+    SimpleCommand().run_cmd(cmd_fsm)
+
+    constraints = [
+            f"pcs -f {cib_xml} constraint order motr-ios then motr-free-space-mon",
+            f"pcs -f {cib_xml} constraint colocation add motr-free-space-mon with motr-ios"
+            ]
+    for c in constraints:
+        SimpleCommand().run_cmd(c)
+
+    if push:
+        cib_push(cib_xml)
+
+
+def s3servers(cib_xml, push=False):
+    """Create resources that belong to s3server group and clone the group.
+
+    S3 background consumer is ordered after s3server and co-located with it."""
+    for i in range(1, 12):
+        cmd_s3server = f"pcs -f {cib_xml} resource create s3server-{i} ocf:seagate:dynamic_fid_service_ra service=s3server fid_service_name=s3service --group io_group"
+        SimpleCommand().run_cmd(cmd_s3server)
+
+    cmd_s3bc = f"pcs -f {cib_xml} resource create s3backcons systemd:s3backgroundconsumer meta failure-timeout=300s --group io_group"
+    SimpleCommand().run_cmd(cmd_s3bc)
+
+    if push:
+        cib_push(cib_xml)
+
+
+def s3bp(cib_xml, push=False):
+    """Create S3 background producer
+
+    S3 background producer have to be only 1 per cluster and co-located with
+    s3server."""
+    cmd_s3bp = f"pcs -f {cib_xml} resource create s3backprod systemd:s3backgroundproducer op monitor interval=30s"
+    cmd_order = f"pcs -f {cib_xml} constraint order io_group-clone then s3backprod"
+
+    for s in (cmd_s3bp, cmd_order):
+        SimpleCommand().run_cmd(s)
+
+    if push:
+        cib_push(cib_xml)
+
+
+def s3auth(cib_xml, push=False):
+    """Create haproxy S3 auth server resource in pacemaker."""
+    cmd_s3auth = f"pcs -f {cib_xml} resource create s3auth systemd:s3authserver clone op monitor interval=30"
+    SimpleCommand().run_cmd(cmd_s3auth)
+
+    if push:
+        cib_push(cib_xml)
+
+
+def haproxy(cib_xml, push=False):
+    """Create haproxy clone resource in pacemaker."""
+    cmd_haproxy = f"pcs -f {cib_xml} resource create haproxy systemd:haproxy clone op monitor interval=30 --group io_group"
+    SimpleCommand().run_cmd(cmd_haproxy)
+
+    if push:
+        cib_push(cib_xml)
+
+
+def sspl(cib_xml, push=False):
+    """Create sspl clone resource in pacemaker."""
+    # Using sspl-ll service file according to the content of SSPL repo
+    cmd_sspl = f"pcs -f {cib_xml} resource create sspl-ll systemd:sspl-ll clone op monitor interval=30 --group monitor"
+    SimpleCommand().run_cmd(cmd_sspl)
+
+    if push:
+        cib_push(cib_xml)
+
+
+def io_stack(cib_xml, push=False):
+    """Wrapper to create IO stack related resources."""
+    resources = [ motr_hax, s3auth, haproxy, s3servers, s3bp]
+    for rcs in resources:
+        rcs(cib_xml, push)
+
+    cmd_clone_group = f"pcs -f {cib_xml} resource clone io_group"
+    SimpleCommand().run_cmd(cmd_clone_group)
+
+    if push:
+        cib_push(cib_xml)
+
+def mgmt_vip(cib_xml, vip, iface, cidr=24, push=False):
+    """Creates mgmt Virtual IP resource."""
+    cmd = f"pcs -f {cib_xml} resource create mgmt-vip ocf:heartbeat:IPaddr2 \
+ip={vip} cidr_netmask={cidr} nic={iface} iflabel=v1 \
+op start   interval=0s timeout=60s \
+op monitor interval=5s timeout=20s \
+op stop    interval=0s timeout=60s"
+    SimpleCommand().run_cmd(cmd)
+
+    if push:
+        cib_push(cib_xml)
+
+def mgmt_resources(cib_xml, push=False):
+    """Creates mandatory resources for mgmt stack."""
+    kibana = f"pcs -f {cib_xml} resource create kibana systemd:kibana op monitor interval=30s"
+    agent = f"pcs -f {cib_xml} resource create csm-agent systemd:csm_agent op monitor interval=30s"
+    web = f"pcs -f {cib_xml} resource create csm-web systemd:csm_web op monitor interval=30s"
+
+    for c in (kibana, agent, web):
+        SimpleCommand().run_cmd(c)
+
+    if push:
+        cib_push(cib_xml)
+
+def uds(cib_xml, push=False):
+    """Create uds resource and constraints."""
+    cmd_uds = f"pcs -f {cib_xml} resource create uds systemd:uds op monitor interval=30s"
+    SimpleCommand().run_cmd(cmd_uds)
+    constraints = [
+            f"pcs -f {cib_xml} constraint colocation add uds with csm-agent score=INFINITY",
+            # According to EOS-9258, there is a bug which requires UDS to be started after csm_agent
+            f"pcs -f {cib_xml} constraint order csm-agent then uds"
+            ]
+    for c in constraints:
+        SimpleCommand().run_cmd(c)
+    if push:
+        cib_push(cib_xml)
+
+
+def mgmt_stack(cib_xml, mgmt_vip_cfg, with_uds=False, push=False):
+    """Wrapper to create Mgmt stack related resources.
+
+    It also creates and defines management group to support colocation and
+    ordering requirements."""
+    mgmt_resources(cib_xml)
+
+    if with_uds:
+        uds(cib_xml)
+
+    cmd = f"pcs -f {cib_xml} resource group add management kibana csm-agent csm-web"
+    SimpleCommand().run_cmd(cmd)
+
+    if mgmt_vip_cfg:
+        mgmt_vip(cib_xml, **mgmt_vip_cfg, push=False)
+        cmd_group = f"pcs -f {cib_xml} resource group add management kibana --before csm-agent"
+        SimpleCommand().run_cmd(cmd_group)
+
+    if push:
+        cib_push(cib_xml)
+
+
+def create_all_resources(cib_xml = "/var/log/seagate/cortx/ha/cortx-lr2-cib.xml", 
+                         push = True, **kwargs):
+    """Wrapper to populate the cluster.
+
+    Parameters:
+        cib_xml - file where CIB XML shall be stored (optional)
+        push - whether changes shall be actually applied (optional)
+        vip - mgmt virtual ip (example: 10.0.0.6)
+        cidr - netmask for mgmt vip (example: 24)
+        iface - interface to configure mgmt vip (example: eno1)
+
+        vip, cidr, iface options are validated to be passed together.
+
+    Returns: None
+
+    Exceptions:
+        CreateResourceError: failed to create any resourse.
+        CreateResourceConfigError: exception is generated if set of argument is
+        not empty but incomplete.
+    """
+    mgmt_vip_cfg = { k: kwargs[k] for k in ("vip", "cidr", "iface")
+                       if k in kwargs and kwargs[k] is not None }
+    if len(mgmt_vip_cfg) not in (0, 3):
+        raise CreateResourceConfigError("Given mgmt VIP configuration is incomplete")
+
+    with_uds = kwargs["uds"] if "uds" in kwargs else False
+
+    try:
+        cib_get(cib_xml)
+        io_stack(cib_xml)
+        sspl(cib_xml)
+        mgmt_stack(cib_xml, mgmt_vip_cfg, with_uds)
+        if push:
+            cib_push(cib_xml)
+    except Exception:
+        raise CreateResourceError("Failed to populare cluster with resources")
+
+def _parse_input_args():
+    """Parse and validate input arguments passed by mini-provisioner or CLI."""
+    parser = argparse.ArgumentParser(
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            description="Create resources for Cortx cluster")
+    parser.add_argument("--dry-run", action="store_true", help="Generate CIB XML but don't push")
+    parser.add_argument("--with-uds", action="store_true", default=False, help="Also create UDS resource")
+    parser.add_argument("--cib-xml", type=str, default="/var/log/seagate/cortx/ha/cortx-lr2-cib.xml", help="File name to store generated CIB")
+    group = parser.add_argument_group("Management", "Parameters to setup virtual IP if needed")
+    group.add_argument("--vip", type=str, nargs="?", help="Virtual mgmt IP address")
+    group.add_argument("--cidr", type=int, nargs="?", help="Netmask for mgmt VIP. Ex.: 24")
+    group.add_argument("--iface", type=str, nargs="?", help="Network interface for mgmt VIP")
+    return parser.parse_args()
+
+
+def _main():
+    # Workaround to make SimpleCommand work, not crash
+    Log.init(service_name="create_pacemaker_resources",
+             log_path="/var/log/seagate/cortx/ha", level="INFO")
+
+    args = _parse_input_args()
+
+    create_all_resources(args.cib_xml, vip=args.vip, cidr=args.cidr,
+                         iface=args.iface, push = not args.dry_run,
+                         uds=args.with_uds)
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
https://jts.seagate.com/browse/EOS-16480
DoD:
We should have a shell script configuring rules for all Cortx services in pacemaker.
Upon executing the script and given that required 3rd party services are up, the Cortx cluster and all resources shall be created.
Stonith is disabled.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
No
  </code>
</pre>
## Problem Description
<pre>
  <code>
Scripts are supposed to be executed by HA mini provisioner during config phase.
  </code>
</pre>
## Solution
<pre>
  <code>
2 python scripts implemented:
* to create cluster
* to populate cluster with resources
They are ready to be imported to HA mini provisioner python code. Scripts also can be used as standalone CLI tools.
Dependent from ha/execute module to run pcs commands.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
No. Scripts can be fully tested only in integration environment.
  </code>
</pre>
