### PR TITLE
EOS-22198: stopping/killing s3server causing restart of ioservice on …

### DIFF
--- a/ha/setup/create_pacemaker_resources.py
+++ b/ha/setup/create_pacemaker_resources.py
@@ -199,7 +199,7 @@ def motr(cib_xml, push=False, **kwargs):
                     not_defined {RESOURCE.MOTR_CONFD.value}-count or {RESOURCE.MOTR_CONFD.value}-count lt integer {quorum_size}")
             process.run_cmd(f"pcs -f {cib_xml} constraint order {RESOURCE.HAX.value}-clone then {RESOURCE.MOTR_IOS.value}-{i}-clone")
             process.run_cmd(f"pcs -f {cib_xml} constraint colocation add {RESOURCE.MOTR_IOS.value}-{i}-clone with {RESOURCE.HAX.value}-clone")
-            process.run_cmd(f"pcs -f {cib_xml} constraint order stop {RESOURCE.MOTR_IOS.value}-{i}-clone then stop {RESOURCE.MOTR_CONFD.value}-1-clone")
+            process.run_cmd(f"pcs -f {cib_xml} constraint order stop {RESOURCE.MOTR_IOS.value}-{i}-clone then stop {RESOURCE.MOTR_CONFD.value}-1-clone kind=Optional")
         except Exception as e:
             raise CreateResourceConfigError(f"Invalid node_count. Error: {e}")
     if push:
@@ -208,7 +208,7 @@ def motr(cib_xml, push=False, **kwargs):
 def stop_constraint_on_motr_ios(resource_name, cib_xml, push=False, **kwargs):
     ios_instances = get_ios_instances(**kwargs)
     for i in range(1, int(ios_instances)+1):
-        process.run_cmd(f"pcs -f {cib_xml} constraint order stop {resource_name} then stop {RESOURCE.MOTR_IOS.value}-{i}-clone")
+        process.run_cmd(f"pcs -f {cib_xml} constraint order stop {resource_name} then stop {RESOURCE.MOTR_IOS.value}-{i}-clone kind=Optional")
     if push:
         cib_push(cib_xml)
 
@@ -264,7 +264,7 @@ def s3servers(cib_xml, push=False, **kwargs):
 def stop_constraint_on_s3servers(resource_name, cib_xml, push=False, **kwargs):
     s3_instances = get_s3servers_instances(**kwargs)
     for i in range(1, int(s3_instances)+1):
-        process.run_cmd(f"pcs -f {cib_xml} constraint order stop {resource_name} then stop s3server-{i}-clone")
+        process.run_cmd(f"pcs -f {cib_xml} constraint order stop {resource_name} then stop s3server-{i}-clone kind=Optional")
     if push:
         cib_push(cib_xml)
 


### PR DESCRIPTION
…3 node setup

- Change the stop order constraint kind property to Optional
  (default is Mandatory) wherever is applicable

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
 https://jts.seagate.com/browse/EOS-22198
 Stopping or killing of s3 services is affecting the io path as well (motr services). If previous gets restart, io path is getting restarted. If one gets stopped, other gets stopped.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Stopping or killing of s3 services is affecting the io path as well (motr services). If previous gets restart, io path is getting restarted. If one gets stopped, other gets stopped. And following constraint Kind:Mandatory property is causing this issue.
    **stop s3server-1-clone then stop motr-ios-1-clone (kind:Mandatory) (id:order-s3server-1-clone-motr-ios-1-clone-mandatory)
    stop s3server-1-clone then stop motr-ios-2-clone (kind:Mandatory) (id:order-s3server-1-clone-motr-ios-2-clone-mandatory)**
  </code>
</pre>
## Solution
<pre>
  <code>
   Change the constraint property to kind=Optional which will remove the mandate to perform some action on former resource in case of previous got some action  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    1. Manually changed the constraint property on many setups and tried killing the s3 service
    2. Observed that io path was unaffected
    3. In order to verify this option, tried cluster stop to check the order in which resources are stopping (resource stop order should be reverse to start order) 
    The new order constraint looks like:
    Ordering Constraints:
  start hax-clone then start motr-confd-1-clone (kind:Mandatory) (id:order-hax-clone-motr-confd-1-clone-mandatory)
  start hax-clone then start motr-ios-1-clone (kind:Mandatory) (id:order-hax-clone-motr-ios-1-clone-mandatory)
  stop motr-ios-1-clone then stop motr-confd-1-clone (kind:Optional) (id:order-motr-ios-1-clone-motr-confd-1-clone-Optional)
  stop s3server-1-clone then stop motr-ios-1-clone (kind:Optional) (id:order-s3server-1-clone-motr-ios-1-clone-Optional)
  stop haproxy-clone then stop s3server-1-clone (kind:Optional) (id:order-haproxy-clone-s3server-1-clone-Optional)
  stop s3backcons-clone then stop s3server-1-clone (kind:Optional) (id:order-s3backcons-clone-s3server-1-clone-Optional)
  stop motr-free-space-mon then stop motr-ios-1-clone (kind:Optional) (id:order-motr-free-space-mon-motr-ios-1-clone-Optional)
  stop s3backprod then stop s3server-1-clone (kind:Optional) (id:order-s3backprod-s3server-1-clone-Optional)

  </code>
</pre>
