### PR TITLE
EOS-20855:Mini-provisioner cleanup command fails if node is in standby

### DIFF
--- a/ha/const.py
+++ b/ha/const.py
@@ -60,6 +60,8 @@ COMPONENTS_CONFIG_DIR = "{}/components".format(CONFIG_DIR)
 SOURCE_HEALTH_HIERARCHY_FILE = "{}/system_health_hierarchy.json".format(SOURCE_CONFIG_PATH)
 HEALTH_HIERARCHY_FILE = "{}/system_health_hierarchy.json".format(CONFIG_DIR)
 IEM_SCHEMA="{}/iem_ha.json".format(CONFIG_DIR)
+SOURCE_LOGROTATE_CONF_FILE = "{}/conf/logrotate/cortx_ha_log.conf".format(SOURCE_PATH)
+LOGROTATE_CONF_DIR="/etc/logrotate.d"
 
 # IEM DESCRIPTION string: To be removed
 IEM_DESCRIPTION="WS0080010001,Node, The cluster has lost $host server. System is running in degraded mode. For more information refer the Troubleshooting guide. Extra Info: host=$host; status=$status;"

--- a/ha/const.py
+++ b/ha/const.py
@@ -308,3 +308,6 @@ class CLUSTER_STATUS(Enum):
     DEGRADED = "degraded"
     UNHEALTHY = "unhealthy"
     ONLINE = "online"
+
+class MINI_PROVISION_CMD(Enum):
+    POST_INSTALL = "post_install"

--- a/ha/const.py
+++ b/ha/const.py
@@ -309,5 +309,3 @@ class CLUSTER_STATUS(Enum):
     UNHEALTHY = "unhealthy"
     ONLINE = "online"
 
-class MINI_PROVISION_CMD(Enum):
-    POST_INSTALL = "post_install"

--- a/ha/const.py
+++ b/ha/const.py
@@ -308,4 +308,3 @@ class CLUSTER_STATUS(Enum):
     DEGRADED = "degraded"
     UNHEALTHY = "unhealthy"
     ONLINE = "online"
-

--- a/ha/core/cluster/cluster_manager.py
+++ b/ha/core/cluster/cluster_manager.py
@@ -303,6 +303,38 @@ class CortxClusterManager:
             # Find more example in test case.
             self.__dict__[controller] = self._controllers[controller]
 
+    def _validate_permissions(self) -> None:
+
+        # confirm that user is root or part of haclient group"
+
+        user = getpass.getuser()
+        group_id = os.getgid()
+
+        try:
+            # find group id for root and haclient
+            id_ha = grp.getgrnam(const.USER_GROUP_HACLIENT)
+            id_root = grp.getgrnam(const.USER_GROUP_ROOT)
+
+            # if group not root or haclient return error
+            if group_id != id_ha.gr_gid and group_id != id_root.gr_gid:
+                Log.error(f"User {user} does not have necessary permissions to execute this CLI")
+                raise HAInvalidPermission(
+                            f"User {user} does not have necessary permissions to execute this CLI")
+
+            # The user name "hauser"; which is part of the "haclient" group;
+            # is used by HA.
+            # internal commands are allowed only if the user is "hauser"
+            # As of now, every HA CLI will be internal command. So, we
+            # do not need this change. We can revisit this if needed in future
+            #if user == const.USER_HA_INTERNAL:
+            #    self._is_hauser = True
+
+
+        # TBD : If required raise seperate exception  for root and haclient
+        except KeyError:
+            Log.error("root / haclient group is not present on the system")
+            raise HAInvalidPermission("root / haclient group is not present on the system")
+
     @property
     def controller_list(self) -> list:
         """

--- a/ha/core/controllers/pcs/node_controller.py
+++ b/ha/core/controllers/pcs/node_controller.py
@@ -129,7 +129,7 @@ class PcsNodeController(NodeController, PcsController):
                     resource to stop, {nodeid} standby is in progress", "error": ""}
         else:
             return {"status": const.STATUSES.FAILED.value, "output": "",
-                    "error": f"Failed to put node in standby as node is in {node_status}"}     
+                    "error": f"Failed to put node in standby as node is in {node_status}"}
 
     @controller_error_handler
     def active(self, nodeid: str) -> dict:

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -861,8 +861,8 @@ class CleanupCmd(Cmd):
                 self._confstore.delete(f"{const.PVTFQDN_TO_NODEID_KEY}/{node_name}")
             # Delete the config file
             self.remove_config_files()
-            if CleanupCmd.PRE_FACTORY_CHECK is True:
-                Log.info("Post_install being called from cleanup command which takes system back to pre-factory stage")
+            if CleanupCmd.PRE_FACTORY_CHECK is not True:
+                Log.info("Post_install being called from cleanup command")
                 self._execute.run_cmd(f"ha_setup {MINI_PROVISION_CMD.POST_INSTALL.value} --config {self._url}")
 
         except Exception as e:

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -149,11 +149,7 @@ class Cmd:
             source (str): [description]
             dest (str): [description]
         """
-        if os.path.isdir(dest):
-            shutil.copy(source, dest)
-        else:
-            Cmd.remove_file(dest)
-            shutil.copyfile(source, dest)
+        shutil.copy(source, dest)
 
     def get_machine_id(self):
         command = "cat /etc/machine-id"
@@ -862,17 +858,9 @@ class CleanupCmd(Cmd):
             # Delete the config file
             self.remove_config_files()
 
-            os.makedirs(const.CONFIG_DIR, exist_ok=True)
-            # Create a directory and copy config file
-            PostInstallCmd.copy_file(const.SOURCE_CONFIG_FILE, const.HA_CONFIG_FILE)
-            PostInstallCmd.copy_file(f"{const.SOURCE_CONFIG_PATH}/{const.CM_CONTROLLER_INDEX}.json",
-                            const.CM_CONTROLLER_SCHEMA)
-            PostInstallCmd.copy_file(const.SOURCE_ALERT_FILTER_RULES_FILE, const.ALERT_FILTER_RULES_FILE)
-            PostInstallCmd.copy_file(const.SOURCE_ALERT_EVENT_RULES_FILE, const.ALERT_EVENT_RULES_FILE)
-            PostInstallCmd.copy_file(const.SOURCE_CLI_SCHEMA_FILE, const.CLI_SCHEMA_FILE)
-            PostInstallCmd.copy_file(const.SOURCE_SERVICE_FILE, const.SYSTEM_SERVICE_FILE)
-            PostInstallCmd.copy_file(const.SOURCE_HEALTH_HIERARCHY_FILE, const.HEALTH_HIERARCHY_FILE)
-            PostInstallCmd.copy_file(const.SOURCE_IEM_SCHEMA_PATH, const.IEM_SCHEMA)
+            Log.info("Post_install being called from cleanup command")
+            PostInstallCmd.process(self)
+
         except Exception as e:
             Log.error(f"Cluster cleanup command failed. Error: {e}")
             raise HaCleanupException("Cluster cleanup failed")

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -841,7 +841,6 @@ class CleanupCmd(Cmd):
             node_count: int = 0 if nodes is None else len(nodes)
             node_name = self.get_node_name()
             # Standby
-            # TODO: handle multiple case for standby EOS-20855
             standby_output: str = self._cluster_manager.node_controller.standby(node_name)
             if json.loads(standby_output).get("status") == STATUSES.FAILED.value:
                 Log.warn(f"Standby for {node_name} failed with output: {standby_output}."

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -304,12 +304,12 @@ class Cmd:
             node_count: int = len(Conf.get(self._index, "server_node"))
             if ConfigCmd.DEV_CHECK == True or node_count < 2:
                 return mgmt_info
-            mgmt_info["mgmt_vip"] = Conf.get(self._index, f"cluster.{cluster_id}.network.management.virtual_host")
-            netmask = Conf.get(self._index, f"server_node.{machine_id}.network.management.netmask")
+            mgmt_info["mgmt_vip"] = Conf.get(self._index, f"cluster{_DELIM}{cluster_id}{_DELIM}network{_DELIM}management{_DELIM}virtual_host")
+            netmask = Conf.get(self._index, f"server_node{_DELIM}{machine_id}{_DELIM}network{_DELIM}management{_DELIM}netmask")
             if netmask is None:
                 raise HaConfigException("Detected invalid netmask, It should not be empty.")
             mgmt_info["mgmt_netmask"] = sum(bin(int(x)).count('1') for x in netmask.split('.'))
-            mgmt_info["mgmt_iface"] = Conf.get(self._index, f"server_node.{machine_id}.network.management.interfaces")[0]
+            mgmt_info["mgmt_iface"] = Conf.get(self._index, f"server_node{_DELIM}{machine_id}{_DELIM}network{_DELIM}management{_DELIM}interfaces")[0]
             Log.info(f"Mgmt vip configuration: {str(mgmt_info)}")
             return mgmt_info
         except Exception as e:

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -830,7 +830,7 @@ class CleanupCmd(Cmd):
         super().__init__(args)
         # TODO: cluster_manager fails if cleanup run multiple time EOS-20947
         self._cluster_manager = CortxClusterManager(default_log_enable=False)
-        self._post_install = PostInstallCmd(args=None)
+        self._post_install_cmd = PostInstallCmd(args=None)
 
     def process(self):
         """
@@ -864,7 +864,7 @@ class CleanupCmd(Cmd):
             self.remove_config_files()
             if CleanupCmd.PRE_FACTORY_CHECK is not True:
                 Log.info("Post_install being called from cleanup command")
-                self._post_install.process()
+                self._post_install_cmd.process()
 
         except Exception as e:
             Log.error(f"Cluster cleanup command failed. Error: {e}")


### PR DESCRIPTION
Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any): EOS-20855
    F-97D - Cluster: Factory Reset: Pre-Factory
    Your Problem statement here...
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    1. F-97D - Cluster: Factory Reset: Pre-Factory
    2. Copy "cortx_ha_log.conf" file under " /etc/logrotate.d/" directory.
  </code>
</pre>
## Solution
<pre>
  <code> 
    system back to pre-factory stages when --pre-factory option is used with cleanup command
    Copied "cortx_ha_log.conf" file under " /etc/logrotate.d/" directory.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Tested & confirmed that " /etc/logrotate.d/cortx_ha_log.conf" created after post_install command.
    and cleanup works fine with --pre-factory option.
  </code>
</pre>
