### PR TITLE
EOS-19431: Unstandby the node even when it is in standby mode with running resource

### DIFF
--- a/ha/core/controllers/pcs/node_controller.py
+++ b/ha/core/controllers/pcs/node_controller.py
@@ -172,10 +172,7 @@ class PcsVMNodeController(PcsNodeController):
         _node_status = self.nodes_status([nodeid])[nodeid]
         if _node_status == NODE_STATUSES.ONLINE.value:
             return {"status": const.STATUSES.SUCCEEDED.value, "msg": f"Node {nodeid}, is already in Online status"}
-        elif _node_status == NODE_STATUSES.STANDBY_WITH_RESOURCES_RUNNING.value:
-            return {"status": const.STATUSES.SUCCEEDED.value, "msg": f"Node {nodeid}, is going in standby mode, "
-                                                  f"We need to wait to complete the resource shutdown"}
-        elif _node_status == NODE_STATUSES.STANDBY.value:
+        elif _node_status == NODE_STATUSES.STANDBY.value or _node_status == NODE_STATUSES.STANDBY_WITH_RESOURCES_RUNNING.value:
             # make node unstandby
             if self.heal_resource(nodeid):
                 _output, _err, _rc = self._execute.run_cmd(const.PCS_NODE_UNSTANDBY.replace("<node>", nodeid),


### PR DESCRIPTION

Signed-off-by: Vijaykumar Thakkar <vijaykumar.thakkar@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-19431
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    QA has observed that node start operation ignored when node is in standby mode with running resource.
  </code>
</pre>
## Solution
<pre>
  <code>
    As discussed in the team's chat, I have removed "standby node with running resources" condition and combined with "standby" condition.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Validation done on 3 node cluster and it works fine
  </code>
</pre>
