### PR TITLE
EOS-22972: Cluster not starting up after successful 3N HW deployment

### DIFF
--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -415,14 +415,14 @@ class ConfigCmd(Cmd):
         s3_instances = ConfigCmd.get_s3_instance(machine_id)
         ios_instances = ConfigCmd.get_ios_instance(machine_id)
 
+        self._update_env(node_name, node_type, const.HA_CLUSTER_SOFTWARE, s3_instances, ios_instances)
+        self._fetch_fids()
+        self._update_cluster_manager_config()
+
         # fetch all nodes stonith config
         all_nodes_stonith_config: dict = {}
         if self.get_installation_type().lower() == const.INSTALLATION_TYPE.HW.value.lower():
             all_nodes_stonith_config = ConfigCmd.get_stonith_config()
-
-        self._update_env(node_name, node_type, const.HA_CLUSTER_SOFTWARE, s3_instances, ios_instances)
-        self._fetch_fids()
-        self._update_cluster_manager_config()
 
         # Push node name mapping to store
         if not self._confstore.key_exists(f"{const.PVTFQDN_TO_NODEID_KEY}/{node_name}"):

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -456,7 +456,8 @@ class ConfigCmd(Cmd):
                     self._create_resource(s3_instances=s3_instances, mgmt_info=mgmt_info, node_count=len(nodelist),
                                           ios_instances=ios_instances, stonith_config=all_nodes_stonith_config.get(node_name))
                     # configure stonith for each node from that node only
-                    configure_stonith(push=True, stonith_config=all_nodes_stonith_config.get(node_name))
+                    if enable_stonith:
+                        configure_stonith(push=True, stonith_config=all_nodes_stonith_config.get(node_name))
                     self._confstore.set(f"{const.CLUSTER_CONFSTORE_NODES_KEY}/{node_name}")
                 except Exception as e:
                     Log.error(f"Cluster creation failed; destroying the cluster. Error: {e}")
@@ -475,10 +476,12 @@ class ConfigCmd(Cmd):
                 # Add node with SSH
                 self._add_node_remotely(node_name, cluster_user, cluster_secret)
                 # configure stonith for each node from that node only
-                configure_stonith(push=True, stonith_config=all_nodes_stonith_config.get(node_name))
+                if enable_stonith:
+                    configure_stonith(push=True, stonith_config=all_nodes_stonith_config.get(node_name))
         else:
             # configure stonith for each node from that node only
-            configure_stonith(push=True, stonith_config=all_nodes_stonith_config.get(node_name))
+            if enable_stonith:
+                configure_stonith(push=True, stonith_config=all_nodes_stonith_config.get(node_name))
             for node in nodelist:
                 if node != node_name:
                     Log.info(f"Adding node {node} to Cluster {cluster_name}")


### PR DESCRIPTION
Signed-off-by: Amol Shinde <amol.shinde@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-22972: Cluster not starting up after successful 3N HW deployment
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    - Cluster not starting up after successful 3N HW deployment due to getting stonith config before updating the ha conf file.
  </code>
</pre>
## Solution
<pre>
  <code>
    - Updated code to return the config after updating the env in ha conf file. 
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
**********************[VM config]****************************

[root@sm34-r6 ~]# ha_setup post_install --config 'json:///root/example_config.json' --dev
Mini Provisioning post_install configured successfully.

[root@sm34-r6 ~]# ha_setup config --config 'json:///root/example_config.json' --dev
Mini Provisioning config configured successfully.

[root@sm27-r6 ~]# cat /etc/cortx/ha/ha.conf
LOG:
    path: /var/log/seagate/cortx/ha
    level: INFO
VERSION:
    version: 2.0.0
CLUSTER_MANAGER:
    cluster_type: corosync-pacemaker
    env: VM
    local_node: <LOCAL_NODE>
SYSTEM_HEALTH:
    num_entity_health_events: 2
EVENT_ANALYZER:
    instance_count: 1
    watcher:
        iem:
            consumer_id: 1
            message_type: alerts
            consumer_group: iem_analyzer
            event_filter: ha.core.event_analyzer.filter.filter.IEMFilter
            event_parser: ha.core.event_analyzer.parser.parser.IEMParser
SERVICE_INSTANCE_COUNTER:
- instances: 1
  resource: motr-confd
  scope: cluster
- instances: <S3_INSTANCES>
  resource: s3server
  scope: node
- instances: <IOS_INSTANCES>
  resource: motr-ios
  scope: node

[root@sm34-r6 ~]# tail -100 /var/log/seagate/cortx/ha/ha_setup.log
2021-07-21 20:05:45 ha_setup [38460]: INFO [process] Checking if cluster exists already
2021-07-21 20:05:45 ha_setup [38460]: INFO [process] Cluster exists? False
2021-07-21 20:05:45 ha_setup [38460]: INFO [process] Creating cluster: cortx_cluster with node: node1
2021-07-21 20:06:06 ha_setup [38460]: INFO [create_cluster] Pacmaker cluster created, waiting to start node.
2021-07-21 20:06:51 ha_setup [38460]: INFO [create_all_resources] HA Rules: Successfully configured all HA resources and its configuration.
2021-07-21 20:06:51 ha_setup [38460]: INFO [_create_resource] Created pacemaker resources successfully
2021-07-21 20:06:52 ha_setup [38460]: INFO [configure_stonith] Stonith configuration not available to create stonith resource.
2021-07-21 20:08:43 ha_setup [38460]: INFO [create_alert] Alert iem_alert created successfully.
2021-07-21 20:08:43 ha_setup [38460]: INFO [process] config command is successful

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
**********************[HW config]****************************

[root@sm34-r6 ~]# ha_setup post_install --config 'json:///root/example_config1.json' --dev
Mini Provisioning post_install configured successfully.

[root@sm34-r6 ~]# ha_setup config --config 'json:///root/example_config1.json' --dev
Mini Provisioning config configured successfully.

[root@sm34-r6 ~]# cat /etc/cortx/ha/ha.conf
CLUSTER_MANAGER:
  cluster_type: corosync
  env: HW
  local_node: node1
EVENT_ANALYZER:
  instance_count: 1
  watcher:
    iem:
      consumer_group: iem_analyzer
      consumer_id: 1
      event_filter: ha.core.event_analyzer.filter.filter.IEMFilter
      event_parser: ha.core.event_analyzer.parser.parser.IEMParser
      message_type: alerts
LOG:
  level: INFO
  path: /var/log/seagate/cortx/ha
SERVICE_INSTANCE_COUNTER:
- instances: 1
  resource: motr-confd
  scope: cluster
- instances: 1
  resource: s3server
  scope: node
- instances: 2
  resource: motr-ios
  scope: node
SYSTEM_HEALTH:
  num_entity_health_events: 2
VERSION:
  version: 2.0.0

[root@sm34-r6 ~]# tail -100 /var/log/seagate/cortx/ha/ha_setup.log
2021-07-21 21:31:39 ha_setup [41305]: INFO [process] Checking if cluster exists already
2021-07-21 21:31:40 ha_setup [41305]: INFO [process] Cluster exists? True
2021-07-21 21:31:41 ha_setup [41305]: INFO [configure_stonith] Configuring stonith.
2021-07-21 21:31:45 ha_setup [41305]: INFO [create_alert] Alert already exists, skipping create alert.
2021-07-21 21:31:45 ha_setup [41305]: INFO [process] config command is successful

  </code>
</pre>
