### PR TITLE
EOS-19431: fix the issue to check resource fail count for the requested node.

### DIFF
--- a/ha/const.py
+++ b/ha/const.py
@@ -116,7 +116,6 @@ PCS_NODE_UNSTANDBY="pcs node unstandby <node>"
 PCS_CLEANUP="pcs resource cleanup"
 PCS_FAILCOUNT_STATUS="pcs resource failcount show"
 PCS_NODE_CLEANUP= PCS_CLEANUP + " --node <node>"
-PCS_NODE_FAILCOUNT_STATUS= PCS_FAILCOUNT_STATUS + " --node <node>"
 PCS_STOP_NODE="pcs cluster stop <node> --request-timeout=<seconds>"
 PCS_STOP_CLUSTER="pcs cluster stop --request-timeout=<seconds> --all"
 PCS_STATUS = "pcs status"
@@ -128,7 +127,6 @@ PCS_STONITH_DISABLE="pcs property set stonith-enabled=False"
 CM_CONTROLLER_INDEX="cluster_controller_interfaces"
 CM_CONTROLLER_SCHEMA="{}/cluster_controller_interfaces.json".format(CONFIG_DIR)
 CM_ELEMENT=["cluster", "node", "service", "storageset"]
-NO_FAILCOUNT = "No failcounts"
 RETRY_COUNT = 2
 PCS_NODE_GROUP_SIZE = 3
 NODE_CONTROLLER = "node_controller"

--- a/ha/core/controllers/pcs/pcs_controller.py
+++ b/ha/core/controllers/pcs/pcs_controller.py
@@ -82,12 +82,11 @@ class PcsController(ElementController):
         """
         Resource fail count check
         """
-        _output, _err, _rc = self._execute.run_cmd(const.PCS_NODE_FAILCOUNT_STATUS.replace("<node>", node_id),
-                                                   check_error=False)
-        if const.NO_FAILCOUNT in _output:
-            return False
-        else:
+        _output, _err, _rc = self._execute.run_cmd(const.PCS_FAILCOUNT_STATUS, check_error=False)
+        if node_id in _output:
             return True
+        else:
+            return False
 
     def clean_failure_count(self, node_id):
         """


### PR DESCRIPTION
Signed-off-by: Vijaykumar Thakkar <vijaykumar.thakkar@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
   EOS-19431
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Observed that current loigc returns the resource failout of the whole cluster but our requirement is to check resource failcount for the requested node.
  </code>
</pre>
## Solution
<pre>
  <code>
    Added fix to check resource failcount exists for requested node.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   Tested changes in the 3 nodes cluster and able to start cluster successfully
  </code>
</pre>
