### PR TITLE
EOS-16248 User interface for cluster start CLI

### DIFF
--- a/ha/cli/command_factory.py
+++ b/ha/cli/command_factory.py
@@ -21,6 +21,7 @@ from cortx.utils.log import Log
 from ha.cli import commands
 from ha.core.config.config_manager import ConfigManager
 
+
 class CmdFactory:
     def __init__(self):
         """

--- a/ha/cli/commands.py
+++ b/ha/cli/commands.py
@@ -21,6 +21,7 @@ from ha.cli.command_factory import CmdFactory
 from ha.cli.exec.commandExecutor import CLIUsage
 from ha.cli.exec.commandExecutor import CommandExecutor as cmdExecutor
 
+
 class Command:
     """  Parse the CLI and call appropriate executor """
     def __init__(self):
@@ -28,7 +29,6 @@ class Command:
         self.operation_name = None
         self.options = None
         self.cmd_factory = CmdFactory()
-
 
     def parse(self, args: list):
         """ Parse the CLI string to identify parameters"""
@@ -71,12 +71,12 @@ class Command:
                 print(CLIUsage.usage())
                 raise HAInvalidCommand("Invalid parameters passed; refer to help for details")
 
-
             exec_class = self.get_class(command_executor)
             # Call execute function of the appropriate executor class
             executor_class = exec_class()
             if executor_class.validate():
                 executor_class.execute()
+
 
 """
 SupportBundleCommand is currently broken, so removed the code.

--- a/ha/cli/exec/commandExecutor.py
+++ b/ha/cli/exec/commandExecutor.py
@@ -24,10 +24,15 @@ import os
 from ha import const
 from cortx.utils.log import Log
 from ha.core.error import HAInvalidPermission, HAClusterCLIError, HAUnimplemented
+from ha.core.cluster.cluster_manager import CortxClusterManager
+from ha.cli.displayOutput import Output
+
 
 class CommandExecutor:
     def __init__(self):
         self._is_hauser = False
+        self._cluster_manager = CortxClusterManager()
+        self._op = Output()
 
     def validate(self) -> bool:
         raise HAUnimplemented("This operation is not implemented.")


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-16248 User interface for cluster start CLI
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Implement user interface for cluster start CLI
  </code>
</pre>
## Solution
<pre>
  <code>
    - Code implementation in cluster manager to point to the cluster controller
    - Code implementation in CortxClusterManager to process the request provided at CLI level
    - Set output to cli of our actual core library function response
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
     -bash-4.2$ sudo cortxha cluster start --all --json
     "{\"status\": \"InProgress\", \"msg\": \"Cluster start operation performed\"}"

     -bash-4.2$ sudo cortxha cluster start --server --json
     "{\"status\": \"InProgress\", \"msg\": \"Cluster start operation performed\"}"
  </code>
</pre>
