### PR TITLE
EOS-20855: Mini-provisioner cleanup command fails if node is in standby

### DIFF
--- a/ha/const.py
+++ b/ha/const.py
@@ -57,6 +57,8 @@ COMPONENTS_CONFIG_DIR = "{}/components".format(CONFIG_DIR)
 SOURCE_HEALTH_HIERARCHY_FILE = "{}/system_health_hierarchy.json".format(SOURCE_CONFIG_PATH)
 HEALTH_HIERARCHY_FILE = "{}/system_health_hierarchy.json".format(CONFIG_DIR)
 IEM_SCHEMA="{}/iem_ha.json".format(CONFIG_DIR)
+SOURCE_LOGROTATE_CONF_FILE = "{}/conf/logrotate/cortx_ha_log.conf".format(SOURCE_PATH)
+LOGROTATE_CONF_DIR="/etc/logrotate.d"
 
 # IEM DESCRIPTION string: To be removed
 IEM_DESCRIPTION="WS0080010001,Node, The cluster has lost $host server. System is running in degraded mode. For more information refer the Troubleshooting guide. Extra Info: host=$host; status=$status;"

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -146,8 +146,11 @@ class Cmd:
             source (str): [description]
             dest (str): [description]
         """
-        Cmd.remove_file(dest)
-        shutil.copyfile(source, dest)
+        if os.path.isdir(dest):
+            shutil.copy(source, dest)
+        else:
+            Cmd.remove_file(dest)
+            shutil.copyfile(source, dest)
 
     def get_machine_id(self):
         command = "cat /etc/machine-id"
@@ -313,6 +316,7 @@ class PostInstallCmd(Cmd):
             PostInstallCmd.copy_file(const.SOURCE_SERVICE_FILE, const.SYSTEM_SERVICE_FILE)
             PostInstallCmd.copy_file(const.SOURCE_HEALTH_HIERARCHY_FILE, const.HEALTH_HIERARCHY_FILE)
             PostInstallCmd.copy_file(const.SOURCE_IEM_SCHEMA_PATH, const.IEM_SCHEMA)
+            PostInstallCmd.copy_file(const.SOURCE_LOGROTATE_CONF_FILE, const.LOGROTATE_CONF_DIR)
             self._execute.run_cmd("systemctl daemon-reload")
             Log.info(f"{self.name}: Copied HA configs file.")
             # Pre-requisite checks are done here.
@@ -826,6 +830,18 @@ class CleanupCmd(Cmd):
                 self._confstore.delete(f"{const.PVTFQDN_TO_NODEID_KEY}/{node_name}")
             # Delete the config file
             self.remove_config_files()
+
+            os.makedirs(const.CONFIG_DIR, exist_ok=True)
+            # Create a directory and copy config file
+            PostInstallCmd.copy_file(const.SOURCE_CONFIG_FILE, const.HA_CONFIG_FILE)
+            PostInstallCmd.copy_file(f"{const.SOURCE_CONFIG_PATH}/{const.CM_CONTROLLER_INDEX}.json",
+                            const.CM_CONTROLLER_SCHEMA)
+            PostInstallCmd.copy_file(const.SOURCE_ALERT_FILTER_RULES_FILE, const.ALERT_FILTER_RULES_FILE)
+            PostInstallCmd.copy_file(const.SOURCE_ALERT_EVENT_RULES_FILE, const.ALERT_EVENT_RULES_FILE)
+            PostInstallCmd.copy_file(const.SOURCE_CLI_SCHEMA_FILE, const.CLI_SCHEMA_FILE)
+            PostInstallCmd.copy_file(const.SOURCE_SERVICE_FILE, const.SYSTEM_SERVICE_FILE)
+            PostInstallCmd.copy_file(const.SOURCE_HEALTH_HIERARCHY_FILE, const.HEALTH_HIERARCHY_FILE)
+            PostInstallCmd.copy_file(const.SOURCE_IEM_SCHEMA_PATH, const.IEM_SCHEMA)
         except Exception as e:
             Log.error(f"Cluster cleanup command failed. Error: {e}")
             raise HaCleanupException("Cluster cleanup failed")


### PR DESCRIPTION
Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any): EOS-20855
    Your Problem statement here...
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    1. Copy config files which are deleted in cleanup phase
    2. Copy "cortx_ha_log.conf" file under " /etc/logrotate.d/" directory.
  </code>
</pre>
## Solution
<pre>
  <code>
    Copied config files which are deleted in cleanup phase
    Copied "cortx_ha_log.conf" file under " /etc/logrotate.d/" directory.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Tested & confirmed that after "cleanup" all config files are again copied and " /etc/logrotate.d/cortx_ha_log.conf" created after post_install command.
    
  </code>
</pre>
