### PR TITLE
EOS-16249 node start CLI change

### DIFF
--- a/ha/cli/exec/clusterExecutor.py
+++ b/ha/cli/exec/clusterExecutor.py
@@ -17,13 +17,9 @@
 
 import argparse
 import os
-import re
-import socket
-import time
 
 from cortx.utils.log import Log
 from ha.cli.exec.commandExecutor import CommandExecutor
-from ha.core.error import HAClusterStart, HAClusterCLIError
 from ha.core.error import HAUnimplemented
 
 
@@ -225,40 +221,6 @@ class ClusterNodeAddExecutor(CommandExecutor):
             return True
         return False
 
-    def _is_valid_node_id(self, node_id) -> bool:
-        '''
-           Checks if node id gets resolved to some IP address or not
-           Returns: bool
-           Exception: socket.gaierror, socket.herror
-        '''
-
-        # TODO: change this logic and validate the node_id from the
-        # list coming from system health
-        ip_validator_regex = "^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"
-
-        # node_id can be passed as IP address or FQDN or
-        # some random number or just sequence of chars
-
-        # first seperate the string from dots.
-        splitted_node_id = node_id.replace('.', '')
-
-        # If string only contains numbers, means it can be just
-        # random number or can be an IP address. So, IP address
-        # validation can be done. else for random number, exception will be
-        # raised
-        if re.search('^[0-9]*$', splitted_node_id):
-            if re.search(ip_validator_regex, node_id):
-                return True
-            raise HAClusterCLIError(f'{node_id} is not a valid node_id')
-        # else it can be combination of chars and numbers means hostname or just a
-        # random meaningless string
-        else:
-            try:
-                socket.gethostbyname(node_id)
-            except Exception as err:
-                raise HAClusterCLIError(f'{node_id} not a valid node_id: {err}')
-        return True
-
     def execute(self) -> None:
         '''
            Execute CLI request by passing it to ClusterManager and
@@ -270,7 +232,7 @@ class ClusterNodeAddExecutor(CommandExecutor):
         cluster_pwd = self._args.password
         if self._args.descfile:
             node_id = self.parse_node_desc_file(self._args.descfile)
-        if self._is_valid_node_id(node_id):
+        if self.is_valid_node_id(node_id):
             add_node_result_message = self.cluster_manager.cluster_controller.add_node(node_id, \
                                     cluster_uname, cluster_pwd)
             if self._args.json:

--- a/ha/cli/exec/commandExecutor.py
+++ b/ha/cli/exec/commandExecutor.py
@@ -20,6 +20,8 @@ import grp
 import getpass
 import json
 import os
+import re
+import socket
 
 from ha import const
 from cortx.utils.log import Log
@@ -39,6 +41,40 @@ class CommandExecutor:
 
     def execute(self) -> None:
         raise HAUnimplemented("This operation is not implemented.")
+
+    def is_valid_node_id(self, node_id) -> bool:
+        '''
+           Checks if node id gets resolved to some IP address or not
+           Returns: bool
+           Exception: socket.gaierror, socket.herror
+        '''
+
+        # TODO: change this logic and validate the node_id from the
+        # list coming from system health
+        ip_validator_regex = "^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"
+
+        # node_id can be passed as IP address or FQDN or
+        # some random number or just sequence of chars
+
+        # first seperate the string from dots.
+        splitted_node_id = node_id.replace('.', '')
+
+        # If string only contains numbers, means it can be just
+        # random number or can be an IP address. So, IP address
+        # validation can be done. else for random number, exception will be
+        # raised
+        if re.search('^[0-9]*$', splitted_node_id):
+            if re.search(ip_validator_regex, node_id):
+                return True
+            raise HAClusterCLIError(f'{node_id} is not a valid node_id')
+        # else it can be combination of chars and numbers means hostname or just a
+        # random meaningless string
+        else:
+            try:
+                socket.gethostbyname(node_id)
+            except Exception as err:
+                raise HAClusterCLIError(f'{node_id} not a valid node_id: {err}')
+        return True
 
     """
     Routine used by executors to confirm acess permissions.

--- a/ha/cli/exec/nodeExecutor.py
+++ b/ha/cli/exec/nodeExecutor.py
@@ -25,7 +25,7 @@ class NodeStartExecutor(CommandExecutor):
 
     def __init__(self):
         """
-        Init cluster start executor
+        Init node start executor
         """
         super(NodeStartExecutor, self).__init__()
         self._args = None
@@ -49,9 +49,9 @@ class NodeStartExecutor(CommandExecutor):
         parser.add_argument('--nodeid', help='Node to start', required=True)
         group = parser.add_mutually_exclusive_group(required='True')
         group.add_argument('--all', action='store_true',
-                           help='All servers to start in a cluster')
+                           help='All server & storage to start in a cluster')
         group.add_argument('--server', action='store_true',
-                           help='Server to start in a cluster')
+                           help='Only server to start in a cluster')
         parser.add_argument('--json', help='Required output format', action='store_true')
         self._args = parser.parse_args()
         return True
@@ -60,7 +60,7 @@ class NodeStartExecutor(CommandExecutor):
         """
         Execute the node start
         """
-        Log.info("Executing cortxha node start")
+        Log.info("Executing cortx node start")
         node_id = None or self._args.nodeid
         if self.is_valid_node_id(node_id):
             result = self.cluster_manager.node_controller.start(node_id)

--- a/ha/cli/exec/nodeExecutor.py
+++ b/ha/cli/exec/nodeExecutor.py
@@ -49,9 +49,9 @@ class NodeStartExecutor(CommandExecutor):
         parser.add_argument('--nodeid', help='Node to start', required=True)
         group = parser.add_mutually_exclusive_group(required='True')
         group.add_argument('--all', action='store_true',
-                           help='All server & storage to start in a cluster')
+                           help='Start both server & storage in a node')
         group.add_argument('--server', action='store_true',
-                           help='Only server to start in a cluster')
+                           help='Start only server in a node')
         parser.add_argument('--json', help='Required output format', action='store_true')
         self._args = parser.parse_args()
         return True

--- a/ha/cli/exec/nodeExecutor.py
+++ b/ha/cli/exec/nodeExecutor.py
@@ -15,16 +15,63 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
+import argparse
 from ha.core.error import HAUnimplemented
 from ha.cli.exec.commandExecutor import CommandExecutor
+from cortx.utils.log import Log
+
 
 class NodeStartExecutor(CommandExecutor):
 
-    def validate(self) -> str:
-        raise HAUnimplemented("This operation is not implemented.")
+    def __init__(self):
+        """
+        Init cluster start executor
+        """
+        super(NodeStartExecutor, self).__init__()
+        self._args = None
 
-    def execute(self) -> str:
-        raise HAUnimplemented("This operation is not implemented.")
+    def validate(self) -> bool:
+        """
+        Validate the command arguments
+        """
+        if self.parse_cluster_args():
+            return True
+        return False
+
+    def parse_cluster_args(self) -> bool:
+        """
+        Parses the command line args.
+        Return: argparse
+        """
+        parser = argparse.ArgumentParser(prog='node start <Node> [all|server] [--json]')
+        parser.add_argument("node", help="Module")
+        parser.add_argument("start", help="action to be performed")
+        parser.add_argument('--nodeid', help='Node to start', required=True)
+        group = parser.add_mutually_exclusive_group(required='True')
+        group.add_argument('--all', action='store_true',
+                           help='All servers to start in a cluster')
+        group.add_argument('--server', action='store_true',
+                           help='Server to start in a cluster')
+        parser.add_argument('--json', help='Required output format', action='store_true')
+        self._args = parser.parse_args()
+        return True
+
+    def execute(self) -> None:
+        """
+        Execute the node start
+        """
+        Log.info("Executing cortxha node start")
+        node_id = None or self._args.nodeid
+        if self.is_valid_node_id(node_id):
+            result = self.cluster_manager.node_controller.start(node_id)
+            if self._args.all:
+                Log.info("Executing storage start")
+                # TODO : start storage enclosure
+            if self._args.json:
+                self.op.print_json(result)
+            else:
+                print(result)
+            Log.info(result)
 
 
 class NodeStopExecutor(CommandExecutor):
@@ -35,6 +82,7 @@ class NodeStopExecutor(CommandExecutor):
     def execute(self) -> str:
         raise HAUnimplemented("This operation is not implemented.")
 
+
 class NodeStandbyExecutor(CommandExecutor):
 
     def validate(self) -> str:
@@ -43,6 +91,7 @@ class NodeStandbyExecutor(CommandExecutor):
     def execute(self) -> str:
         raise HAUnimplemented("This operation is not implemented.")
 
+
 class NodeActiveExecutor(CommandExecutor):
 
     def validate(self) -> str:
@@ -50,6 +99,7 @@ class NodeActiveExecutor(CommandExecutor):
 
     def execute(self) -> str:
         raise HAUnimplemented("This operation is not implemented.")
+
 
 class NodeStatusExecutor(CommandExecutor):
 


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    https://jts.seagate.com/browse/EOS-16249
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    To add CLI support for node start
  </code>
</pre>
## Solution
<pre>
  <code>
    - Code implementation to point to the node controller in nodeExecutor
    - Code implementation to process the request provided at CLI level via execute method in nodeExecutor
    - Set output to cli of our actual core library function response
    - Implementation of validate functionality & parse args for the node start functionality.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Positive test:
    -bash-4.2$ sudo cortxha node start --nodeid node1 --all
    {"status": "Succeeded", "msg": "Node node1, is already in Online status"}
    
    -bash-4.2$ sudo cortxha node start --nodeid node1 --all
    {"status": "InProgress", "msg": "Node node1 : Node was in cluster_offline mode, Cluster started on node successfully"}
    
    -bash-4.2$ sudo cortxha node start --nodeid node1 --all --json
    "{\"status\": \"Succeeded\", \"msg\": \"Node node1, is already in Online status\"}"
    
    -bash-4.2$ sudo cortxha node start --nodeid node1 --server --json
    "{\"status\": \"Succeeded\", \"msg\": \"Node node1, is already in Online status\"}"
    
    Negative test:
    -bash-4.2$ sudo cortxha node start --nodeid nod1 --server --json
    
    ha.core.error.HAClusterCLIError: error(1): nod1 not a valid node_id: [Errno -2] Name or service not known
    [5311] Failed to execute script cortxha

  </code>
</pre>
