### PR TITLE
Changes for EOS-22165 Implement event manager interface to list (get_events) and get message type APIs

### DIFF
--- a/ha/core/event_manager/event_manager.py
+++ b/ha/core/event_manager/event_manager.py
@@ -336,8 +336,8 @@ class EventManager:
         value = []
         Log.debug(f"Fetching subscribed events for {key}")
 
-        if self._confstore.key_exists(key):
-            kv = self._confstore.get(key)
+        kv = self._confstore.get(key)
+        if kv:
             for k, v in kv.items():
                 if k.endswith(key):
                     value = json.loads(v)
@@ -382,8 +382,8 @@ class EventManager:
         value = None
         Log.debug(f"Fetching message type for {key}")
 
-        if self._confstore.key_exists(key):
-            kv = self._confstore.get(key)
+        kv = self._confstore.get(key)
+        if kv:
             for k, v in kv.items():
                 if k.endswith(key):
                     value = v

--- a/ha/core/event_manager/event_manager.py
+++ b/ha/core/event_manager/event_manager.py
@@ -332,9 +332,20 @@ class EventManager:
         Returns:
             list: List of events.
         """
-        pass
+        key = f'{const.COMPONENT_KEY}/{component}'
+        value = []
+        Log.debug(f"Fetching subscribed events for {key}")
 
-    def publish(self, event: RecoveryActionEvent) -> None:
+        if self._confstore.key_exists(key):
+            kv = self._confstore.get(key)
+            for k, v in kv.items():
+                if k.endswith(key):
+                    value = json.loads(v)
+                    break
+        return value
+
+
+    def publish(self, component:str, event: RecoveryActionEvent) -> None:
         """
         Publish event.
         Args:
@@ -367,4 +378,16 @@ class EventManager:
         Args:
             component (str): component name.
         """
-        pass
+        key = const.EVENT_MGR_MESSAGE_TYPE_KEY.replace("<component_id>", component)
+        value = None
+        Log.debug(f"Fetching message type for {key}")
+
+        if self._confstore.key_exists(key):
+            kv = self._confstore.get(key)
+            for k, v in kv.items():
+                if k.endswith(key):
+                    value = v
+                    break
+        return value
+
+# TODO: Add unit tests for this

--- a/ha/core/event_manager/event_manager.py
+++ b/ha/core/event_manager/event_manager.py
@@ -340,7 +340,7 @@ class EventManager:
         if kv:
             for k, v in kv.items():
                 if k.endswith(key):
-                    value = json.loads(v)
+                    value.extend(json.loads(v))
                     break
         return value
 

--- a/ha/util/consul_kv_store.py
+++ b/ha/util/consul_kv_store.py
@@ -144,6 +144,8 @@ class ConsulKvStore:
         self._consul.kv.put(self._prepare_key(key), new_val)
         return new_val
 
+    # TODO : Currently all keys with the matching prefix "key" are returned
+    # add additional parameter so that only the exact matching key is returned when required
     def get(self, key: str = ""):
         """
         Get values. Default it will return all keys. It is block call,


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    Need to implement the functions get_events, message_type
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No , testing done on deployed setup using python files directly
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Implement the functions get_events, message_type
  </code>
</pre>
## Solution
<pre>
  <code>
    Implemented functionality for get_events, message_type
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   On a 3 node deployment  ddded keys to consul directly.
   Tested by executing the event_manager.py file directly that 
  For both function calls
  -  Correct value returned when matching key is found
  -  None / empty list returned when exact matching key is not found
  -  All success / failure paths in code tested ( single key / multiple keys with same prefix / no matching keys present in consul etc)
  </code>
</pre>
