### PR TITLE
EOS-23330: Stonith resource creation is getting overlapped in config phase on other than first node

### DIFF
--- a/ha/setup/create_pacemaker_resources.py
+++ b/ha/setup/create_pacemaker_resources.py
@@ -466,12 +466,11 @@ def configure_stonith(cib_xml=None, push=False, **kwargs):
     if stonith_config and stonith_config.get("node_type").lower() == const.INSTALLATION_TYPE.HW.value.lower():
         Log.info("Configuring stonith.")
         resource_id = stonith_config.get("resource_id")
-        node_name = stonith_config.get("node_name")
 
         # check for stonith config present for that node
         _output, _err, _rc = process.run_cmd(const.PCS_STONITH_SHOW.replace("<resource_id>", resource_id), check_error=False)
         if _output and "Error" not in _output and resource_id in _output:
-            Log.info(f"Stonith configuration already exists for node {node_name}.")
+            Log.info(f"Stonith configuration already exists for node {resource_id}.")
             return
 
         ipaddr = stonith_config.get("ipaddr")

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -779,7 +779,9 @@ class InitCmd(Cmd):
         Log.info("Processing init command")
         env_type = self.get_installation_type().lower()
         if env_type == const.INSTALLATION_TYPE.HW.value.lower():
+            Log.info("Enabling the stonith.")
             self._execute.run_cmd(const.PCS_STONITH_ENABLE)
+            Log.info("Stonith enabled successfully.")
         elif env_type == const.INSTALLATION_TYPE.VM.value.lower():
             Log.warn("Stonith configuration not available, detected VM env")
         else:

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -783,7 +783,7 @@ class InitCmd(Cmd):
             self._execute.run_cmd(const.PCS_STONITH_ENABLE)
             Log.info("Stonith enabled successfully.")
         elif env_type == const.INSTALLATION_TYPE.VM.value.lower():
-            Log.warn("Stonith configuration not available, detected VM env")
+            Log.warn(f"Stonith configuration not available, detected {env_type} env")
         else:
             raise HaConfigException(f"Invalid env detected, {env_type}")
         Log.info("init command is successful")

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -511,6 +511,7 @@ class ConfigCmd(Cmd):
                     if node != node_name:
                         Log.info(f"Adding node {node} to Cluster {cluster_name}")
                         self._add_node(node, cluster_user, cluster_secret)
+                        self._configure_stonith(all_nodes_stonith_config, node, enable_stonith)
             else:
                 # Add node with SSH
                 self._add_node_remotely(node_name, cluster_user, cluster_secret)
@@ -523,9 +524,8 @@ class ConfigCmd(Cmd):
                 if node != node_name:
                     Log.info(f"Adding node {node} to Cluster {cluster_name}")
                     self._add_node(node, cluster_user, cluster_secret)
+                    self._configure_stonith(all_nodes_stonith_config, node, enable_stonith)
         self._execute.run_cmd(const.PCS_CLEANUP)
-        if enable_stonith:
-            self._execute.run_cmd(const.PCS_STONITH_ENABLE)
         # Create Alert if not exists
         self._alert_config.create_alert()
         Log.info("config command is successful")
@@ -777,6 +777,13 @@ class InitCmd(Cmd):
         Process init command.
         """
         Log.info("Processing init command")
+        env_type = self.get_installation_type().lower()
+        if env_type == const.INSTALLATION_TYPE.HW.value.lower():
+            self._execute.run_cmd(const.PCS_STONITH_ENABLE)
+        elif env_type == const.INSTALLATION_TYPE.VM.value.lower():
+            Log.warn("Stonith configuration not available, detected VM env")
+        else:
+            raise HaConfigException(f"Invalid env detected, {env_type}")
         Log.info("init command is successful")
 
 class TestCmd(Cmd):


### PR DESCRIPTION
Signed-off-by: Amol Shinde <amol.shinde@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-23330: Stonith resource creation is getting overlapped in config phase on other than first node
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    EOS-23330: Stonith resource creation is getting overlapped in config phase on other than first node
  </code>
</pre>
## Solution
<pre>
  <code>
- Added code to create stonith resources for all nodes in config phase execution on first node
- Changed code a bit, whenever adding a node to the cluster we are configuring stonith for that node. Its creating stonith resources, but stonith_enable is false at that time.
- Before creating any stonith resource for any node we first checking its already present or not, if not then only we create the stonith resource for that node.
- Enabling stonith at init phase
- Starting the cortx cluster after init phase. All resource are created properly and working as expected.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
On first node config phase execution

 Clone Set: stonith-srvnode-1-clone [stonith-srvnode-1]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: stonith-srvnode-2-clone [stonith-srvnode-2]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]
 Clone Set: stonith-srvnode-3-clone [stonith-srvnode-3]
     Stopped: [ srvnode-1 srvnode-2 srvnode-3 ]

[root@sm10-r29 ~]# pcs property list
Cluster Properties:
 ...
 stonith-enabled: False

After init phase execution:

[root@sm10-r29 ~]# pcs property list
Cluster Properties:
 ...
 stonith-enabled: true
Node Attributes:
 srvnode-1: standby=on
 srvnode-2: standby=on
 srvnode-3: standby=on

[root@sm10-r29 ~]# cortx cluster start
{"status": "InProgress", "output": "Cluster start operation performed", "error": ""}[root@sm10-r29 ~]#

After pcs status:
[root@sm10-r29 ~]# pcs status
Cluster name: cortx_cluster
Stack: corosync
Current DC: srvnode-1 (version 1.1.23-1.el7-9acf116022) - partition with quorum
Last updated: Wed Aug  4 16:20:55 2021
Last change: Wed Aug  4 16:18:42 2021 by root via cibadmin on srvnode-1

3 nodes configured
48 resource instances configured

Online: [ srvnode-1 srvnode-2 srvnode-3 ]

 Clone Set: stonith-srvnode-1-clone [stonith-srvnode-1]
     Started: [ srvnode-2 srvnode-3 ]
     Stopped: [ srvnode-1 ]
 Clone Set: stonith-srvnode-2-clone [stonith-srvnode-2]
     Started: [ srvnode-1 srvnode-3 ]
     Stopped: [ srvnode-2 ]
 Clone Set: stonith-srvnode-3-clone [stonith-srvnode-3]
     Started: [ srvnode-1 srvnode-2 ]
     Stopped: [ srvnode-3 ]
  </code>
</pre>
