### PR TITLE
SW upgrade failed on HA upgrade branch

### DIFF
--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -1048,8 +1048,8 @@ class PostUpgradeCmd(Cmd):
 
                 Log.info(f"Performing post disruptive upgrade routines on cluster \
                         level. cluster_id: {cluster_id}, mgmt_info: {mgmt_info}, node_count: {node_count}")
-                perform_post_upgrade(self.s3_instance, mgmt_info=mgmt_info,
-                                     ios_instances=ios_instances, node_count=node_count, do_unstandby=False)
+                perform_post_upgrade(ios_instances=ios_instances, s3_instances=self.s3_instance, do_unstandby=False,
+                                     mgmt_info=mgmt_info, node_count=node_count)
         except Exception as err:
             raise SetupError("Post-upgrade routines failed") from err
 


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  https://jts.seagate.com/browse/EOS-23039
 </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
  Basic problem was, some code of getting ios_instaces and passing it to create_resources through post_upgrade routine was missing. This was fixed using earlier PR but that PR had a mistake of passing the arguments (there was a order mismatch). Hence correcting those order. 
  </code>
</pre>
## Solution
<pre>
  <code>
   Pass every argument as named argument with proper order
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
 RPM installation
 Perform Pre and Post upgrade with some changes that will make the upgrade testing  
 </code>
</pre>
