### PR TITLE
EOS-17922: Add hooks for pre and post disruptive upgrade routines

### DIFF
--- a/conf/mini_provisioner/v2/setup.yaml
+++ b/conf/mini_provisioner/v2/setup.yaml
@@ -37,6 +37,14 @@ ha:
     upgrade:
         cmd: /opt/seagate/cortx/ha/bin/ha_setup upgrade
         args: --config $URL
+        pre:
+            cmd: /opt/seagate/cortx/ha/bin/ha_setup pre_upgrade
+            args: --config $URL
+            when: {{ flow == 'upgrade-offline' }}
+        post:
+            cmd: /opt/seagate/cortx/ha/bin/ha_setup post_upgrade
+            args: --config $URL
+            when: {{ flow == 'upgrade-offline' }}
 
     reset:
         cmd: /opt/seagate/cortx/ha/bin/ha_setup reset

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -816,7 +816,6 @@ class PreUpgradeCmd(Cmd):
             if os.environ['PRVSNR_MINI_LEVEL'] == 'cluster':
                 Log.info("Performing pre disruptive upgrade routines on cluster \
                          level")
-                cluster_standby_mode()
                 delete_resources()
             else:
                 Log.info("Performing pre disruptive upgrade routines on node \

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -34,7 +34,7 @@ from ha.const import STATUSES
 from ha.setup.create_pacemaker_resources import create_all_resources
 from ha.setup.post_disruptive_upgrade import perform_post_upgrade
 from ha.setup.pre_disruptive_upgrade import (backup_configuration,
-                                             cluster_standby_mode, delete_resources)
+                                             delete_resources)
 from ha.core.cluster.cluster_manager import CortxClusterManager
 from ha.core.config.config_manager import ConfigManager
 from ha.remote_execution.ssh_communicator import SSHRemoteExecutor

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -33,6 +33,8 @@ from ha import const
 from ha.const import STATUSES
 from ha.setup.create_pacemaker_resources import create_all_resources
 from ha.setup.post_disruptive_upgrade import perform_post_upgrade
+from ha.setup.pre_disruptive_upgrade import (backup_configuration,
+                                             cluster_standby_mode, delete_resources)
 from ha.core.cluster.cluster_manager import CortxClusterManager
 from ha.core.config.config_manager import ConfigManager
 from ha.remote_execution.ssh_communicator import SSHRemoteExecutor
@@ -81,7 +83,7 @@ class Cmd:
         sys.stderr.write(
             f"usage: {prog} [-h] <cmd> <--config url> <args>...\n"
             f"where:\n"
-            f"cmd   post_install, prepare, config, init, test, upgrade, reset, cleanup, backup, restore\n"
+            f"cmd   post_install, prepare, config, init, test, upgrade, reset, cleanup, backup, restore, pre_upgrade, post_upgrade\n"
             f"--config   Config URL")
 
     @staticmethod
@@ -609,14 +611,11 @@ class UpgradeCmd(Cmd):
         Init method.
         """
         super().__init__(args)
-        machine_id = self.get_machine_id()
-        self.s3_instance = UpgradeCmd.get_s3_instance(machine_id)
 
     def process(self):
         """
         Process upgrade command.
         """
-        perform_post_upgrade(self.s3_instance)
 
 class ResetCmd(Cmd):
     """
@@ -790,6 +789,69 @@ class RestoreCmd(Cmd):
         Process restore command.
         """
         pass # TBD
+
+
+class PreUpgradeCmd(Cmd):
+    """
+    Pre-Upgrade Cmd
+    """
+    name = "pre_upgrade"
+
+    def __init__(self, args):
+        """
+        Init method.
+        """
+        super().__init__(args)
+
+    def process(self):
+        """
+        Process command.
+
+        NOTE: Consul is not expected to be upgraded, so no need to backup
+        consul config
+        Configuration backup is performed for every node while pacemaker setup
+        only on one node (cluster level).
+        """
+        try:
+            if os.environ['PRVSNR_MINI_LEVEL'] == 'cluster':
+                Log.info("Performing pre disruptive upgrade routines on cluster \
+                         level")
+                cluster_standby_mode()
+                delete_resources()
+            else:
+                Log.info("Performing pre disruptive upgrade routines on node \
+                         level")
+                backup_configuration()
+        except Exception as err:
+            raise SetupError("Pre-upgrade routines failed") from err
+
+
+class PostUpgradeCmd(Cmd):
+    """
+    Post-Upgrade Cmd
+    """
+    name = "post_upgrade"
+
+    def __init__(self, args):
+        """
+        Init method.
+        """
+        super().__init__(args)
+        machine_id = self.get_machine_id()
+        self.s3_instance = UpgradeCmd.get_s3_instance(machine_id)
+
+    def process(self):
+        """
+        Process command.
+        """
+        try:
+            if os.environ['PRVSNR_MINI_LEVEL'] == 'cluster':
+                Log.info("Performing post disruptive upgrade routines on cluster \
+                         level")
+                perform_post_upgrade(self.s3_instance)
+        except Exception as err:
+            raise SetupError("Post-upgrade routines failed") from err
+
 
 def main(argv: list):
     try:

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -847,7 +847,7 @@ class PostUpgradeCmd(Cmd):
             if os.environ['PRVSNR_MINI_LEVEL'] == 'cluster':
                 Log.info("Performing post disruptive upgrade routines on cluster \
                          level")
-                perform_post_upgrade(self.s3_instance)
+                perform_post_upgrade(self.s3_instance, do_unstandby=False)
         except Exception as err:
             raise SetupError("Post-upgrade routines failed") from err
 

--- a/ha/setup/post_disruptive_upgrade.py
+++ b/ha/setup/post_disruptive_upgrade.py
@@ -153,11 +153,12 @@ def _unstandby_cluster() -> None:
     _switch_cluster_mode(PCS_CLUSTER_UNSTANDBY)
     Log.info('### cluster is up and running ###')
 
-def perform_post_upgrade(s3_instances=None):
+def perform_post_upgrade(s3_instances=None, do_unstandby=False):
     '''Starting routine for post-upgrade process'''
     Log.init(service_name="post_disruptive_upgrade", log_path=RA_LOG_DIR, level="INFO")
     _check_for_any_resource_presence()
     _is_cluster_standby_on()
     _load_config()
     _create_resources(s3_instances)
-    _unstandby_cluster()
+    if do_unstandby:
+        _unstandby_cluster()


### PR DESCRIPTION


## Problem Statement
<pre>
  <code>
  Story Ref (if any):
  EOS-17922
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
No pre-disruptive upgrade hooks implemented.
  </code>
</pre>
## Solution
<pre>
  <code>
Provisioner setup.yaml format supports configurable pre and post hooks
for upgrade procedure.
Respective commands were added to HA mini provisioner.
So, perform_post_upgrade was moved from `upgrade` command to new
`post_upgrade` command.

Cluster-related changes in pacemaker are done only when mini-provisioner
is invoked on cluster level (provisioner env variables are being
checked).
Configuration backup is done on every node (node level).
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
This code requires QA testing with upgrade scenario.
Provisioner commands can be used to verify which commands will be invoked for each level.
See: https://github.com/Seagate/cortx-prvsnr/blob/pre-cortx-1.0/docs/mini_prvsnr_api.md#mini-provisioner-commands
  </code>
</pre>
