### PR TITLE
EOS-16878: SSPL resource agent improvements

### DIFF
--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -144,10 +144,8 @@ stateful_start() {
         start_sspl_service
         if [ $? == 0 ]; then
             return $OCF_RUNNING_MASTER
-        elif [ $? == 1 ]; then
-            return $OCF_FAILED_MASTER
         else
-            return $OCF_ERR_GENERIC
+            return $OCF_FAILED_MASTER
         fi
     fi
     stateful_update "slave"

--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -27,7 +27,7 @@
 #	SSPL OCF Stateful master/slave RA.
 
 # Return codes and its menaning
-# 0: OCF_SUCESS: Successful Execution
+# 0: OCF_SUCCESS: Successful Execution
 # 9: OCF_MASTER_FAILED: Resource is failed in Master mode
 # 7: OCF_NOT_RUNNING: Resource is safely stopped.
 
@@ -121,6 +121,10 @@ stateful_start() {
         # CRM Error - Should never happen
         log "START (master)..."
         systemctl start sspl-ll
+        while ! systemctl is-active sspl-ll | grep "active"
+        do
+            sleep 1
+        done
         log "START (master): $?"
         return $OCF_RUNNING_MASTER
     fi
@@ -128,6 +132,10 @@ stateful_start() {
     "${HA_SBIN_DIR}/crm_master" -l reboot -v 1
     log "START... (crm_reboot: $?)"
     systemctl start sspl-ll
+    while ! systemctl is-active sspl-ll | grep "active"
+    do
+        sleep 1
+    done
     log "START: $?"
 
     return $OCF_SUCCESS
@@ -177,7 +185,8 @@ stateful_stop() {
     log "STOP..."
     systemctl stop sspl-ll
     log "STOP: $?"
-    return $OCF_SUCESS
+    rm -rf "${OCF_RESKEY_state}"
+    return $OCF_SUCCESS
 }
 
 stateful_monitor() {

--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -115,30 +115,45 @@ stateful_check_state() {
     return 7
 }
 
+start_sspl_service() {
+        systemctl start sspl-ll
+        echo "START (master): $?"
+        while true
+        do
+            status=`systemctl is-active sspl-ll`
+            if [[ $status == "active" ]]; then
+                return 0
+            elif [[ $status == "failed" ]]; then
+                return 1
+            else
+                sleep 1
+            fi
+        done
+}
+
 stateful_start() {
     stateful_check_state "master"
     if [ $? -eq 0 ]; then
         # CRM Error - Should never happen
         log "START (master)..."
-        systemctl start sspl-ll
-        while ! systemctl is-active sspl-ll | grep "active"
-        do
-            sleep 1
-        done
-        log "START (master): $?"
-        return $OCF_RUNNING_MASTER
+        start_sspl_service
+        if [ $? == 0 ]; then
+            return $OCF_RUNNING_MASTER
+        elif [ $? == 1 ]; then
+            return $OCF_FAILED_MASTER
+        else
+            return $OCF_ERR_GENERIC
+        fi
     fi
     stateful_update "slave"
     "${HA_SBIN_DIR}/crm_master" -l reboot -v 1
     log "START... (crm_reboot: $?)"
-    systemctl start sspl-ll
-    while ! systemctl is-active sspl-ll | grep "active"
-    do
-        sleep 1
-    done
-    log "START: $?"
-
-    return $OCF_SUCCESS
+    start_sspl_service
+    if [ $? == 0 ]; then
+        return $OCF_SUCCESS
+    else
+        return $OCF_ERR_GENERIC
+    fi
 }
 
 stateful_demote() {

--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -118,6 +118,7 @@ stateful_check_state() {
 start_sspl_service() {
         systemctl start sspl-ll
         echo "START (master): $?"
+        count=0
         while true
         do
             status=`systemctl is-active sspl-ll`
@@ -125,9 +126,13 @@ start_sspl_service() {
                 return 0
             elif [[ $status == "failed" ]]; then
                 return 1
-            else
-                sleep 1
+            elif [[ $status == "unknown" ]]; then
+                ((count++))
+                if [ $count == 5 ]; then
+                    return 1
+                fi
             fi
+            sleep 1
         done
 }
 


### PR DESCRIPTION
Signed-off-by: Vijay Thakkar <vijaykumar.thakkar@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-16878: HA (pcs) did not detect that SSPL had crashed and did not restart it
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Observed that demoted node is taking too much time after the forcefully kill.
  </code>
</pre>
## Solution
<pre>
  <code>
    Added code changes to remove state file in the stop method and also added couple of improvement
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Tested changes in the live setup and observed that sspl service starts immediately after the demotion.
  </code>
</pre>
