### PR TITLE
EOS-16878: SSPL resource agent improvements

### DIFF
--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -130,9 +130,6 @@ start_sspl_service() {
                 failed )
                     return 1
                     ;;
-
-                * )
-                    ;;
             esac
             sleep 1
         done

--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -27,7 +27,7 @@
 #	SSPL OCF Stateful master/slave RA.
 
 # Return codes and its menaning
-# 0: OCF_SUCESS: Successful Execution
+# 0: OCF_SUCCESS: Successful Execution
 # 9: OCF_MASTER_FAILED: Resource is failed in Master mode
 # 7: OCF_NOT_RUNNING: Resource is safely stopped.
 
@@ -115,22 +115,43 @@ stateful_check_state() {
     return 7
 }
 
+start_sspl_service() {
+        systemctl start sspl-ll
+        echo "START (master): $?"
+
+        #check status
+        for retry in {1..5}; do
+            status=$(systemctl is-active sspl-ll)
+            case $status in
+                active )
+                    return 0
+                    ;;
+
+                failed )
+                    return 1
+                    ;;
+
+                * )
+                    ;;
+            esac
+            sleep 1
+        done
+        return 1
+}
+
 stateful_start() {
     stateful_check_state "master"
     if [ $? -eq 0 ]; then
         # CRM Error - Should never happen
         log "START (master)..."
-        systemctl start sspl-ll
-        log "START (master): $?"
-        return $OCF_RUNNING_MASTER
+        start_sspl_service && return $OCF_RUNNING_MASTER
+        return $OCF_FAILED_MASTER
     fi
     stateful_update "slave"
     "${HA_SBIN_DIR}/crm_master" -l reboot -v 1
     log "START... (crm_reboot: $?)"
-    systemctl start sspl-ll
-    log "START: $?"
-
-    return $OCF_SUCCESS
+    start_sspl_service && return $OCF_SUCCESS
+    return $OCF_ERR_GENERIC
 }
 
 stateful_demote() {
@@ -177,7 +198,8 @@ stateful_stop() {
     log "STOP..."
     systemctl stop sspl-ll
     log "STOP: $?"
-    return $OCF_SUCESS
+    rm -rf "${OCF_RESKEY_state}"
+    return $OCF_SUCCESS
 }
 
 stateful_monitor() {


### PR DESCRIPTION
Signed-off-by: Vijay Thakkar <vijaykumar.thakkar@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-16878: HA (pcs) did not detect that SSPL had crashed and did not restart it
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
   Observed that demoted node is taking too much time after the forcefully kill.
  </code>
</pre>
## Solution
<pre>
  <code>
    Added code changes to remove state file in the stop method and also added couple of improvement
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Tested changes on the hardware setup and observed that sspl service starts immediately after the demotion.
  </code>
</pre>
