### PR TITLE
EOS-21436: Add stop constraints.

### DIFF
--- a/ha/resource/dynamic_fid_service_ra.py
+++ b/ha/resource/dynamic_fid_service_ra.py
@@ -72,7 +72,7 @@ class AttribUpdater:
     def del_attr(resource: str):
         try:
             executor = SimpleCommand()
-            executor.run_cmd(f"attrd_updater -D -n {resource}", check_error=False)
+            executor.run_cmd(f"attrd_updater -U 0 -n {resource}", check_error=False)
         except Exception as e:
             Log.error(f"Problem in deleting attr - resource: {resource}, Error: {e}")
 


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  EOS-21436: motr-confd service getting stopped before motr-ios while stopping the cluster.
  Remove deletion of attribute, instead set it to zero to check if timeout for srv_counter happens less frequently.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes. On 3-node VM.
  </code>
</pre>

