### PR TITLE
EOS-23192: 3 Node automated HW deployment fails on Jenkins

### DIFF
--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -517,6 +517,7 @@ class ConfigCmd(Cmd):
                 self._add_node_remotely(node_name, cluster_user, cluster_secret)
                 # configure stonith for each node from that node only
                 if enable_stonith:
+                    self._execute.run_cmd(const.PCS_CLEANUP)
                     configure_stonith(push=True, stonith_config=all_nodes_stonith_config.get(node_name))
         else:
             # configure stonith for each node from that node only

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -521,6 +521,7 @@ class ConfigCmd(Cmd):
         else:
             # configure stonith for each node from that node only
             if enable_stonith:
+                self._execute.run_cmd(const.PCS_CLEANUP)
                 configure_stonith(push=True, stonith_config=all_nodes_stonith_config.get(node_name))
             for node in nodelist:
                 if node != node_name:


### PR DESCRIPTION
Signed-off-by: Amol Shinde <amol.shinde@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-23192: 3 Node automated HW deployment fails on Jenkins
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    3 Node automated HW deployment fails on Jenkins
  </code>
</pre>
## Solution
<pre>
  <code>
    - Needs to cleanup resources before creating stonith resource for other nodes
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   
2021-08-02 17:49:05 ha_setup [44959]: ERROR [run_cmd] cmd: pcs -f /var/log/seagate/cortx/ha/cortx-r2-cib.xml stonith create stonith-srvnode-1 fence_ipmilan ipaddr=10.237.65.161             login=bmcadmin passwd=adminBMC! pcmk_host_list=srvnode-1 pcmk_host_check=static-list             lanplus=true auth=PASSWORD power_timeout=40 verbose=true             op monitor interval=10s meta failure-timeout=15s --group ha_group, output: , err: Error: Agent 'fence_ipmilan' is not installed or does not provide valid metadata: Agent fence_ipmilan not found or does not support meta-data: Invalid argument (22)
Metadata query for stonith:fence_ipmilan failed: Input/output error, use --force to override
, rc: 1

After fixing the above issue and taken call with Ajay P and Subhash, Added fix for cib verify command failure

[root@sm10-r29 ~]# ha_setup post_install --config 'json:///root/example_config.json' --dev
Mini Provisioning post_install configured successfully.

[root@sm10-r29 ~]# ha_setup config --config 'json:///root/example_config.json' --dev
Mini Provisioning config configured successfully.

[root@sm10-r29 ~]# pcs status
Cluster name: cortx_cluster
Stack: corosync
Current DC: srvnode-1 (version 1.1.23-1.el7-9acf116022) - partition with quorum
Last updated: Mon Aug  2 19:21:27 2021
Last change: Mon Aug  2 19:18:56 2021 by root via cibadmin on srvnode-1

3 nodes configured
42 resource instances configured

Node srvnode-1: standby
Node srvnode-2: UNCLEAN (online)
Node srvnode-3: UNCLEAN (online)

Full list of resources:

 Clone Set: hax-clone [hax]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: motr-confd-1-clone [motr-confd-1]
     motr-confd-1       (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-2
     motr-confd-1       (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-3
     Stopped: [ srvnode-1 ]
 Clone Set: motr-ios-1-clone [motr-ios-1]
     motr-ios-1 (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-2
     motr-ios-1 (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-3
     Stopped: [ srvnode-1 ]
 Clone Set: motr-ios-2-clone [motr-ios-2]
     motr-ios-2 (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-2
     motr-ios-2 (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-3
     Stopped: [ srvnode-1 ]
 Clone Set: s3auth-clone [s3auth]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: s3server-1-clone [s3server-1]
     s3server-1 (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-2
     s3server-1 (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-3
     Stopped: [ srvnode-1 ]
 Clone Set: haproxy-clone [haproxy]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: s3backcons-clone [s3backcons]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 motr-free-space-mon    (systemd:motr-free-space-monitor):      Stopped
 s3backprod     (systemd:s3backgroundproducer): Stopped
 Clone Set: monitor_group-clone [monitor_group]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Resource Group: management_group
     kibana     (systemd:kibana):       Stopped
     csm-agent  (systemd:csm_agent):    Stopped
     csm-web    (systemd:csm_web):      Stopped
 Resource Group: ha_group
     event_analyzer     (systemd:event_analyzer):       Stopped
 Clone Set: srv_counter-clone [srv_counter]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: mbus_rest-clone [mbus_rest]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: stonith-srvnode-1-clone [stonith-srvnode-1]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]

Failed Resource Actions:
* motr-confd-1_monitor_0 on srvnode-2 'not configured' (6): call=124, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:18:59 2021', queued=0ms, exec=301ms
* motr-ios-1_monitor_0 on srvnode-2 'not configured' (6): call=129, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:18:59 2021', queued=0ms, exec=324ms
* motr-ios-2_monitor_0 on srvnode-2 'not configured' (6): call=134, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:18:59 2021', queued=0ms, exec=308ms
* s3server-1_stop_0 on srvnode-2 'not configured' (6): call=152, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:19:01 2021', queued=0ms, exec=314ms
* motr-confd-1_monitor_0 on srvnode-3 'not configured' (6): call=123, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:18:59 2021', queued=0ms, exec=337ms
* motr-ios-1_monitor_0 on srvnode-3 'not configured' (6): call=128, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:18:59 2021', queued=0ms, exec=344ms
* motr-ios-2_monitor_0 on srvnode-3 'not configured' (6): call=133, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:18:59 2021', queued=0ms, exec=357ms
* s3server-1_stop_0 on srvnode-3 'not configured' (6): call=152, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:19:01 2021', queued=0ms, exec=348ms

Failed Fencing Actions:
* reboot of srvnode-2 failed: delegate=, client=crmd.73193, origin=srvnode-1,
    last-failed='Mon Aug  2 19:19:01 2021'
* reboot of srvnode-3 failed: delegate=, client=crmd.73193, origin=srvnode-1,
    last-failed='Mon Aug  2 19:19:01 2021'

Daemon Status:
  corosync: active/enabled
  pacemaker: active/enabled
  pcsd: active/enabled

On node 2:
[root@sm21-r29 ~]# ha_setup post_install --config 'json:///root/example_config.json' --dev  
Mini Provisioning post_install configured successfully.
  
[root@sm21-r29 ~]# ha_setup config --config 'json:///root/example_config.json' --dev
Mini Provisioning config configured successfully.

[root@sm21-r29 ~]# pcs status
Cluster name: cortx_cluster
Stack: corosync
Current DC: srvnode-1 (version 1.1.23-1.el7-9acf116022) - partition with quorum
Last updated: Mon Aug  2 19:24:36 2021
Last change: Mon Aug  2 19:22:26 2021 by hacluster via crmd on srvnode-3

3 nodes configured
45 resource instances configured

Node srvnode-1: standby
Node srvnode-2: standby
Node srvnode-3: UNCLEAN (online)

Full list of resources:

 Clone Set: hax-clone [hax]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: motr-confd-1-clone [motr-confd-1]
     motr-confd-1       (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-3
     Stopped: [ srvnode-1 srvnode-2 ]
 Clone Set: motr-ios-1-clone [motr-ios-1]
     motr-ios-1 (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-3
     Stopped: [ srvnode-1 srvnode-2 ]
 Clone Set: motr-ios-2-clone [motr-ios-2]
     motr-ios-2 (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-3
     Stopped: [ srvnode-1 srvnode-2 ]
 Clone Set: s3auth-clone [s3auth]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: s3server-1-clone [s3server-1]
     s3server-1 (ocf::seagate:dynamic_fid_service_ra):  FAILED srvnode-3
     Stopped: [ srvnode-1 srvnode-2 ]
 Clone Set: haproxy-clone [haproxy]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: s3backcons-clone [s3backcons]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 motr-free-space-mon    (systemd:motr-free-space-monitor):      Stopped
 s3backprod     (systemd:s3backgroundproducer): Stopped
 Clone Set: monitor_group-clone [monitor_group]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Resource Group: management_group
     kibana     (systemd:kibana):       Stopped
     csm-agent  (systemd:csm_agent):    Stopped
     csm-web    (systemd:csm_web):      Stopped
 Resource Group: ha_group
     event_analyzer     (systemd:event_analyzer):       Stopped
 Clone Set: srv_counter-clone [srv_counter]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: mbus_rest-clone [mbus_rest]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: stonith-srvnode-1-clone [stonith-srvnode-1]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: stonith-srvnode-2-clone [stonith-srvnode-2]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]

Failed Resource Actions:
* motr-confd-1_monitor_0 on srvnode-3 'not configured' (6): call=195, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:22:28 2021', queued=0ms, exec=334ms
* motr-ios-1_monitor_0 on srvnode-3 'not configured' (6): call=200, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:22:28 2021', queued=0ms, exec=390ms
* motr-ios-2_monitor_0 on srvnode-3 'not configured' (6): call=205, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:22:28 2021', queued=0ms, exec=345ms
* s3server-1_stop_0 on srvnode-3 'not configured' (6): call=220, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:22:28 2021', queued=1ms, exec=348ms

Failed Fencing Actions:
* reboot of srvnode-3 failed: delegate=, client=crmd.73193, origin=srvnode-1,
    last-failed='Mon Aug  2 19:22:29 2021'
* reboot of srvnode-2 failed: delegate=, client=crmd.73193, origin=srvnode-1,
    last-failed='Mon Aug  2 19:19:01 2021'

Daemon Status:
  corosync: active/enabled
  pacemaker: active/enabled
  pcsd: active/enabled

[root@sm17-r18 ~]#  ha_setup config --config 'json:///root/example_config.json' --dev
Mini Provisioning config configured successfully.

[root@sm17-r18 ~]# pcs status
Cluster name: cortx_cluster
Stack: corosync
Current DC: srvnode-1 (version 1.1.23-1.el7-9acf116022) - partition with quorum
Last updated: Mon Aug  2 19:32:46 2021
Last change: Mon Aug  2 19:32:23 2021 by root via cibadmin on srvnode-3

3 nodes configured
48 resource instances configured

Node srvnode-1: standby
Node srvnode-2: standby
Node srvnode-3: standby

Full list of resources:

 Clone Set: hax-clone [hax]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: motr-confd-1-clone [motr-confd-1]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: motr-ios-1-clone [motr-ios-1]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: motr-ios-2-clone [motr-ios-2]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: s3auth-clone [s3auth]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: s3server-1-clone [s3server-1]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: haproxy-clone [haproxy]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: s3backcons-clone [s3backcons]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 motr-free-space-mon    (systemd:motr-free-space-monitor):      Stopped
 s3backprod     (systemd:s3backgroundproducer): Stopped
 Clone Set: monitor_group-clone [monitor_group]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Resource Group: management_group
     kibana     (systemd:kibana):       Stopped
     csm-agent  (systemd:csm_agent):    Stopped
     csm-web    (systemd:csm_web):      Stopped
 Resource Group: ha_group
     event_analyzer     (systemd:event_analyzer):       Stopped
 Clone Set: srv_counter-clone [srv_counter]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: mbus_rest-clone [mbus_rest]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: stonith-srvnode-1-clone [stonith-srvnode-1]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: stonith-srvnode-2-clone [stonith-srvnode-2]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: stonith-srvnode-3-clone [stonith-srvnode-3]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]

Failed Fencing Actions:
* reboot of srvnode-3 failed: delegate=, client=crmd.73193, origin=srvnode-1,
    last-failed='Mon Aug  2 19:22:29 2021'
* reboot of srvnode-2 failed: delegate=, client=crmd.73193, origin=srvnode-1,
    last-failed='Mon Aug  2 19:19:01 2021'

Daemon Status:
  corosync: active/enabled
  pacemaker: active/enabled
  pcsd: active/enabled


After cortx cluster start :

[root@sm10-r29 ~]# cortx cluster start
{"status": "InProgress", "output": "Cluster start operation performed", "error": ""}[root@sm10-r29 ~]#
[root@sm10-r29 ~]#
[root@sm10-r29 ~]# pcs status
Cluster name: cortx_cluster
Stack: corosync
Current DC: srvnode-1 (version 1.1.23-1.el7-9acf116022) - partition with quorum
Last updated: Mon Aug  2 19:34:04 2021
Last change: Mon Aug  2 19:33:42 2021 by root via cibadmin on srvnode-1

3 nodes configured
48 resource instances configured

Online: [ srvnode-1 srvnode-2 srvnode-3 ]

Full list of resources:

 Clone Set: hax-clone [hax]
     Started: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: motr-confd-1-clone [motr-confd-1]
     Started: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: motr-ios-1-clone [motr-ios-1]
     motr-ios-1 (ocf::seagate:dynamic_fid_service_ra):  Starting srvnode-1
     motr-ios-1 (ocf::seagate:dynamic_fid_service_ra):  Starting srvnode-2
     motr-ios-1 (ocf::seagate:dynamic_fid_service_ra):  Starting srvnode-3
 Clone Set: motr-ios-2-clone [motr-ios-2]
     motr-ios-2 (ocf::seagate:dynamic_fid_service_ra):  Starting srvnode-1
     motr-ios-2 (ocf::seagate:dynamic_fid_service_ra):  Starting srvnode-2
     motr-ios-2 (ocf::seagate:dynamic_fid_service_ra):  Starting srvnode-3
 Clone Set: s3auth-clone [s3auth]
     Started: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: s3server-1-clone [s3server-1]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: haproxy-clone [haproxy]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: s3backcons-clone [s3backcons]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 motr-free-space-mon    (systemd:motr-free-space-monitor):      Stopped
 s3backprod     (systemd:s3backgroundproducer): Stopped
 Clone Set: monitor_group-clone [monitor_group]
     Started: [ srvnode-1 srvnode-2 srvnode-3 ]
 Resource Group: management_group
     kibana     (systemd:kibana):       Started srvnode-1
     csm-agent  (systemd:csm_agent):    Started srvnode-1
     csm-web    (systemd:csm_web):      Started srvnode-1
 Resource Group: ha_group
     event_analyzer     (systemd:event_analyzer):       FAILED srvnode-3
 Clone Set: srv_counter-clone [srv_counter]
     Started: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: mbus_rest-clone [mbus_rest]
     Started: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: stonith-srvnode-1-clone [stonith-srvnode-1]
     Started: [ srvnode-2 srvnode-3 ]
     Stopped: [ srvnode-1 ]
 Clone Set: stonith-srvnode-2-clone [stonith-srvnode-2]
     Started: [ srvnode-1 srvnode-3 ]
     Stopped: [ srvnode-2 ]
 Clone Set: stonith-srvnode-3-clone [stonith-srvnode-3]
     Started: [ srvnode-1 srvnode-2 ]
     Stopped: [ srvnode-3 ]

Failed Resource Actions:
* event_analyzer_start_0 on srvnode-1 'unknown error' (1): call=103, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:33:40 2021', queued=0ms, exec=2147ms
* event_analyzer_start_0 on srvnode-2 'unknown error' (1): call=216, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:33:53 2021', queued=0ms, exec=2108ms
* event_analyzer_start_0 on srvnode-3 'unknown error' (1): call=284, status=complete, exitreason='',
    last-rc-change='Mon Aug  2 19:34:01 2021', queued=0ms, exec=2105ms

Failed Fencing Actions:
* reboot of srvnode-3 failed: delegate=, client=crmd.73193, origin=srvnode-1,
    last-failed='Mon Aug  2 19:22:29 2021'
* reboot of srvnode-2 failed: delegate=, client=crmd.73193, origin=srvnode-1,
    last-failed='Mon Aug  2 19:19:01 2021'

Daemon Status:
  corosync: active/enabled
  pacemaker: active/enabled
  pcsd: active/enabled


After taking node3 down : 

```
 ip link set down eno1
```

Pending Fencing Actions:
* reboot of srvnode-3 pending: client=crmd.73193, origin=srvnode-1

Node rebooted and joined back to cluster

[root@sm17-r18 ~]# last reboot
reboot   system boot  3.10.0-1127.el7. Mon Aug  2 19:40 - 19:41  (00:01)
reboot   system boot  3.10.0-1127.el7. Mon Aug  2 11:47 - 19:41  (07:54)

wtmp begins Mon Aug  2 11:47:42 2021
[root@sm17-r18 ~]# date
Mon Aug  2 19:41:55 IST 2021
[root@sm17-r18 ~]#

  </code>
</pre>
