### PR TITLE
EOS-20697: Rewrite pacemaker rules to accommodate new and future requirements

### DIFF
--- a/conf/etc/v2/ha.conf
+++ b/conf/etc/v2/ha.conf
@@ -9,3 +9,13 @@ CLUSTER_MANAGER:
     local_node: <LOCAL_NODE>
 SYSTEM_HEALTH:
     num_entity_health_events: 2
+SERVICE_INSTANCE_COUNTER:
+- instances: 1
+  resource: motr-confd
+  scope: cluster
+- instances: <S3_INSTANCES>
+  resource: s3server
+  scope: node
+- instances: 2
+  resource: motr-ios
+  scope: node

--- a/ha/resource/dynamic_fid_service_ra.py
+++ b/ha/resource/dynamic_fid_service_ra.py
@@ -58,6 +58,25 @@ class FidManager:
                 {instance_id}). Error: {e}")
             return None
 
+
+class AttribUpdater:
+    @staticmethod
+    def set_attr(resource: str):
+        try:
+            executor = SimpleCommand()
+            executor.run_cmd(f"attrd_updater -U 1 -n {resource}", check_error=False)
+        except Exception as e:
+            Log.error(f"Problem in updating attr - resource: {resource}")
+
+    @staticmethod
+    def del_attr(resource: str):
+        try:
+            executor = SimpleCommand()
+            executor.run_cmd(f"attrd_updater -D -n {resource}", check_error=False)
+        except Exception as e:
+            Log.error(f"Problem in deleting attr - resource: {resource}")
+
+
 class DynamicFidServiceRA(CortxServiceRA):
     """
     This class is used to provide wrapper around systemd resource agent.
@@ -77,6 +96,11 @@ class DynamicFidServiceRA(CortxServiceRA):
         super(DynamicFidServiceRA, self).__init__()
         self._execute = SimpleCommand()
         self._status_list: list = ["failed", "active", "unknown"]
+
+    def _get_update_attrib_info(self) -> None:
+        res_param = self.get_env()
+        self._resource = res_param["OCF_RESOURCE_INSTANCE"]
+        self._update_attrib = res_param["OCF_RESKEY_update_attrib"]
 
     def _get_systemd_service(self) -> str:
         """
@@ -136,15 +160,20 @@ class DynamicFidServiceRA(CortxServiceRA):
         </longdesc>
         <shortdesc lang="en">Systemd wrapper agent</shortdesc>
         <parameters>
-        <parameter name="service" required="0">
+        <parameter name="service" required="1">
         <longdesc lang="en"> Service name to manage systemd </longdesc>
         <shortdesc lang="en"> Systemd service </shortdesc>
         <content type="string"/>
         </parameter>
-        <parameter name="fid_service_name" required="0">
+        <parameter name="fid_service_name" required="1">
         <longdesc lang="en"> Fid service name used in mapping </longdesc>
         <shortdesc lang="en"> Systemd service </shortdesc>
         <content type="string"/>
+        </parameter>
+        <parameter name="update_attrib" required="0">
+        <longdesc lang="en"> If true, updates the node attribute for resource. </longdesc>
+        <shortdesc lang="en"> Update attribute. </shortdesc>
+        <content type="boolean" default="false"/>
         </parameter>
         </parameters>
         <actions>
@@ -188,6 +217,9 @@ class DynamicFidServiceRA(CortxServiceRA):
                 time.sleep(1)
                 continue
         Log.info(f"Start: Started {service} service")
+        self._get_update_attrib_info()
+        if self._update_attrib:
+            AttribUpdater.set_attr(self._resource)
         return const.OCF_SUCCESS
 
     def stop(self) -> int:
@@ -208,6 +240,9 @@ class DynamicFidServiceRA(CortxServiceRA):
             if status in ["failed", "unknown"]:
                 break
         Log.info(f"Stop: Stopped {service} service")
+        self._get_update_attrib_info()
+        if self._update_attrib:
+            AttribUpdater.del_attr(self._resource)
         return const.OCF_SUCCESS
 
     def monitor(self) -> int:
@@ -232,9 +267,15 @@ class DynamicFidServiceRA(CortxServiceRA):
                 break
             elif status == "failed":
                 Log.debug(f"Monitor: failed to monitor {service}")
+                self._get_update_attrib_info()
+                if self._update_attrib:
+                    AttribUpdater.del_attr(self._resource)
                 return const.OCF_ERR_GENERIC
             elif status == "unknown":
                 Log.debug(f"Monitor: Service {service} is not started yet...")
+                self._get_update_attrib_info()
+                if self._update_attrib:
+                    AttribUpdater.del_attr(self._resource)
                 return const.OCF_NOT_RUNNING
             else:
                 # wait if there is unstable status like activating, deactivating

--- a/ha/resource/dynamic_fid_service_ra.py
+++ b/ha/resource/dynamic_fid_service_ra.py
@@ -74,7 +74,7 @@ class AttribUpdater:
             executor = SimpleCommand()
             executor.run_cmd(f"attrd_updater -D -n {resource}", check_error=False)
         except Exception as e:
-            Log.error(f"Problem in deleting attr - resource: {resource}")
+            Log.error(f"Problem in deleting attr - resource: {resource}, Error: {e}")
 
 
 class DynamicFidServiceRA(CortxServiceRA):

--- a/ha/resource/dynamic_fid_service_ra.py
+++ b/ha/resource/dynamic_fid_service_ra.py
@@ -66,7 +66,7 @@ class AttribUpdater:
             executor = SimpleCommand()
             executor.run_cmd(f"attrd_updater -U 1 -n {resource}", check_error=False)
         except Exception as e:
-            Log.error(f"Problem in updating attr - resource: {resource}")
+            Log.error(f"Problem in updating attr - resource: {resource}. Error: {e}")
 
     @staticmethod
     def del_attr(resource: str):

--- a/ha/resource/service_instances_counter.py
+++ b/ha/resource/service_instances_counter.py
@@ -48,6 +48,10 @@ class AttribUpdater:
         if node_name is none, then instances are counted cluster wide,
         otherwise it's counted for just that node.
         """
+        count = -1
+        if output is None:
+            return count
+
         count = 0
         lines = output.split('\n')
         if len(lines) > 0:
@@ -68,10 +72,10 @@ class AttribUpdater:
             executor = SimpleCommand()
             for instance in range(1, instances_per_node+1):
                 service = resource + "-" + str(instance)
-                out, err, rc = executor.run_cmd(f"attrd_updater -Q -A -n {service}", check_error=False)
+                out, _, _ = executor.run_cmd(f"attrd_updater -Q -A -n {service}", check_error=False)
                 count += AttribUpdater._get_count_from_output(out, node_name)
         except Exception as e:
-            Log.error(f"Problem in fetching attr. resource: {resource}")
+            Log.error(f"Problem in fetching attr. resource: {resource}. Error: {e}")
             count = -1
 
         return count

--- a/ha/resource/service_instances_counter.py
+++ b/ha/resource/service_instances_counter.py
@@ -92,7 +92,7 @@ class AttribUpdater:
                 executor = SimpleCommand()
                 executor.run_cmd(f"attrd_updater -U {count} -n {attrib_name}", check_error=False)
         except Exception as e:
-            Log.error(f"Problem in updating attr - count of resource: {resource}")
+            Log.error(f"Problem in updating attr - count of resource: {resource}. Error: {e}")
 
 
 class ServiceInstancesCounter(CortxServiceRA):

--- a/ha/resource/service_instances_counter.py
+++ b/ha/resource/service_instances_counter.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+"""
+ ****************************************************************************
+ Description:       Generic resource agent used to map fid to cloneids.
+ ****************************************************************************
+"""
+
+import sys
+import re
+from cortx.utils.log import Log
+from cortx.utils.conf_store import Conf
+
+from ha.core.config.config_manager import ConfigManager
+from ha.resource.resource_agent import CortxServiceRA
+from ha.execute import SimpleCommand
+from ha import const
+
+
+class AttribScope:
+    CLUSTER = "cluster"
+    NODE = "node"
+
+
+class AttribUpdater:
+    @staticmethod
+    def _get_count_from_output(output: str, node_name: str) -> int:
+        count = 0
+        lines = output.split('\n')
+        if len(lines) > 0:
+            for a_line in lines:
+                info = re.split(r'\s+', a_line)
+                if len(info) >= 3:
+                    node_found = True
+                    if node_name is not None and info[1].split('=')[1].strip('""') != node_name:
+                        node_found = False
+                    if node_found and info[2].split('=')[1].strip('""') == "1":
+                        count += 1
+        return count
+
+    @staticmethod
+    def get_count(resource: str, instances_per_node: int, node_name: str = None):
+        count = 0
+        try:
+            executor = SimpleCommand()
+            for instance in range(1, instances_per_node+1):
+                service = resource + "-" + str(instance)
+                out, err, rc = executor.run_cmd(f"attrd_updater -Q -A -n {service}", check_error=False)
+                count += AttribUpdater._get_count_from_output(out, node_name)
+        except Exception as e:
+            Log.error(f"Problem in fetching attr. resource: {resource}")
+            count = -1
+
+        return count
+
+    @staticmethod
+    def update_attr(scope: str, resource: str, instances_per_node: int, node_name:str = None):
+        if scope == AttribScope.CLUSTER:
+            node_name = None
+
+        try:
+            count: int = AttribUpdater.get_count(resource, instances_per_node, node_name)
+            if count >= 0:
+                attrib_name: str = resource + "-count"
+                executor = SimpleCommand()
+                executor.run_cmd(f"attrd_updater -U {count} -n {attrib_name}", check_error=False)
+        except Exception as e:
+            Log.error(f"Problem in updating attr - count of resource: {resource}")
+
+
+class ServiceInstancesCounter(CortxServiceRA):
+    """
+        Updates count of instances of a resource running on
+        a node which can be used by other resources in
+        constraint rules.
+        The name of attribute would be service_count.
+        Expects input in list of following information -
+        services : [
+            { "resource": "motr-confd", #resource name without instance in it.
+              "instances": "1", #instances per node.
+              "scope": "cluster" #update the count of services in cluster or node.
+            }
+        ]
+        Prerequisite: Corresponding RA or systemd must be updating the attribute
+        with name as resource name.
+    """
+    def __init__(self):
+        """
+        Initialize the class.
+        """
+        super(ServiceInstancesCounter, self).__init__()
+        self._local_node = None
+        self._resources = Conf.get(const.HA_GLOBAL_INDEX, 'SERVICE_INSTANCE_COUNTER')
+        Log.info(f"Resource configured: {self._resources}")
+
+    def metadata(self) -> int:
+        """
+        Provide meta data for resource agent and parameter
+        """
+        env: str =r"""<?xml version="1.0"?>
+        <!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+        <resource-agent name="service_instances_counter">
+        <version>1.0</version>
+
+        <longdesc lang="en">
+            Updates count of instances of a resource running on
+            a node which can be used by other resources in
+            constraint rules.
+            The name of attribute would be service_count.
+            Expects input in list of following information -
+            services : [
+                {   "name": "motr-confd", #resource name without instance in it.
+                    "instances": "1", #instances per node.
+                    "scope": "cluster" #update the count of services in cluster or node.
+                }
+            ]
+            Prerequisite: Corresponding RA or systemd must be updating the attribute
+            with name as resource name.
+        </longdesc>
+        <shortdesc lang="en">Service instance counter agent</shortdesc>
+        <parameters>
+        </parameters>
+        <actions>
+        <action name="start"        timeout="40s" />
+        <action name="stop"         timeout="40s" />
+        <action name="monitor"      timeout="40s" interval="60s" depth="0" />
+        <action name="meta-data"    timeout="4s" />
+        </actions>
+        </resource-agent>
+        """
+        sys.stdout.write(env)
+        return const.OCF_SUCCESS
+
+    def start(self) -> int:
+        """
+        Updates the count. Same as monitor.
+        """
+        self.monitor()
+        return const.OCF_SUCCESS
+
+    def stop(self) -> int:
+        """
+        Updates the count. Same as monitor.
+        """
+        self.monitor()
+        return const.OCF_SUCCESS
+
+    def monitor(self) -> int:
+        """
+        Monitor updates the count of every
+        service present in ha.conf
+        """
+        if self._local_node is None:
+            res_param = self.get_env()
+            self._local_node = res_param["OCF_RESKEY_CRM_meta_on_node"]
+
+        for a_resource in self._resources:
+            AttribUpdater.update_attr(a_resource['scope'], a_resource['resource'], a_resource['instances'], self._local_node)
+        return const.OCF_SUCCESS
+
+
+def main(resource: ServiceInstancesCounter, action: str ='') -> int:
+    """
+    Main function acts as switch case for ServiceInstancesCounter resource agent.
+
+    Args:
+        resource (ServiceInstancesCounter): Resource agent
+        action (str): Resource agent action called by Pacemaker. Defaults to ''.
+
+    Returns:
+        int: Provide output as int code provided by pacemaker.
+    """
+    try:
+        if action == "meta-data":
+            return resource.metadata()
+        Log.debug(f"{resource} initialized for action {action}")
+        if action == "monitor":
+            return resource_agent.monitor()
+        elif action == "start":
+            return resource_agent.start()
+        elif action == "stop":
+            return resource_agent.stop()
+        else:
+            print(f"Usage {sys.argv[0]} [monitor] [start] [stop] [meta-data]")
+            exit(0)
+    except Exception as e:
+        Log.error(f"service_instances_counter failed to perform {action}. Error: {e}")
+        return const.OCF_ERR_GENERIC
+
+
+if __name__ == '__main__':
+    action = sys.argv[1] if len(sys.argv) > 1 else ""
+    ConfigManager.init("resource_agent")
+    resource_agent = ServiceInstancesCounter()
+    sys.exit(main(resource_agent, action))

--- a/ha/resource/service_instances_counter.py
+++ b/ha/resource/service_instances_counter.py
@@ -40,6 +40,14 @@ class AttribScope:
 class AttribUpdater:
     @staticmethod
     def _get_count_from_output(output: str, node_name: str) -> int:
+        """
+        Parses output of attrd_updater query command -
+            name="motr-confd-1" host="srvnode-1" value="1"
+            name="motr-confd-1" host="srvnode-2" value=""
+            name="motr-confd-1" host="srvnode-3" value="1"
+        if node_name is none, then instances are counted cluster wide,
+        otherwise it's counted for just that node.
+        """
         count = 0
         lines = output.split('\n')
         if len(lines) > 0:
@@ -162,7 +170,7 @@ class ServiceInstancesCounter(CortxServiceRA):
 
     def monitor(self) -> int:
         """
-        Monitor updates the count of every
+        Monitor - updates the count of every
         service present in ha.conf
         """
         if self._local_node is None:

--- a/ha/setup/create_pacemaker_resources.py
+++ b/ha/setup/create_pacemaker_resources.py
@@ -61,6 +61,12 @@ def cib_get(cib_xml):
     process.run_cmd(f"pcs cluster cib {cib_xml}")
     return cib_xml
 
+def change_pcs_default(cib_xml, push=False, **kwargs):
+    """Modify pcs defaults here"""
+    process.run_cmd(f"pcs -f {cib_xml} resource defaults resource-stickiness=1")
+    if push:
+        cib_push(cib_xml)
+
 def hax(cib_xml, push=False, **kwargs):
     """Create resources that belong to hax and clone the group."""
     # hax

--- a/jenkins/rpm/v2/post_install_script.sh
+++ b/jenkins/rpm/v2/post_install_script.sh
@@ -7,6 +7,7 @@ SITE_PACKAGES=`python3 -c 'import sysconfig; print(sysconfig.get_paths()["pureli
 HA_SETUP=${SITE_PACKAGES}/ha/setup/ha_setup.py
 CLI_EXEC=${SITE_PACKAGES}/ha/cli/cortxha.py
 DYNAMIC_RA=${SITE_PACKAGES}/ha/resource/dynamic_fid_service_ra.py
+SRV_COUNTER_RA=${SITE_PACKAGES}/ha/resource/service_instances_counter.py
 EVENT_ANALYZER=${SITE_PACKAGES}/ha/core/event_analyzer/event_analyzerd.py
 
 chmod +x ${HA_SETUP}
@@ -23,6 +24,11 @@ chmod +x ${DYNAMIC_RA}
 ln -sf ${DYNAMIC_RA} ${BIN_DIR}/dynamic_fid_service_ra
 ln -sf ${DYNAMIC_RA} /usr/bin/dynamic_fid_service_ra
 ln -sf ${DYNAMIC_RA} $RES_AGENT/dynamic_fid_service_ra
+
+chmod +x ${SRV_COUNTER_RA}
+ln -sf ${SRV_COUNTER_RA} ${BIN_DIR}/service_instances_counter
+ln -sf ${SRV_COUNTER_RA} /usr/bin/service_instances_counter
+ln -sf ${SRV_COUNTER_RA} $RES_AGENT/service_instances_counter
 
 chmod +x ${EVENT_ANALYZER}
 ln -sf ${EVENT_ANALYZER} ${BIN_DIR}/event_analyzerd

--- a/jenkins/rpm/v2/post_uninstall_script.sh
+++ b/jenkins/rpm/v2/post_uninstall_script.sh
@@ -16,6 +16,10 @@ rm -f ${BIN_DIR}/dynamic_fid_service_ra
 rm -f /usr/bin/dynamic_fid_service_ra
 rm -f $RES_AGENT/dynamic_fid_service_ra
 
+rm -f ${BIN_DIR}/service_instances_counter
+rm -f ${SRV_COUNTER_RA} /usr/bin/service_instances_counter
+rm -f ${SRV_COUNTER_RA} $RES_AGENT/service_instances_counter
+
 rm -f ${BIN_DIR}/event_analyzerd
 rm -f /usr/local/bin/event_analyzerd
 rm -f /usr/bin/event_analyzerd


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  EOS-20697: HA: during bootstrap motr ioservices have dependency on all confd m0d's
  Added cortx_message_bus service in the rules.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes - on three node VMs.
  </code>
</pre>
## Solution
<pre>
  <code>
    To implement constraint rules based on number of instances running of a resource, a mechanism is required to count the
    running instances. It was achieved by updating node level attributes using attrd_updater.
    A new HA service srv_counter is introduced for this purpose.
  </code>
</pre>

