### PR TITLE
EOS-20496: user group permissions fix

### DIFF
--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -282,6 +282,9 @@ class PostInstallCmd(Cmd):
             else:
                 Log.info("hacluster is a part of the haclient group")
             self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_HACLIENT}:rwx {const.RA_LOG_DIR}")
+            self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_ROOT}:rwx {const.RA_LOG_DIR}")
+            self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_HACLIENT}:r-x {const.CONFIG_DIR}")
+            self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_ROOT}:rwx {const.CONFIG_DIR}")
         except Exception as e:
             Log.error(f"Failed prerequisite with Error: {e}")
             raise HaPrerequisiteException("post_install command failed")

--- a/jenkins/rpm/v2/post_install_script.sh
+++ b/jenkins/rpm/v2/post_install_script.sh
@@ -1,7 +1,5 @@
 RES_AGENT="/usr/lib/ocf/resource.d/seagate"
 HA_INSTALL_DIR=/opt/seagate/cortx/ha
-CONFIG_DIR="/etc/cortx/ha"
-RA_LOG_DIR="/var/log/seagate/cortx/ha"
 BIN_DIR=${HA_INSTALL_DIR}/bin
 mkdir -p ${BIN_DIR} ${RES_AGENT}
 
@@ -38,9 +36,4 @@ ln -sf ${PCMK_ALERT} /usr/local/bin/pcmk_alert
 ln -sf ${PCMK_ALERT} /usr/bin/pcmk_alert
 
 chown -R root:root /opt/seagate/cortx/ha
-
-# give permissions to conf and log dir
-setfacl -R -m g:haclient:rwx ${RA_LOG_DIR}
-setfacl -R -m g:haclient:r-x ${CONFIG_DIR}
-
 exit 0


### PR DESCRIPTION
Signed-off-by: Amol Shinde <amol.shinde@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    https://jts.seagate.com/browse/EOS-20496
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Validate permissions for log & conf dirs - root user and ha_client user permissions
  </code>
</pre>
## Solution
<pre>
  <code>
    Validate permissions for log & conf dirs - root user and ha_client user permissions
    Add User and Permission validation
    R/W for log for root and other user
    R/W for conf for root
    R for conf for other user
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   [root@ssc-vm-c-0281 ~]# /opt/seagate/cortx/ha/bin/ha_setup post_install --config 'json:///root/cortx-ha/1nodevmconfig.json' --dev

    [root@ssc-vm-c-0281 ~]# getfacl /etc/cortx/ha
    getfacl: Removing leading '/' from absolute path names
    # file: etc/cortx/ha
    # owner: root
    # group: root
    user::rwx
    group::r-x
    group:root:rwx
    group:haclient:r-x
    mask::rwx
    other::r-x
    
    [root@ssc-vm-c-0281 ~]# getfacl /var/log/seagate/cortx/ha/
    getfacl: Removing leading '/' from absolute path names
    # file: var/log/seagate/cortx/ha/
    # owner: 730727
    # group: root
    user::rwx
    group::r-x
    group:root:rwx
    group:haclient:rwx
    mask::rwx
    other::r-x

  </code>
</pre>
