### PR TITLE
EOS-19779: Corrected messsage consumer offset

### DIFF
--- a/ha/core/event_analyzer/watcher/watcher.py
+++ b/ha/core/event_analyzer/watcher/watcher.py
@@ -77,7 +77,7 @@ class Watcher(Thread):
         return MessageConsumer(consumer_id=str(self.consumer_id),
                                 consumer_group=self.consumer_group,
                                 message_types=[self.message_type],
-                                auto_ack=False, offset='latest')
+                                auto_ack=False, offset='earliest')
 
     def _get_message(self):
         """

--- a/ha/test/integration/event_analyzer/test_alert_receiver.py
+++ b/ha/test/integration/event_analyzer/test_alert_receiver.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     consumer = MessageConsumer(consumer_id="1",
                                 consumer_group='ha_event_analyzer',
                                 message_types=["alerts"],
-                                auto_ack=False, offset='latest')
+                                auto_ack=False, offset='earliest')
 
     while True:
         try:


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-19779
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Modify the kafka message consumer offset from 'latest' to 'earliest'
  </code>
</pre>
## Solution
<pre>
  <code>
    Modified the kafka message consumer offset from 'latest' to 'earliest'
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Applied this change on already deployed system and made sure that event analyzer is receiving messages.
  </code>
</pre>
