### PR TITLE
EOS-17151: remove cryptography python dependency for LR-2 cortx-ha

### DIFF
--- a/jenkins/pyinstaller/v2/requirements.txt
+++ b/jenkins/pyinstaller/v2/requirements.txt
@@ -24,5 +24,4 @@ requests==2.22.0
 pathlib==1.0.1
 statsd==3.2.2
 urllib3==1.25.7
-cryptography==2.8
 pytest==5.4.2


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
 Story Ref (if any): https://jts.seagate.com/browse/EOS-17151
Remove cryptography python dependency for LR-2 cortx-ha
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
ha_setup can be successfully imported when cortx-utils package is installed.
  </code>
</pre>
## Problem Description
<pre>
  <code>
Package is not used directly. Instead cortx-utils module is used. No need to have it cortx-ha requirements.txt
  </code>
</pre>
## Solution
<pre>
  <code>
Remove dependency in LR-2 requirements.txt
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
N/A
  </code>
</pre>
