### PR TITLE
EOS-18250: Cluster Manager destroy cluster

### DIFF
--- a/ha/core/controllers/pcs/cluster_controller.py
+++ b/ha/core/controllers/pcs/cluster_controller.py
@@ -371,14 +371,14 @@ class PcsClusterController(ClusterController, PcsController):
     @controller_error_handler
     def destroy_cluster(self, retry_index: int = 0):
         if retry_index < const.CLUSTER_RETRY_COUNT and not self._is_pcs_cluster_running():
-            Log.warning('Cluster is not running, safe to destroy the cluster')
-            output = self._execute.run_cmd(const.PCS_CLUSTER_DESTROY)
+            Log.warn('Cluster is not running, safe to destroy the cluster')
+            output = self._execute.run_cmd(const.PCS_CLUSTER_DESTROY + ' --force')
             Log.error(f"Cluster destroyed. Output: {output}")
             return
         elif retry_index == 0:
             cluster_stop_response = self.stop()
             if cluster_stop_response:
-                Log.warning('Successfully stopped the cluster, destroying the cluster')
+                Log.warn('Successfully stopped the cluster, destroying the cluster')
                 if not self._is_pcs_cluster_running():
                     output = self._execute.run_cmd(const.PCS_CLUSTER_DESTROY)
                     Log.error(f"Cluster destroyed. Output: {output}")
@@ -386,4 +386,4 @@ class PcsClusterController(ClusterController, PcsController):
         Log.info('cluster is still running, wait for cluster to stop')
         time.sleep(const.BASE_WAIT_TIME)
         retry_index += 1
-        destroy_cluster(retry_index)
+        self.destroy_cluster(retry_index)

--- a/ha/core/controllers/pcs/cluster_controller.py
+++ b/ha/core/controllers/pcs/cluster_controller.py
@@ -369,11 +369,14 @@ class PcsClusterController(ClusterController, PcsController):
             raise ClusterManagerError(f"Failed to create cluster. Error: {e}")
 
     @controller_error_handler
-    def destroy_cluster(self, retry_index: int = 0):
+    def destroy_cluster(self, retry_index: int = 0, force=True):
         if retry_index < const.CLUSTER_RETRY_COUNT and not self._is_pcs_cluster_running():
             Log.warn('Cluster is not running, safe to destroy the cluster')
-            output = self._execute.run_cmd(const.PCS_CLUSTER_DESTROY + ' --force')
-            Log.error(f"Cluster destroyed. Output: {output}")
+            if force:
+                Log.warn('Executing cluster kill before destroy')
+                self._execute.run_cmd(const.PCS_CLUSTER_KILL)
+            output = self._execute.run_cmd(const.PCS_CLUSTER_DESTROY)
+            Log.error(f"Cluster is destroyed. Output: {output}")
             return
         elif retry_index == 0:
             cluster_stop_response = self.stop()

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -310,7 +310,6 @@ class ConfigCmd(Cmd):
         Init method.
         """
         super().__init__(args)
-        self._cluster_manager = CortxClusterManager(default_log_enable=False)
 
     def process(self):
         """
@@ -341,6 +340,7 @@ class ConfigCmd(Cmd):
         self._update_cluster_manager_config()
 
         # Update cluster and resources
+        self._cluster_manager = CortxClusterManager(default_log_enable=False)
         Log.info("Checking if cluster exists already")
         cluster_exists = bool(json.loads(self._cluster_manager.cluster_controller.cluster_exists()).get("msg"))
         Log.info(f"Cluster exists? {cluster_exists}")
@@ -671,7 +671,8 @@ class CleanupCmd(Cmd):
                 self._remove_node(node_name)
             else:
                 # Destroy
-                self._destroy_cluster(node_name)
+                self._cluster_manager.cluster_controller.destroy_cluster()
+                # self._destroy_cluster(node_name)
 
             if self._confstore.key_exists(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}"):
                 self._confstore.delete(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}")

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -310,6 +310,7 @@ class ConfigCmd(Cmd):
         Init method.
         """
         super().__init__(args)
+        self._cluster_manager = CortxClusterManager(default_log_enable=False)
 
     def process(self):
         """
@@ -340,7 +341,6 @@ class ConfigCmd(Cmd):
         self._update_cluster_manager_config()
 
         # Update cluster and resources
-        self._cluster_manager = CortxClusterManager(default_log_enable=False)
         Log.info("Checking if cluster exists already")
         cluster_exists = bool(json.loads(self._cluster_manager.cluster_controller.cluster_exists()).get("msg"))
         Log.info(f"Cluster exists? {cluster_exists}")
@@ -356,8 +356,9 @@ class ConfigCmd(Cmd):
                     self._confstore.set(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}")
                 except Exception as e:
                     Log.error(f"Cluster creation failed; destroying the cluster. Error: {e}")
-                    output = self._execute.run_cmd(const.PCS_CLUSTER_DESTROY)
-                    Log.error(f"Cluster destroyed. Output: {output}")
+                    # output = self._execute.run_cmd(const.PCS_CLUSTER_DESTROY)
+                    # Log.error(f"Cluster destroyed. Output: {output}")
+                    self._cluster_manager.cluster_controller.destroy_cluster()
                     # Delete the node from nodelist if it was added in the store
                     if self._confstore.key_exists(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}"):
                         self._confstore.delete(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}")


### PR DESCRIPTION
- Add interface to destroy the cluster in the cluster manager
- Use this interface in ha_setup to destroy the cluster in
  case of HA mini-provisioner error

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    https://jts.seagate.com/browse/EOS-18250
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  WIP
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Provide destroy cluster interface in cluster manager
  </code>
</pre>
## Solution
<pre>
  <code>
     - Provide stop interface in cluster controller 
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    WIP 
  </code>
</pre>
