### PR TITLE
EOS-19624 Password is exposed during add node

### DIFF
--- a/ha/remote_execution/remote_executor.py
+++ b/ha/remote_execution/remote_executor.py
@@ -30,6 +30,6 @@ class RemoteExecutor:
         self._port = port
 
     @abc.abstractmethod
-    def execute(self, command):
+    def execute(self, command, secret=None):
         '''Communicates to remote node by code execution'''
         raise NotImplementedError

--- a/ha/remote_execution/remote_executor.py
+++ b/ha/remote_execution/remote_executor.py
@@ -30,6 +30,6 @@ class RemoteExecutor:
         self._port = port
 
     @abc.abstractmethod
-    def execute(self, command, secret=None):
+    def execute(self, command: str, secret: str=None):
         '''Communicates to remote node by code execution'''
         raise NotImplementedError

--- a/ha/remote_execution/ssh_communicator.py
+++ b/ha/remote_execution/ssh_communicator.py
@@ -41,7 +41,7 @@ class SSHRemoteExecutor(RemoteExecutor):
             Log.error(f'SSHRemoteExecutor, some error occured while connecting \
                         to SSH channel {err}')
 
-    def execute(self, command: str) -> None:
+    def execute(self, command: str, secret=None) -> None:
         '''
         Communicates to remote node by code execution
 
@@ -54,21 +54,22 @@ class SSHRemoteExecutor(RemoteExecutor):
         Exceptions:
                 RemoteExecutorError
         '''
+        command_log = command.replace(secret, '****') if secret is not None else command
         ret_code = 0
         res = None
-        Log.info(f'Executing command: {command} on a remote host: {self._hostname}')
+        Log.info(f'Executing command: {command_log} on a remote host: {self._hostname}')
         try:
             ret_code, res = self._ssh_client.execute(command)
             if ret_code:
                 raise RemoteExecutorError(f'Error: Failed to \
-                                            execute command {command} on a \
+                                            execute command {command_log} on a \
                                             remote node: {self._hostname} with \
                                             error: {res}', ret_code)
         except RemoteExecutorError as ree:
             raise ree
         except Exception as err:
             raise RemoteExecutorError(f"Error: {err}.Some problem occured while executing \
-                                        command {command} on a remote node: \
+                                        command {command_log} on a remote node: \
                                         {self._hostname}", ret_code)
 
 def _parse_args():

--- a/ha/remote_execution/ssh_communicator.py
+++ b/ha/remote_execution/ssh_communicator.py
@@ -41,7 +41,7 @@ class SSHRemoteExecutor(RemoteExecutor):
             Log.error(f'SSHRemoteExecutor, some error occured while connecting \
                         to SSH channel {err}')
 
-    def execute(self, command: str, secret=None) -> None:
+    def execute(self, command: str, secret: str=None) -> None:
         '''
         Communicates to remote node by code execution
 

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -302,7 +302,7 @@ class ConfigCmd(Cmd):
                     try:
                         remote_executor.execute(const.CORTX_CLUSTER_NODE_ADD.replace("<node>", node_name)
                                                                             .replace("<user>", cluster_user)
-                                                                            .replace("<secret>", "'" + cluster_secret + "'"))
+                                                                            .replace("<secret>", "'" + cluster_secret + "'"), secret=cluster_secret)
                         # TODO: Change following PCS command to CLI when available.
                         remote_executor.execute(const.PCS_NODE_STANDBY.replace("<node>", node_name))
                         # Add this node to the cluster nodes list in the store.


### PR DESCRIPTION
Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any): EOS-19624
    Password is exposed during add node
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    We are passing command as it is to log file without masking password during add node.
  </code>
</pre>
## Solution
<pre>
  <code>
    Here we are creating copy of command then password is masked in that copied command and passed to log fie.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
