### PR TITLE
EOS-18359: add setup py for development installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from distutils.core import setup
+
+setup(name='ha',
+      version='2.0.0',
+      description='High Availability for Cortx cluster',
+      url='https://github.com/Seagate/cortx-ha',
+      packages=[
+          'ha',
+          'ha/cli',
+          'ha/core',
+          'ha/plugin/hare',
+          'ha/setup',
+          'ha/resource'
+          ],
+      )


### PR DESCRIPTION
The presence of setup.py file allows to create a development
installation.

Use `pip3 instal -e ./` command to install cortx-ha to active venv.
Use `pip3 uninstall ha` to remove it.

`python3 setup.py bdist{,_rpm}` shall also work, though they are not an
official way to build cortx-ha package.

## Problem Statement
<pre>
  <code>
  Story Ref: https://jts.seagate.com/browse/EOS-18359
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
Pyinstaller is used to bundle cortx-ha.
Due to this fact, option with development installation is missing.
It is useful and sometimes crucial for testing.
  </code>
</pre>
## Solution
<pre>
  <code>
Add setup.py with distutils invocations to make command pip install -e ./ available
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
Done on VM. Not used on production environment.
  </code>
</pre>
