### PR TITLE
EOS-19850: HA: Alert Generator: Alert Monitor-Create_IEM

### DIFF
--- a/ha/alert_monitor/node_alert_monitor.py
+++ b/ha/alert_monitor/node_alert_monitor.py
@@ -27,15 +27,6 @@ class NodeAlertMonitor():
     '''
     #TODO: Inherit this class from base AlertMonitor
 
-    # TODO: This can be initialized at base level
-    IEC_mapping_dict = {
-        'severity': {'shutdown': 'W', 'poweron': 'I'},
-        'source': 'S',
-        'component': '008',
-        'module': '001',
-        'event': {'failure': '0001', 'recover': '0002'}
-        }
-
     def __init__(self):
         ''''Init method'''
         self._execute = SimpleCommand()

--- a/ha/alert_monitor/node_alert_monitor.py
+++ b/ha/alert_monitor/node_alert_monitor.py
@@ -1,4 +1,24 @@
-'''Dervied module in the Monitoring hierarchy which monitors node alert'''
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+'''Derived module in the Monitoring hierarchy which monitors node alert'''
+
+from cortx.utils.log import Log
+from ha.const import IEC, RA_LOG_DIR, IEC_MAPPING_DICT
+from ha.execute import SimpleCommand
+
 
 class NodeAlertMonitor():
     '''
@@ -18,18 +38,38 @@ class NodeAlertMonitor():
 
     def __init__(self):
         ''''Init method'''
+        self._execute = SimpleCommand()
+
         # Name of the node event. e.g. shutdown or poweron
         # Can be known from base class. Values may change
         self._event = None
         self._event_type = 'failure'
 
+        # No need to initialize this here. It will be available from
+        # base class. For now, initializing it to None for testing purpose.
+        self.alert_desc = None
+
     def create_iem(self):
         '''Creates the structure required to send the information as IEC'''
         # From the base implementation, self.alert_desc value will be available
         # From which, actual event can be found. like shutdown or poweron
-        severity = self.IEC_mapping_dict['severity'][self._event]
+
+        severity = IEC_MAPPING_DICT['severity'][self._event]
         if self._event == 'poweron':
             self._event_type = 'recover'
-        event = self.IEC_mapping_dict['event'][self._event_type]
-        iec_string = f"IEC:{severity}{self.IEC_mapping_dict['source']}{self.IEC_mapping_dict['component']}{self.IEC_mapping_dict['module']}{event}"
-        # TODO: Send to the syslog
+        event = IEC_MAPPING_DICT['event'][self._event_type]
+
+        # self.alert_desc will be available from Base class which can be
+        # directly used to append the description to IEC string or we can
+        # parse out the info and append
+        iec_string = f'"IEC:{severity}{IEC_MAPPING_DICT["source"]}{IEC_MAPPING_DICT["component"]}{IEC_MAPPING_DICT["module"]}{event}:{self.alert_desc}"'
+        iec_command = IEC + ' ' + iec_string
+        Log.info(f'Sending an IEC: {iec_string} to syslog')
+        _output, _err, _rc = self._execute.run_cmd(iec_command, check_error=False)
+
+        if _rc != 0 or _err:
+            raise Exception(f'Failed to populate an IEC to syslog')
+
+
+if __name__ == '__main__':
+    Log.init(service_name="alert_monitor", log_path=RA_LOG_DIR, level="INFO")

--- a/ha/alert_monitor/node_alert_monitor.py
+++ b/ha/alert_monitor/node_alert_monitor.py
@@ -1,0 +1,35 @@
+'''Dervied module in the Monitoring hierarchy which monitors node alert'''
+
+class NodeAlertMonitor():
+    '''
+    Module responsible for analyzing an alert information
+    to generate an IEM and sending the IEM across.
+    '''
+    #TODO: Inherit this class from base AlertMonitor
+
+    # TODO: This can be initialized at base level
+    IEC_mapping_dict = {
+        'severity': {'shutdown': 'W', 'poweron': 'I'},
+        'source': 'S',
+        'component': '008',
+        'module': '001',
+        'event': {'failure': '0001', 'recover': '0002'}
+        }
+
+    def __init__(self):
+        ''''Init method'''
+        # Name of the node event. e.g. shutdown or poweron
+        # Can be known from base class. Values may change
+        self._event = None
+        self._event_type = 'failure'
+
+    def create_iem(self):
+        '''Creates the structure required to send the information as IEC'''
+        # From the base implementation, self.alert_desc value will be available
+        # From which, actual event can be found. like shutdown or poweron
+        severity = self.IEC_mapping_dict['severity'][self._event]
+        if self._event == 'poweron':
+            self._event_type = 'recover'
+        event = self.IEC_mapping_dict['event'][self._event_type]
+        iec_string = f"IEC:{severity}{self.IEC_mapping_dict['source']}{self.IEC_mapping_dict['component']}{self.IEC_mapping_dict['module']}{event}"
+        # TODO: Send to the syslog

--- a/ha/alert_monitor/node_alert_monitor.py
+++ b/ha/alert_monitor/node_alert_monitor.py
@@ -59,7 +59,7 @@ class NodeAlertMonitor():
         _output, _err, _rc = self._execute.run_cmd(iec_command, check_error=False)
 
         if _rc != 0 or _err:
-            raise Exception(f'Failed to populate an IEC to syslog')
+            raise Exception('Failed to populate an IEC to syslog')
 
 
 if __name__ == '__main__':

--- a/ha/const.py
+++ b/ha/const.py
@@ -110,6 +110,8 @@ NODE_ONLINE="Online"
 # Systemd wrapper resource agent
 HARE_FID_MAPPING_FILE="/var/lib/hare/consul-server-conf/consul-server-conf.json"
 
+# Send IEC to syslog
+IEC="logger -i -p local3.err"
 # PCS Commands
 PCS_CLUSTER_START="pcs cluster start --all"
 PCS_CLUSTER_START_NODE="pcs cluster start"
@@ -166,6 +168,14 @@ MODULE = "module"
 RESOURCE_TYPE = "resource_type"
 IEM_DESCRIPTION="WS0080010001, Node, The cluster has lost $host server. System is running in degraded mode. " \
                 "For more information refer the Troubleshooting guide. Extra Info: host=$host; status=$status;"
+
+IEC_MAPPING_DICT = {
+        'severity': {'shutdown': 'W', 'poweron': 'I'},
+        'source': 'S',
+        'component': '008',
+        'module': '001',
+        'event': {'failure': '0001', 'recover': '0002'}
+        }
 
 class STATUSES(Enum):
     IN_PROGRESS = "InProgress"

--- a/jenkins/pyinstaller/v2/pyinstaller-cortx-ha.spec
+++ b/jenkins/pyinstaller/v2/pyinstaller-cortx-ha.spec
@@ -120,6 +120,7 @@ remote_execution =  Analysis([ha_path + '/ha/remote_execution/ssh_communicator.p
         noarchive=False)
 
 event_analyzerd =  Analysis([ha_path + '/ha/core/event_analyzer/event_analyzerd.py'],
+node_alert_monitor =  Analysis([ha_path + '/ha/alert_monitor/node_alert_monitor.py'],
         pathex=[ha_path],
         binaries=[],
         datas=[],
@@ -139,6 +140,7 @@ MERGE((cortxha, 'cortxha', 'cortxha'),
         (event_analyzerd, 'event_analyzerd', 'event_analyzerd'),
         (post_disruptive_upgrade, 'post_disruptive_upgrade', 'post_disruptive_upgrade'),
         (remote_execution, 'remote_execution', 'remote_execution')
+        (node_alert_monitor, 'node_alert_monitor', 'node_alert_monitor'),
         )
 
 # cortxha
@@ -240,6 +242,14 @@ event_analyzerd_exe = EXE(event_analyzerd_pyz,
         [],
         exclude_binaries=True,
         name='event_analyzerd',
+node_alert_monitor_pyz = PYZ(node_alert_monitor.pure, node_alert_monitor.zipped_data,
+        cipher=block_cipher)
+
+node_alert_monitor_exe = EXE(remote_execution_pyz,
+        node_alert_monitor.scripts,
+        [],
+        exclude_binaries=True,
+        name='node_alert_monitor',
         debug=False,
         bootloader_ignore_signals=False,
         strip=False,
@@ -288,6 +298,12 @@ coll = COLLECT(
         event_analyzerd.binaries,
         event_analyzerd.zipfiles,
         event_analyzerd.datas,
+
+        # node_alert_monitor
+        node_alert_monitor_exe,
+        node_alert_monitor.binaries,
+        node_alert_monitor.zipfiles,
+        node_alert_monitor.datas,
 
         strip=False,
         upx=True,


### PR DESCRIPTION
- Define base structure for IEM generation
- Form the IEC string

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    https://jts.seagate.com/browse/EOS-19850
 </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  In progress
  </code>
</pre>
## Problem Description
<pre>
  <code>
    HA will be handling the alert generation for some of the node failure/recover cases.  Once the alert is received from pacemaker, it will be filtered out. After successful filter, its IEC will be formed and will be logged to syslog.
    So, handling of IEC will be addressed through this
  </code>
</pre>
<pre>
  <code>
  Define IEC structure by checking the alert and its information and form an IEC
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Executed the script with some hardcoded value which will generate an IEC.
    IEX was successfully populated in the syslog as
    May 29 22:20:55 ssc-vm-0917 root[17434]: "IEC:WS0080010001:None"
   </code>
</pre>
