### PR TITLE
EOS-17229: First patch to do force create

### DIFF
--- a/ha/setup/create_pacemaker_resources.py
+++ b/ha/setup/create_pacemaker_resources.py
@@ -45,8 +45,8 @@ def cib_get(cib_xml):
 def motr_hax(cib_xml, push=False):
     """Create resources that belong to motr group and clone the group."""
     cmd_hax = f"pcs -f {cib_xml} resource create hax systemd:hare-hax --group io_group"
-    cmd_confd = f"pcs -f {cib_xml} resource create motr-confd-1 ocf:seagate:dynamic_fid_service_ra service=m0d fid_service_name=confd --group io_group"
-    cmd_ios = f"pcs -f {cib_xml} resource create motr-ios-1 ocf:seagate:dynamic_fid_service_ra service=m0d fid_service_name=ios --group io_group"
+    cmd_confd = f"pcs -f {cib_xml} resource create motr-confd-1 ocf:seagate:dynamic_fid_service_ra service=m0d fid_service_name=confd --group io_group --force"
+    cmd_ios = f"pcs -f {cib_xml} resource create motr-ios-1 ocf:seagate:dynamic_fid_service_ra service=m0d fid_service_name=ios --group io_group --force"
 
     for s in (cmd_hax, cmd_confd, cmd_ios):
         SimpleCommand().run_cmd(s)
@@ -77,7 +77,7 @@ def s3servers(cib_xml, push=False):
     S3 background consumer is ordered after s3server and co-located with it.
     """
     for i in range(1, 12):
-        cmd_s3server = f"pcs -f {cib_xml} resource create s3server-{i} ocf:seagate:dynamic_fid_service_ra service=s3server fid_service_name=s3service --group io_group"
+        cmd_s3server = f"pcs -f {cib_xml} resource create s3server-{i} ocf:seagate:dynamic_fid_service_ra service=s3server fid_service_name=s3service --group io_group --force"
         SimpleCommand().run_cmd(cmd_s3server)
 
     cmd_s3bc = f"pcs -f {cib_xml} resource create s3backcons systemd:s3backgroundconsumer meta failure-timeout=300s --group io_group"


### PR DESCRIPTION
Signed-off-by: Ajay Paratmandali <ajay.paratmandali@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    Your Problem statement here...
EOS-17229
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Your Problem decription here...
meta-data query failing.
  </code>
</pre>
## Solution
<pre>
  <code>
    Your Problem solution here...
Found command given in description of ticket is typo

pcs resource create motr-confd-1 ocf:seagate:dynamic_fid_servce_ra service=m0d fid_service_name=confd --group io_group

it is ocf:seagate:dynamic_fid_service_ra

But still problem exist and tried --force
Seen --force is working and resource started with no error even in logs
Crating first patch with --force to unblock and mode debug can be done later
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
No unit testing provided
  </code>
</pre>
