### PR TITLE
Changes for EOS-17336 Change the cortxha keyword in HA CLIs to cortx

### DIFF
--- a/ha/cli/cortxha.py
+++ b/ha/cli/cortxha.py
@@ -62,10 +62,17 @@ class HACli:
 
     @staticmethod
     def _usage():
-        return """
+
+        if ha_cli._version == const.CORTX_VERSION_1:
+            return """
     Use below command for more detail
     cortxha --help
-    """
+            """
+        else:
+            return """
+    Use below command for more detail
+    cortx --help
+            """
 
     def command(self):
         try:

--- a/jenkins/rpm/v2/cortx-ha.spec
+++ b/jenkins/rpm/v2/cortx-ha.spec
@@ -43,8 +43,8 @@ RES_AGENT="/usr/lib/ocf/resource.d/seagate"
 mkdir -p $HA_DIR/bin /usr/bin $RES_AGENT
 
 # Move binary file
-ln -sf $HA_DIR/lib/cortxha $HA_DIR/bin/cortxha
-ln -sf $HA_DIR/lib/cortxha /usr/bin/cortxha
+ln -sf $HA_DIR/lib/cortxha $HA_DIR/bin/cortx
+ln -sf $HA_DIR/lib/cortxha /usr/bin/cortx
 ln -sf $HA_DIR/lib/dynamic_fid_service_ra $HA_DIR/bin/dynamic_fid_service_ra
 # TODO: dynamic_fid_service_ra to RESOURCE_AGENT path from setup post_install
 ln -sf $HA_DIR/lib/dynamic_fid_service_ra $RES_AGENT/dynamic_fid_service_ra
@@ -59,8 +59,8 @@ exit 0
 %postun
 [ $1 -eq 1 ] && exit 0
 HA_DIR=<HA_PATH>/ha
-rm -f /usr/bin/cortxha 2> /dev/null;
-rm -f $HA_DIR/bin/cortxha 2> /dev/null;
+rm -f /usr/bin/cortx 2> /dev/null;
+rm -f $HA_DIR/bin/cortx 2> /dev/null;
 rm -f $RES_AGENT/dynamic_fid_service_ra 2> /dev/null;
 rm -f $HA_DIR/bin/dynamic_fid_service_ra 2> /dev/null;
 rm -f /usr/local/bin/ha_setup 2> /dev/null;


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    The cortx HA clis start with the keyword "cortxha".
    This needs to be changed to "cortx"
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    The cortx HA clis start with the keyword "cortxha".
    This needs to be changed to "cortx"
  </code>
</pre>
## Solution
<pre>
  <code>
   Renamed the executable file  for the CLI from crotxha to cortx for V2
   Modified the help string 
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    - Verified that for V2, the CLI is displayed as "cortx" . Ex "cortx cluster start" 
    -  Verified that the help string also displays "cortx" instead of "cortxha"
    -  Verified that for V1, the CLI is displayed as cortxha . Ex cortxha cluster start 
    -  Verified that the help string also displays "cortxha " for V1 
    - Confirmed that the correct CLI functionality is executed based on version (V1 or V2) 
        i.e. there is no change in the behavior of the CLI due to the name change 
   
  </code>
</pre>
