### PR TITLE
EOS-23039: SW upgrade failed on HA upgrade branch

### DIFF
--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -523,11 +523,11 @@ class ConfigCmd(Cmd):
         self._alert_config.create_alert()
         Log.info("config command is successful")
 
-    def _create_resource(self, s3_instances, mgmt_info, node_count, ios_instances, stonith_config=None):
+    def _create_resource(self, ios_instances, s3_instances, mgmt_info, node_count, stonith_config=None):
         Log.info("Creating pacemaker resources")
         try:
             # TODO: create resource if not already exists.
-            create_all_resources(s3_instances=s3_instances, ios_instances=ios_instances, mgmt_info=mgmt_info, node_count=node_count, stonith_config=stonith_config)
+            create_all_resources(ios_instances=ios_instances, s3_instances=s3_instances, mgmt_info=mgmt_info, node_count=node_count, stonith_config=stonith_config)
         except Exception as e:
             Log.info(f"Resource creation failed. Error {e}")
             raise HaConfigException("Resource creation failed.")
@@ -1043,12 +1043,13 @@ class PostUpgradeCmd(Cmd):
                 machine_id = self.get_machine_id()
                 cluster_id = Conf.get(self._index, f"server_node{_DELIM}{machine_id}{_DELIM}cluster_id")
                 mgmt_info: dict = self.get_mgmt_vip(machine_id, cluster_id)
+                ios_instances = self.get_ios_instance(machine_id)
                 node_count: int = len(self.get_nodelist(fetch_from=UpgradeCmd.HA_CONFSTORE))
 
                 Log.info(f"Performing post disruptive upgrade routines on cluster \
                         level. cluster_id: {cluster_id}, mgmt_info: {mgmt_info}, node_count: {node_count}")
                 perform_post_upgrade(self.s3_instance, mgmt_info=mgmt_info,
-                                     node_count=node_count, do_unstandby=False)
+                                     ios_instances=ios_instances, node_count=node_count, do_unstandby=False)
         except Exception as err:
             raise SetupError("Post-upgrade routines failed") from err
 

--- a/ha/setup/post_disruptive_upgrade.py
+++ b/ha/setup/post_disruptive_upgrade.py
@@ -130,9 +130,9 @@ def _load_config(ha_source_conf: str = SOURCE_CONFIG_FILE, \
                        upgrading the RPM. Please retry Upgrade process again') \
                        from err
 
-def _create_resources(s3_instances=None, mgmt_info=None, node_count=None) -> None:
+def _create_resources(ios_instances=None, s3_instances=None, mgmt_info=None, node_count=None) -> None:
     '''create required resources'''
-    create_all_resources(s3_instances=s3_instances, mgmt_info=mgmt_info, node_count=node_count)
+    create_all_resources(ios_instances=ios_instances, s3_instances=s3_instances, mgmt_info=mgmt_info, node_count=node_count)
 
 def _switch_cluster_mode(cluster_mode, retry_count=0) -> None:
     '''
@@ -155,12 +155,12 @@ def _unstandby_cluster() -> None:
     _switch_cluster_mode(PCS_CLUSTER_UNSTANDBY)
     Log.info('### cluster is up and running ###')
 
-def perform_post_upgrade(s3_instances=None, do_unstandby=False, mgmt_info=None, node_count=None):
+def perform_post_upgrade(ios_instances=None, s3_instances=None, do_unstandby=False, mgmt_info=None, node_count=None):
     '''Starting routine for post-upgrade process'''
     Log.init(service_name="post_disruptive_upgrade", log_path=RA_LOG_DIR, level="INFO")
     _check_for_any_resource_presence()
     _is_cluster_standby_on()
     _load_config()
-    _create_resources(s3_instances, mgmt_info, node_count)
+    _create_resources(ios_instances, s3_instances, mgmt_info, node_count)
     if do_unstandby:
         _unstandby_cluster()


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
 EOS-23039: SW upgrade failed on HA upgrade branch
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
  Upgrade path code is missing ios_instances argument which gets passed as an argument to create_all _resources and which is  needed in post_upgrade path as well
  </code>
</pre>
## Solution
<pre>
  <code>
   Added the code to get ios_instances wherever is needed  
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    For now, just installed the RPM and performed the mini prov steps and checked the cluster status
 </code>
</pre>
