### PR TITLE
EOS-19535: Update ha_setup path of setup.yaml

### DIFF
--- a/conf/mini_provisioner/v2/ha_setup.yaml
+++ b/conf/mini_provisioner/v2/ha_setup.yaml
@@ -15,39 +15,39 @@
 
 ha:
     post_install:
-        cmd: ha_setup post_install
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup post_install
         args: --config $URL
 
     config:
-        cmd: ha_setup config
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup config
         args: --config $URL
 
     init:
-        cmd: ha_setup init
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup init
         args: --config $URL
 
     test:
-        cmd: ha_setup test
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup test
         args: --config $URL
 
     upgrade:
-        cmd: ha_setup upgrade
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup upgrade
         args: --config $URL
 
     reset:
-        cmd: ha_setup reset
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup reset
         args: --config $URL
 
     cleanup:
-        cmd: ha_setup cleanup
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup cleanup
         args: --config $URL
 
     backup:
-        cmd: ha_setup backup
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup backup
         args: --location $URL
 
     restore:
-        cmd: ha_setup restore
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup restore
         args: --location $URL
 
 support_bundle:

--- a/conf/mini_provisioner/v2/setup.yaml
+++ b/conf/mini_provisioner/v2/setup.yaml
@@ -14,12 +14,12 @@
 # cortx-questions@seagate.com.
 
 ha:
-    prepare:
-        cmd: /opt/seagate/cortx/ha/bin/ha_setup prepare
-        args: --config $URL
-
     post_install:
         cmd: /opt/seagate/cortx/ha/bin/ha_setup post_install
+        args: --config $URL
+
+    prepare:
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup prepare
         args: --config $URL
 
     config:

--- a/conf/mini_provisioner/v2/setup.yaml
+++ b/conf/mini_provisioner/v2/setup.yaml
@@ -14,6 +14,10 @@
 # cortx-questions@seagate.com.
 
 ha:
+    prepare:
+        cmd: /opt/seagate/cortx/ha/bin/ha_setup prepare
+        args: --config $URL
+
     post_install:
         cmd: /opt/seagate/cortx/ha/bin/ha_setup post_install
         args: --config $URL


### PR DESCRIPTION
Signed-off-by: Ajay Paratmandali <ajay.paratmandali@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    Add mini-provisioner prepare command and updated setup.yaml
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    The mini-provisioner prepare command is missing. and path in setup.yaml is not proper. 
  </code>
</pre>
## Solution
<pre>
  <code>
    Add mini-provisioner prepare command and updated setup.yaml
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Successfully tested with single node by running the new command.
  </code>
</pre>
