### PR TITLE
Changes for EOS-21143 Not able to change delimiter in conf

### DIFF
--- a/ha/const.py
+++ b/ha/const.py
@@ -295,8 +295,8 @@ class EVENT_ATTRIBUTES:
 
 # Alert constants
 class AlertEventConstants(Enum):
-    ALERT_FILTER_TYPE = "alert.filter_type"
-    IEM_FILTER_TYPE = "iem.filter_type"
-    ALERT_RESOURCE_TYPE = "alert.resource_type"
-    IEM_COMPONENTS = "iem.components"
-    IEM_MODULES = "iem.modules"
+    ALERT_FILTER_TYPE = f"alert{_DELIM}filter_type"
+    IEM_FILTER_TYPE = f"iem{_DELIM}filter_type"
+    ALERT_RESOURCE_TYPE = f"alert{_DELIM}resource_type"
+    IEM_COMPONENTS = f"iem{_DELIM}components"
+    IEM_MODULES = f"iem{_DELIM}modules"

--- a/ha/core/event_analyzer/filter/filter.py
+++ b/ha/core/event_analyzer/filter/filter.py
@@ -25,7 +25,6 @@ from ha.core.config.config_manager import ConfigManager
 from ha.const import ALERT_ATTRIBUTES
 from ha.core.event_analyzer.event_analyzer_exceptions import EventFilterException
 from ha.core.event_analyzer.event_analyzer_exceptions import InvalidFilterRules
-from ha.const import _DELIM
 
 class MESSAGETYPE(Enum):
     ALERT = "ALERT"
@@ -76,10 +75,10 @@ class AlertFilter(Filter):
         Init method
         """
         super(AlertFilter, self).__init__()
-        AlertFilter.validate_filter(f"const{_DELIM}AlertEventConstants{_DELIM}ALERT_FILTER_TYPE{_DELIM}value")
+        AlertFilter.validate_filter(const.AlertEventConstants.ALERT_FILTER_TYPE.value)
         # Get filter type and resource types list from the alert rule file
-        self.filter_type = Conf.get(const.ALERT_FILTER_INDEX, f"const{_DELIM}AlertEventConstants{_DELIM}ALERT_FILTER_TYPE{_DELIM}value")
-        self.resource_types_list = Conf.get(const.ALERT_FILTER_INDEX, f"const{_DELIM}AlertEventConstants{_DELIM}ALERT_RESOURCE_TYPE{_DELIM}value")
+        self.filter_type = Conf.get(const.ALERT_FILTER_INDEX, const.AlertEventConstants.ALERT_FILTER_TYPE.value)
+        self.resource_types_list = Conf.get(const.ALERT_FILTER_INDEX, const.AlertEventConstants.ALERT_RESOURCE_TYPE.value)
         Log.info("Alert Filter is initialized ...")
 
     def filter_event(self, msg: str) -> bool:
@@ -121,11 +120,11 @@ class IEMFilter(Filter):
         Init method
         """
         super(IEMFilter, self).__init__()
-        IEMFilter.validate_filter(f"const{_DELIM}AlertEventConstants{_DELIM}IEM_FILTER_TYPE{_DELIM}value")
+        IEMFilter.validate_filter(const.AlertEventConstants.IEM_FILTER_TYPE.value)
         # Get filter type and resource types list from the IEM rule file
-        self.filter_type = Conf.get(const.ALERT_FILTER_INDEX, f"const{_DELIM}AlertEventConstants{_DELIM}IEM_FILTER_TYPE{_DELIM}value")
-        self.components_list = Conf.get(const.ALERT_FILTER_INDEX, f"const{_DELIM}AlertEventConstants{_DELIM}IEM_COMPONENTS{_DELIM}value")
-        self.modules_dict = Conf.get(const.ALERT_FILTER_INDEX, f"const{_DELIM}AlertEventConstants{_DELIM}IEM_MODULES{_DELIM}value")
+        self.filter_type = Conf.get(const.ALERT_FILTER_INDEX, const.AlertEventConstants.IEM_FILTER_TYPE.value)
+        self.components_list = Conf.get(const.ALERT_FILTER_INDEX, const.AlertEventConstants.IEM_COMPONENTS.value)
+        self.modules_dict = Conf.get(const.ALERT_FILTER_INDEX, const.AlertEventConstants.IEM_MODULES.value)
         Log.info("IEM Filter is initialized ...")
 
     def filter_event(self, msg: str) -> bool:


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
   In event_analyzer,  filter the delimiter '>' was not correctly being used to access the Confstore 
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
       In event_analyzer,  filter the delimiter '>' was not correctly being used to access the Confstore 
  </code>
</pre>
## Solution
<pre>
  <code>
     In event_analyzer,  filter the delimiter '>' was not correctly being used to access the Confstore 
     Corrected the code to use delimiter in the appropriate place 
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   Using a standalone file and code copied from filter.py, confirmed that the correct string is getting generated to fetch data from Confstore  
  </code>
</pre>
