### PR TITLE
EOS-20856: Implement cluster start and stop on HW

### DIFF
--- a/ha/core/controllers/pcs/node_controller.py
+++ b/ha/core/controllers/pcs/node_controller.py
@@ -218,24 +218,12 @@ class PcsVMNodeController(PcsNodeController):
             Log.error(f"{nodeid} status is {_node_status}, node may not be started.")
             raise ClusterManagerError(f"Failed to start {nodeid} as found unhandled status {_node_status}")
 
-class PcsHWNodeController(PcsNodeController):
+class PcsHWNodeController(PcsVMNodeController):
     def initialize(self, controllers):
         """
         Initialize the storageset controller
         """
         self._controllers = controllers
-
-    @controller_error_handler
-    def start(self, nodeid: str) -> dict:
-        """
-        Start node with nodeid.
-        Args:
-            nodeid (str): Node ID from cluster nodes.
-        Returns:
-            ([dict]): Return dictionary. {"status": "", "msg":""}
-                status: Succeeded, Failed, InProgress
-        """
-        raise HAUnimplemented("This operation is not implemented.")
 
     @controller_error_handler
     def shutdown(self, nodeid: str) -> dict:


### PR DESCRIPTION
- Remove start functionality from PcsHWNodeController
- Inherit PcsHWNodeController from PcsVMNodeController

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    https://jts.seagate.com/browse/EOS-20856
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Implement cortx node start on HW environment
 </code>
</pre>
  <pre>
  <code>
    1. node start is already implemented for VM environment and this functionality does not differ env to env
   2. So, Inherit PcsHWNodeController from PcsVMNodeController
   3. Remove start functionality from PcsHWNodeController if its present. So, that call will directly go to base class start.
 </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    1. Perform mini provisioning steps
    2. Change env to HW in /etc/ha/ha.conf file
    3. Execute cortx **node start srvnode-1 --server --json**
    4. Verified the environment and call hierachy by:
    **2021-06-01 22:21:43 cluster_manager ERROR [execute] <ha.core.controllers.pcs.node_controller.PcsVMNodeController object at 0x7f22271fec88>** --- _value for cm.node_controller_
  **cm.__dict__** :
  _###### {'_cluster_type': 'corosync', **'_env': 'HW'**, '_controllers': {'cluster_controller': <ha.core.controllers.pcs.cluster_controller.PcsClusterController object at 0x7f7eb25c4a20>, 'node_controller': <ha.core.controllers.pcs.node_controller.PcsHWNodeController object at 0x7f7eb25c4c88>, 'service_controller': <ha.core.controllers.pcs.service_controller.PcsServiceController object at 0x7f7eb25c4dd8>, 'storageset_controller': <ha.core.controllers.pcs.storageset_controller.PcsStorageSetController object at 0x7f7eb25c4cf8>}, 'cluster_controller': <ha.core.controllers.pcs.cluster_controller.PcsClusterController object at 0x7f7eb25c4a20>, 'node_controller': <ha.core.controllers.pcs.node_controller.PcsHWNodeController object at 0x7f7eb25c4c88>, 'service_controller': <ha.core.controllers.pcs.service_controller.PcsServiceController object at 0x7f7eb25c4dd8>, 'storageset_controller': <ha.core.controllers.pcs.storageset_controller.PcsStorageSetController object at 0x7f7eb25c4cf8>}_

  </code>
</pre>
