### PR TITLE
EOS-18115: CORTX-HA : User interface for cluster stop CLI

### DIFF
--- a/ha/cli/exec/clusterExecutor.py
+++ b/ha/cli/exec/clusterExecutor.py
@@ -118,7 +118,7 @@ class ClusterStopExecutor(CommandExecutor):
            also displays an output
         '''
         stop_cluster_message = None
-        stop_cluster_message = self._cluster_manager.cluster_controller.stop(self._args.all or self._args.server)
+        stop_cluster_message = self._cluster_manager.cluster_controller.stop()
         if self._args.json:
             self._op.print_json(stop_cluster_message)
         else:

--- a/ha/cli/exec/clusterExecutor.py
+++ b/ha/cli/exec/clusterExecutor.py
@@ -114,12 +114,19 @@ class ClusterStopExecutor(CommandExecutor):
            Execute CLI request by passing it to ClusterManager and
            also displays an output
         '''
+        Log.info("Executing cluster stop")
         stop_cluster_message = None
+        if self._args.all:
+            Log.info("Executing storageset stop")
+            # TODO: Perform storageset stop
+
+        # TODO: pass the argument parsed from command line. server or all
         stop_cluster_message = self.cluster_manager.cluster_controller.stop()
         if self._args.json:
             self.op.print_json(stop_cluster_message)
         else:
             print(stop_cluster_message)
+        Log.info(stop_cluster_message)
 
 
 class ClusterRestartExecutor(CommandExecutor):
@@ -258,6 +265,7 @@ class ClusterNodeAddExecutor(CommandExecutor):
            Execute CLI request by passing it to ClusterManager and
            also displays an output
         '''
+        Log.info("Executing cluster add node")
         node_id = None or self._args.nodeid
         cluster_uname = self._args.username
         cluster_pwd = self._args.password
@@ -268,4 +276,6 @@ class ClusterNodeAddExecutor(CommandExecutor):
                                     cluster_uname, cluster_pwd)
             if self._args.json:
                 self.op.print_json(add_node_result_message)
-            print(add_node_result_message)
+            else:
+                print(add_node_result_message)
+        Log.info(add_node_result_message)

--- a/ha/cli/exec/clusterExecutor.py
+++ b/ha/cli/exec/clusterExecutor.py
@@ -24,7 +24,6 @@ import time
 from cortx.utils.log import Log
 from ha.cli.exec.commandExecutor import CommandExecutor
 from ha.core.error import HAClusterStart, HAClusterCLIError
-from ha.core.cluster.cluster_manager import CortxClusterManager
 from ha.core.error import HAUnimplemented
 
 
@@ -67,13 +66,13 @@ class ClusterStartExecutor(CommandExecutor):
         Execute the cluster start for all or only cluster
         """
         Log.info("Executing cortxha cluster start")
-        _cluster_start_result = self._cluster_manager.cluster_controller.start()
+        _cluster_start_result = self.cluster_manager.cluster_controller.start()
         if self._args.all:
             Log.info("Executing storage start")
             # TODO : start storage enclosure
 
         if self._args.json:
-            self._op.print_json(_cluster_start_result)
+            self.op.print_json(_cluster_start_result)
         Log.info(_cluster_start_result)
 
 
@@ -82,8 +81,7 @@ class ClusterStopExecutor(CommandExecutor):
     def __init__(self):
         '''Init method'''
         super(ClusterStopExecutor, self).__init__()
-        self._cluster_manager = CortxClusterManager()
-        self._op = Output()
+        self.op = Output()
         self._args = None
 
     def parse_args(self) -> None:
@@ -118,9 +116,9 @@ class ClusterStopExecutor(CommandExecutor):
            also displays an output
         '''
         stop_cluster_message = None
-        stop_cluster_message = self._cluster_manager.cluster_controller.stop()
+        stop_cluster_message = self.cluster_manager.cluster_controller.stop()
         if self._args.json:
-            self._op.print_json(stop_cluster_message)
+            self.op.print_json(stop_cluster_message)
         else:
             print(stop_cluster_message)
 
@@ -267,8 +265,8 @@ class ClusterNodeAddExecutor(CommandExecutor):
         if self._args.descfile:
             node_id = self.parse_node_desc_file(self._args.descfile)
         if self._is_valid_node_id(node_id):
-            add_node_result_message = self._cluster_manager.cluster_controller.add_node(node_id, \
+            add_node_result_message = self.cluster_manager.cluster_controller.add_node(node_id, \
                                     cluster_uname, cluster_pwd)
             if self._args.json:
-                self._op.print_json(add_node_result_message)
+                self.op.print_json(add_node_result_message)
             print(add_node_result_message)

--- a/ha/cli/exec/clusterExecutor.py
+++ b/ha/cli/exec/clusterExecutor.py
@@ -120,7 +120,6 @@ class ClusterStopExecutor(CommandExecutor):
             Log.info("Executing storageset stop")
             # TODO: Perform storageset stop
 
-        # TODO: pass the argument parsed from command line. server or all
         stop_cluster_message = self.cluster_manager.cluster_controller.stop()
         if self._args.json:
             self.op.print_json(stop_cluster_message)

--- a/ha/cli/exec/clusterExecutor.py
+++ b/ha/cli/exec/clusterExecutor.py
@@ -81,7 +81,6 @@ class ClusterStopExecutor(CommandExecutor):
     def __init__(self):
         '''Init method'''
         super(ClusterStopExecutor, self).__init__()
-        self.op = Output()
         self._args = None
 
     def parse_args(self) -> None:

--- a/ha/cli/exec/clusterExecutor.py
+++ b/ha/cli/exec/clusterExecutor.py
@@ -24,6 +24,7 @@ import time
 from cortx.utils.log import Log
 from ha.cli.exec.commandExecutor import CommandExecutor
 from ha.core.error import HAClusterStart, HAClusterCLIError
+from ha.core.cluster.cluster_manager import CortxClusterManager
 from ha.core.error import HAUnimplemented
 
 
@@ -81,7 +82,7 @@ class ClusterStopExecutor(CommandExecutor):
     def __init__(self):
         '''Init method'''
         super(ClusterStopExecutor, self).__init__()
-        self._pcs_cluster_controller = PcsClusterController()
+        self._cluster_manager = CortxClusterManager()
         self._op = Output()
         self._args = None
 
@@ -117,7 +118,7 @@ class ClusterStopExecutor(CommandExecutor):
            also displays an output
         '''
         stop_cluster_message = None
-        # stop_cluster_message = self._pcs_cluster_controller.stop()
+        stop_cluster_message = self._cluster_manager.cluster_controller.stop(self._args.all or self._args.server)
         if self._args.json:
             self._op.print_json(stop_cluster_message)
         else:

--- a/ha/cli/exec/clusterExecutor.py
+++ b/ha/cli/exec/clusterExecutor.py
@@ -77,11 +77,51 @@ class ClusterStartExecutor(CommandExecutor):
 
 
 class ClusterStopExecutor(CommandExecutor):
+
+    def __init__(self):
+        '''Init method'''
+        super(ClusterStopExecutor, self).__init__()
+        self._pcs_cluster_controller = PcsClusterController()
+        self._op = Output()
+        self._args = None
+
+    def parse_args(self) -> None:
+        '''
+           Parses the command line args.
+           Return: argparse
+        '''
+        parser = argparse.ArgumentParser(description="cluster stop")
+        parser.add_argument("cluster", help="Module")
+        parser.add_argument("stop", help="action to be performed")
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument('--all', action='store_true', \
+                            help='Server and storage stop')
+        group.add_argument('--server', action='store_false', \
+                            help='server stop')
+        parser.add_argument('--json', help='Required output format', action='store_true')
+        return parser.parse_args()
+
     def validate(self) -> bool:
-        raise HAUnimplemented("This operation is not implemented.")
+        '''
+           Validates permission and command line arguments.
+           Return: bool
+        '''
+        self._args = self.parse_args()
+        if self._args:
+            return True
+        return False
 
     def execute(self) -> None:
-        raise HAUnimplemented("This operation is not implemented.")
+        '''
+           Execute CLI request by passing it to ClusterManager and
+           also displays an output
+        '''
+        stop_cluster_message = None
+        # stop_cluster_message = self._pcs_cluster_controller.stop()
+        if self._args.json:
+            self._op.print_json(stop_cluster_message)
+        else:
+            print(stop_cluster_message)
 
 
 class ClusterRestartExecutor(CommandExecutor):

--- a/ha/cli/exec/commandExecutor.py
+++ b/ha/cli/exec/commandExecutor.py
@@ -31,8 +31,8 @@ from ha.cli.displayOutput import Output
 class CommandExecutor:
     def __init__(self):
         self._is_hauser = False
-        self._cluster_manager = CortxClusterManager()
-        self._op = Output()
+        self.cluster_manager = CortxClusterManager()
+        self.op = Output()
 
     def validate(self) -> bool:
         raise HAUnimplemented("This operation is not implemented.")


### PR DESCRIPTION
- Add command line parsing
- Validate arguments

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

## Problem Statement
<pre>
  <code>
  EOS-18115: CORTX-HA : User interface for cluster stop CLI  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Implement "cortx cluster stop" CLI for HA   </code>
</pre>
## Solution
<pre>
  <code>
    Base framework is already there. Verify cluster add option. . If node is there. Control will go to cluster node add module and eventually to cluster manager
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Execute CLI using 
    cortx cluster stop <--server | --all>. --server is the default argument.
  </code>
</pre>
