### PR TITLE
EOS-16878: Modify sspl start service function for more code readability

### DIFF
--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -118,22 +118,25 @@ stateful_check_state() {
 start_sspl_service() {
         systemctl start sspl-ll
         echo "START (master): $?"
-        count=0
-        while true
-        do
-            status=`systemctl is-active sspl-ll`
-            if [[ $status == "active" ]]; then
-                return 0
-            elif [[ $status == "failed" ]]; then
-                return 1
-            elif [[ $status == "unknown" ]]; then
-                ((count++))
-                if [ $count == 5 ]; then
+
+        #check status
+        for retry in {1..5}; do
+            status=$(systemctl is-active sspl-ll)
+            case $status in
+                active )
+                    return 0
+                    ;;
+
+                failed )
                     return 1
-                fi
-            fi
+                    ;;
+
+                * )
+                    ;;
+            esac
             sleep 1
         done
+        return 1
 }
 
 stateful_start() {
@@ -141,22 +144,14 @@ stateful_start() {
     if [ $? -eq 0 ]; then
         # CRM Error - Should never happen
         log "START (master)..."
-        start_sspl_service
-        if [ $? == 0 ]; then
-            return $OCF_RUNNING_MASTER
-        else
-            return $OCF_FAILED_MASTER
-        fi
+        start_sspl_service && return $OCF_RUNNING_MASTER
+        return $OCF_FAILED_MASTER
     fi
     stateful_update "slave"
     "${HA_SBIN_DIR}/crm_master" -l reboot -v 1
     log "START... (crm_reboot: $?)"
-    start_sspl_service
-    if [ $? == 0 ]; then
-        return $OCF_SUCCESS
-    else
-        return $OCF_ERR_GENERIC
-    fi
+    start_sspl_service && return $OCF_SUCCESS
+    return $OCF_ERR_GENERIC
 }
 
 stateful_demote() {

--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -130,9 +130,6 @@ start_sspl_service() {
                 failed )
                     return 1
                     ;;
-
-                * )
-                    ;;
             esac
             sleep 1
         done


### PR DESCRIPTION
Signed-off-by: Vijay Thakkar <vijaykumar.thakkar@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-16878: HA (pcs) did not detect that SSPL had crashed and did not restart it
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Modify start_sspl_service() function for more code readability
  </code>
</pre>
## Solution
<pre>
  <code>
    Modified start_sspl_service() function to address review comments
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Valiadated changes on the hardware setup and it's working as expected
  </code>
</pre>
