### PR TITLE
Fix CI scripts and quick start guide

### DIFF
--- a/Quick-Start-Guide.rst
+++ b/Quick-Start-Guide.rst
@@ -171,11 +171,9 @@ To build the source code, perform the following:
 
 1. Install the pip packages by running the following commands:
 
- - **$ bash jenkins/cicd/cortx-ha-dep.sh dev <github-token>**
+ - **$ bash jenkins/cicd/cortx-ha-dep.sh -e dev -t <github-token>**
 
   - Refer `GitHub Token <https://github.com/Seagate/cortx/blob/main/doc/ContributingToCortxHA.md#token-personal-access-for-command-line-required-for-submodule-clone-process>`_ to know the process that must be followed to create a GitHub token.
-
- - **$ python3 -m pip install -r jenkins/pyinstaller/requirements.txt**
 
 2. Build the RPMs by navigating to the directory where the HA component has been cloned, and running one of the following commands:
 

--- a/jenkins/cicd/cortx-ha-dep.sh
+++ b/jenkins/cicd/cortx-ha-dep.sh
@@ -15,6 +15,7 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
+set -e -o pipefail
 
 BASE_DIR=$(realpath "$(dirname $0)/../../")
 HA1="1"
@@ -29,10 +30,10 @@ For Production
 """
 }
 
-while getopts ":h:v:e:t" o; do
+while getopts ":h:v:e:t:" o; do
     case "${o}" in
         h)
-            usage
+            usage ; exit 0
             ;;
         v)
             VERSION=${OPTARG}
@@ -44,7 +45,7 @@ while getopts ":h:v:e:t" o; do
             TOKEN=${OPTARG}
             ;;
         *)
-            usage
+            usage ; exit 1
             ;;
     esac
 done


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
Story Ref (if any): n/a
Fix for CI script and quick start guide
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
No
cortx-ha-dep.sh script for development invocation on my VM. There is always a small chance that CI will get broken as a result of these updates.
  </code>
</pre>
## Problem Description
<pre>
  <code>
Dev installation described in quick start guide simply does not work because cortx-ha-dep.sh scripts contains mistakes.
  </code>
</pre>
## Solution
<pre>
  <code>
Fixed argument parsing and modified program flow for usage cases.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
Just run: `sudo jenkins/cicd/cortx-ha-dep.sh -e dev -t <your-github-token>`
It shall work now.
`sudo` is needed due to cortx-utils.
  </code>
</pre>
