### PR TITLE
EOS-21080: 3N VM-Deployment Failed in HA for the build Main#1268

### DIFF
--- a/ha/cli/cortxha.py
+++ b/ha/cli/cortxha.py
@@ -25,6 +25,7 @@ def main(argv):
     Entry point for cortx CLI
     """
     from ha.cli.commands import Command
+    #sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..'))
     try:
         command = Command()
         command.process(argv[1:])

--- a/ha/cli/cortxha.py
+++ b/ha/cli/cortxha.py
@@ -25,7 +25,6 @@ def main(argv):
     Entry point for cortx CLI
     """
     from ha.cli.commands import Command
-    #sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..'))
     try:
         command = Command()
         command.process(argv[1:])

--- a/ha/core/controllers/pcs/cluster_controller.py
+++ b/ha/core/controllers/pcs/cluster_controller.py
@@ -52,33 +52,19 @@ class PcsClusterController(ClusterController, PcsController):
             return False
         return True
 
-    def wait_for_node_online(self, nodeid: str, instru=False) -> bool:
+    def wait_for_node_online(self, nodeid: str) -> bool:
         """
         Wait till the node becomes online
         """
-        #print("In wait_for_node_online ..")
-        if instru:
-            # Even with this retry count node is coming online.
-            # so instead simulating failure 
-            # retry_count = 1
-            #wait_time = 1
-            Log.info(f"Node {nodeid} failure simulated ")
-            return False
-        else:
-            retry_count =  const.CLUSTER_RETRY_COUNT
-            wait_time = const.BASE_WAIT_TIME
 
-        for retry_index in range(0, retry_count):
+        for retry_index in range(0, const.CLUSTER_RETRY_COUNT):
             node_status = self.nodes_status([nodeid]).get(nodeid)
-            #print("Node status: ", node_status)  
             if node_status == const.NODE_STATUSES.ONLINE.value:
                 Log.info(f"Node {nodeid} is online.")
-                print("Node is online")
                 return True
             # Sleep for some time and try again.
             Log.info(f"Node {nodeid} is not online, retry index #{retry_index}")
-            print("Node not online, retry index ", retry_index)  
-            time.sleep(wait_time)
+            time.sleep(const.BASE_WAIT_TIME)
         return False
 
     def _pcs_cluster_start(self):

--- a/ha/core/controllers/pcs/cluster_controller.py
+++ b/ha/core/controllers/pcs/cluster_controller.py
@@ -52,12 +52,19 @@ class PcsClusterController(ClusterController, PcsController):
             return False
         return True
 
-    def wait_for_node_online(self, nodeid: str) -> bool:
+    def wait_for_node_online(self, nodeid: str, instru=False) -> bool:
         """
         Wait till the node becomes online
         """
         #print("In wait_for_node_online ..")
-        for retry_index in range(0, const.CLUSTER_RETRY_COUNT):
+        if instru:
+            retry_count = 1
+            wait_time = 1
+        else:
+            retry_count =  const.CLUSTER_RETRY_COUNT
+            wait_time = const.BASE_WAIT_TIME
+
+        for retry_index in range(0, retry_count):
             node_status = self.nodes_status([nodeid]).get(nodeid)
             #print("Node status: ", node_status)  
             if node_status == const.NODE_STATUSES.ONLINE.value:
@@ -67,7 +74,7 @@ class PcsClusterController(ClusterController, PcsController):
             # Sleep for some time and try again.
             Log.info(f"Node {nodeid} is not online, retry index #{retry_index}")
             print("Node not online, retry index ", retry_index)  
-            time.sleep(const.BASE_WAIT_TIME)
+            time.sleep(wait_time)
         return False
 
     def _pcs_cluster_start(self):

--- a/ha/core/controllers/pcs/cluster_controller.py
+++ b/ha/core/controllers/pcs/cluster_controller.py
@@ -58,8 +58,12 @@ class PcsClusterController(ClusterController, PcsController):
         """
         #print("In wait_for_node_online ..")
         if instru:
-            retry_count = 1
-            wait_time = 1
+            # Even with this retry count node is coming online.
+            # so instead simulating failure 
+            # retry_count = 1
+            #wait_time = 1
+            Log.info(f"Node {nodeid} failure simulated ")
+            return False
         else:
             retry_count =  const.CLUSTER_RETRY_COUNT
             wait_time = const.BASE_WAIT_TIME

--- a/ha/core/controllers/pcs/cluster_controller.py
+++ b/ha/core/controllers/pcs/cluster_controller.py
@@ -52,17 +52,21 @@ class PcsClusterController(ClusterController, PcsController):
             return False
         return True
 
-    def _wait_for_node_online(self, nodeid: str) -> bool:
+    def wait_for_node_online(self, nodeid: str) -> bool:
         """
         Wait till the node becomes online
         """
+        #print("In wait_for_node_online ..")
         for retry_index in range(0, const.CLUSTER_RETRY_COUNT):
             node_status = self.nodes_status([nodeid]).get(nodeid)
+            #print("Node status: ", node_status)  
             if node_status == const.NODE_STATUSES.ONLINE.value:
                 Log.info(f"Node {nodeid} is online.")
+                print("Node is online")
                 return True
             # Sleep for some time and try again.
             Log.info(f"Node {nodeid} is not online, retry index #{retry_index}")
+            print("Node not online, retry index ", retry_index)  
             time.sleep(const.BASE_WAIT_TIME)
         return False
 
@@ -307,7 +311,7 @@ class PcsClusterController(ClusterController, PcsController):
         cluster_node_count = self._get_cluster_size()
         if cluster_node_count < 32:
             _output, _err, _rc = self._execute.run_cmd(const.PCS_CLUSTER_NODE_ADD.replace("<node>", nodeid))
-            if self._wait_for_node_online(nodeid):
+            if self.wait_for_node_online(nodeid):
                 return {"status": const.STATUSES.SUCCEEDED.value, "msg": f"Node {nodeid} added successfully in the cluster"}
             else:
                 return {"status": const.STATUSES.FAILED.value, "msg": f"Node {nodeid} add operation failed, node not online"}
@@ -356,7 +360,7 @@ class PcsClusterController(ClusterController, PcsController):
                 Log.info("Node started and enabled successfully.")
                 time.sleep(const.BASE_WAIT_TIME * 2)
             if self._is_pcs_cluster_running():
-                if self._wait_for_node_online(nodeid):
+                if self.wait_for_node_online(nodeid):
                     # TODO: Divide class into vm, hw when stonith is needed.
                     self._execute.run_cmd(const.PCS_STONITH_DISABLE)
                     return {"status": const.STATUSES.SUCCEEDED.value,

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -435,7 +435,7 @@ class ConfigCmd(Cmd):
             #print(f"Executing command  {add_node_cli} ")
             self._execute.run_cmd(add_node_cli, check_error=False, secret=cluster_secret)
             #print(f"Running wait_for_node_online ")
-            node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name)
+            node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name, True)
             # Node is expected to be Online when it is added
             # Nodes are added to the cluster during cluster creation only
             # scaleout to be implemented later
@@ -473,7 +473,7 @@ class ConfigCmd(Cmd):
                         .replace("<user>", cluster_user).replace("<secret>", "'" + cluster_secret + "'"),
                         secret=cluster_secret)
 
-                    node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name)
+                    node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name, True)
                     # Node is expected to be Online when it is added
                     # Nodes are added to the cluster during cluster creation only
                     # scaleout to be implemented later

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -432,7 +432,7 @@ class ConfigCmd(Cmd):
             # Nodes are added to the cluster during cluster creation
             # Node is expected to be Online when it is added
             if node_status != True:
-                raise Exception
+                raise HaConfigException(f"Node {node_name} did not come online; Add node failed")
 
             self.standby_node(node_name)
             self._confstore.set(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}")
@@ -465,7 +465,7 @@ class ConfigCmd(Cmd):
                     # Nodes are added to the cluster during cluster creation
                     # Node is expected to be Online when it is added
                     if node_status != True:
-                        raise Exception
+                        raise HaConfigException(f"Node {node_name} did not come online; Add node failed")
 
                     self.standby_node(node_name)
                     self._confstore.set(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}")

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -447,7 +447,6 @@ class ConfigCmd(Cmd):
             raise HaConfigException(f"Adding {node_name} failed")
 
     def _add_node_remotely(self, node_name: str, cluster_user: str, cluster_secret: str):
-
         try:
             if self._confstore.key_exists(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}"):
                 Log.info(f"The node already {node_name} present in the cluster.")
@@ -462,7 +461,6 @@ class ConfigCmd(Cmd):
                     remote_executor.execute(const.CORTX_CLUSTER_NODE_ADD.replace("<node>", node_name)
                         .replace("<user>", cluster_user).replace("<secret>", "'" + cluster_secret + "'"),
                         secret=cluster_secret)
-
                     node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name)
                     # Nodes are added to the cluster during cluster creation
                     # Node is expected to be Online when it is added

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -371,6 +371,10 @@ class ConfigCmd(Cmd):
                 # Add node with SSH
                 self._add_node_remotely(node_name, cluster_user, cluster_secret)
         else:
+            #print(nodelist)
+            #print("adding node to the above list")
+            #nodelist.append("ssc-vm-5467.colo.seagate.com")
+            #print(nodelist)
             for node in nodelist:
                 if node != node_name:
                     Log.info(f"Adding node {node} to Cluster {cluster_name}")
@@ -421,13 +425,24 @@ class ConfigCmd(Cmd):
             cluster_user (str): HA user
             cluster_secret (str): Ha user password
         """
+        print(f"Adding node {node_name} to cluster")
         try:
             if self._confstore.key_exists(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}"):
                 Log.info(f"The node already {node_name} present in the cluster.")
                 return
             add_node_cli = const.CORTX_CLUSTER_NODE_ADD.replace("<node>", node_name)\
                 .replace("<user>", cluster_user).replace("<secret>", cluster_secret)
+            #print(f"Executing command  {add_node_cli} ")
             self._execute.run_cmd(add_node_cli, check_error=False, secret=cluster_secret)
+            #print(f"Running wait_for_node_online ")
+            node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name)
+            # Node is expected to be Online when it is added
+            # Nodes are added to the cluster during cluster creation only
+            # scaleout to be implemented later
+            print("node status ", node_status)
+            if node_status != True:
+                raise Exception
+
             self.standby_node(node_name)
             self._confstore.set(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}")
             Log.info(f"The node {node_name} added in the existing cluster.")
@@ -441,6 +456,8 @@ class ConfigCmd(Cmd):
             raise HaConfigException(f"Adding {node_name} failed")
 
     def _add_node_remotely(self, node_name: str, cluster_user: str, cluster_secret: str):
+
+        print(f"Adding remote node {node_name} to cluster")
         try:
             if self._confstore.key_exists(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}"):
                 Log.info(f"The node already {node_name} present in the cluster.")
@@ -455,6 +472,15 @@ class ConfigCmd(Cmd):
                     remote_executor.execute(const.CORTX_CLUSTER_NODE_ADD.replace("<node>", node_name)
                         .replace("<user>", cluster_user).replace("<secret>", "'" + cluster_secret + "'"),
                         secret=cluster_secret)
+
+                    node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name)
+                    # Node is expected to be Online when it is added
+                    # Nodes are added to the cluster during cluster creation only
+                    # scaleout to be implemented later
+                    print("node status ", node_status)
+                    if node_status != True:
+                        raise Exception
+
                     self.standby_node(node_name)
                     self._confstore.set(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}")
                     Log.info(f"Added new node: {node_name} using {remote_node}")

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -371,10 +371,6 @@ class ConfigCmd(Cmd):
                 # Add node with SSH
                 self._add_node_remotely(node_name, cluster_user, cluster_secret)
         else:
-            #print(nodelist)
-            #print("adding node to the above list")
-            #nodelist.append("ssc-vm-5467.colo.seagate.com")
-            #print(nodelist)
             for node in nodelist:
                 if node != node_name:
                     Log.info(f"Adding node {node} to Cluster {cluster_name}")
@@ -425,21 +421,16 @@ class ConfigCmd(Cmd):
             cluster_user (str): HA user
             cluster_secret (str): Ha user password
         """
-        print(f"Adding node {node_name} to cluster")
         try:
             if self._confstore.key_exists(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}"):
                 Log.info(f"The node already {node_name} present in the cluster.")
                 return
             add_node_cli = const.CORTX_CLUSTER_NODE_ADD.replace("<node>", node_name)\
                 .replace("<user>", cluster_user).replace("<secret>", cluster_secret)
-            #print(f"Executing command  {add_node_cli} ")
             self._execute.run_cmd(add_node_cli, check_error=False, secret=cluster_secret)
-            #print(f"Running wait_for_node_online ")
-            node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name, True)
+            node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name)
+            # Nodes are added to the cluster during cluster creation
             # Node is expected to be Online when it is added
-            # Nodes are added to the cluster during cluster creation only
-            # scaleout to be implemented later
-            print("node status ", node_status)
             if node_status != True:
                 raise Exception
 
@@ -457,7 +448,6 @@ class ConfigCmd(Cmd):
 
     def _add_node_remotely(self, node_name: str, cluster_user: str, cluster_secret: str):
 
-        print(f"Adding remote node {node_name} to cluster")
         try:
             if self._confstore.key_exists(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}"):
                 Log.info(f"The node already {node_name} present in the cluster.")
@@ -473,11 +463,9 @@ class ConfigCmd(Cmd):
                         .replace("<user>", cluster_user).replace("<secret>", "'" + cluster_secret + "'"),
                         secret=cluster_secret)
 
-                    node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name, True)
+                    node_status =  self._cluster_manager.cluster_controller.wait_for_node_online(node_name)
+                    # Nodes are added to the cluster during cluster creation
                     # Node is expected to be Online when it is added
-                    # Nodes are added to the cluster during cluster creation only
-                    # scaleout to be implemented later
-                    print("node status ", node_status)
                     if node_status != True:
                         raise Exception
 


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
     3N VM-Deployment Failed in HA 
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
     3N VM-Deployment Failed in HA . Possible cause is one/more of the nodes that were getting added in the cluster during cluster creation did not come online  before further steps in ha_setup config phase were carried out 
  </code>
</pre>
## Solution
<pre>
  <code>
    Added check in _add_node, _add_node_remotely  to wait for the node to come online before proceeding
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   - On 3 node VM deployment confirmed that in happy path cluster deployment is successful
   - Instrumented code added to cause failure. i.e node status does not change to Online after addition. Confirmed that exception raised in this case and node not added to cluster 
  </code>
</pre>
