### PR TITLE
Add initial Python code guidelines

### DIFF
--- a/doc/python-guidelines.md
+++ b/doc/python-guidelines.md
@@ -1,0 +1,7 @@
+# Python Guidelines
+
+Few of them:
+
+* Use type annotations from `typing` module and `mypy` for static verification
+* In case of uncertainty regarding style and approach use Google Python style-guide: https://google.github.io/styleguide/pyguide.html
+

--- a/doc/python-guidelines.md
+++ b/doc/python-guidelines.md
@@ -3,5 +3,5 @@
 Few of them:
 
 * Use type annotations from `typing` module and `mypy` for static verification
+* Deliver PEP8 formatted code. Use linters to check and auto-format tools to fix.
 * In case of uncertainty regarding style and approach use Google Python style-guide: https://google.github.io/styleguide/pyguide.html
-


### PR DESCRIPTION
In order to address action items from retrospective meeting, the initial version of code guidelines document was created.
Suggested to add missing items or suggest exceptions for google python guidelines.

-----
[View rendered doc/python-guidelines.md](https://github.com/azheregelya/cortx-ha/blob/code-guidelines/doc/python-guidelines.md)