### PR TITLE
EOS-23626 : Create support.yaml for HA

### DIFF
--- a/conf/mini_provisioner/v2/setup.yaml
+++ b/conf/mini_provisioner/v2/setup.yaml
@@ -63,5 +63,3 @@ ha:
         cmd: /opt/seagate/cortx/ha/bin/ha_setup restore
         args: --location $URL
 
-support_bundle:
-    - cortx support_bundle create

--- a/conf/mini_provisioner/v2/support.yaml
+++ b/conf/mini_provisioner/v2/support.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+support_bundle:
+    - cortx support_bundle create

--- a/jenkins/build_with_pyinstaller.sh
+++ b/jenkins/build_with_pyinstaller.sh
@@ -148,7 +148,6 @@ then
      cp -rf $BASE_DIR/conf/script/v1/* $HA_DIR/conf/script/
      cp -rf $BASE_DIR/conf/iostack-ha/ $HA_DIR/conf/
      cp -rf $BASE_DIR/conf/mini_provisioner/v1/setup.yaml $HA_DIR/conf/setup.yaml
-     cp -rf $BASE_DIR/conf/mini_provisioner/v1/support.yaml $HA_DIR/conf/support.yaml
 
      # Update HA path in setup
      sed -i -e "s|<HA_PATH>|${HA_PATH}/ha|g" ${HA_DIR}/conf/script/ha_setup

--- a/jenkins/build_with_pyinstaller.sh
+++ b/jenkins/build_with_pyinstaller.sh
@@ -148,6 +148,7 @@ then
      cp -rf $BASE_DIR/conf/script/v1/* $HA_DIR/conf/script/
      cp -rf $BASE_DIR/conf/iostack-ha/ $HA_DIR/conf/
      cp -rf $BASE_DIR/conf/mini_provisioner/v1/setup.yaml $HA_DIR/conf/setup.yaml
+     cp -rf $BASE_DIR/conf/mini_provisioner/v1/support.yaml $HA_DIR/conf/support.yaml
 
      # Update HA path in setup
      sed -i -e "s|<HA_PATH>|${HA_PATH}/ha|g" ${HA_DIR}/conf/script/ha_setup


### PR DESCRIPTION


## Problem Statement
<pre>
  <code>
  Story Ref (if any):
EOS-23626 : Create support.yaml for HA
  </code>
</pre>
## Unit testing on RPM done
<pre>
Yes, on single node and 3 node VM. Refer unit cases section for tests.
  
</pre>
## Problem Description
<pre>
  <code>
 With addition of upgrade related entries in setup.yaml, YAML parsing of setup.yaml is broken (but provisioner is capable of handling this).
Command for component specific support bundle generation is in setup.yaml
Due to broken parsing, support bundle generation is at risk and a quick remedy is required.
  </code>
</pre>
## Solution
    -Create support.yaml file which will have the "support_bundle" entry from setup.yaml 
    -Install this support.yaml file at the same location where current setup.yaml file resides after installation.


## Unit Test Cases

-  Automated single node deployment passed : http://eos-jenkins.colo.seagate.com/job/Cortx-Deployment/job/VM-Deployment-R2-1Node/1866/
- Automated 3 node deployment passed : http://eos-jenkins.colo.seagate.com/job/Cortx-Deployment/job/VM-Deployment-R2-3Node/754/
- RPM testing  - details below
<pre>
<code>
srvnode-1
----------
[root@ssc-vm-g2-rhev4-0626 ~]# rpm -qa | grep cortx-ha-
cortx-ha-2.0.0-2504_7e8381a.x86_64

[root@ssc-vm-g2-rhev4-0626 ~]# find /opt/seagate/cortx/ha/ -name *.yaml
/opt/seagate/cortx/ha/conf/setup.yaml
/opt/seagate/cortx/ha/conf/support.yaml

srvnode-2
----------
root@ssc-vm-g2-rhev4-0627 ~]# rpm -qa | grep cortx-ha-
cortx-ha-2.0.0-2504_7e8381a.x86_64

[root@ssc-vm-g2-rhev4-0627 ~]# find /opt/seagate/cortx/ha/ -name *.yaml
/opt/seagate/cortx/ha/conf/setup.yaml
/opt/seagate/cortx/ha/conf/support.yaml

srvnode-3 
---------
[root@ssc-vm-g2-rhev4-0628 ~]#  rpm -qa | grep cortx-ha-
cortx-ha-2.0.0-2504_7e8381a.x86_64

[root@ssc-vm-g2-rhev4-0628 ~]# find /opt/seagate/cortx/ha/ -name *.yaml
/opt/seagate/cortx/ha/conf/setup.yaml
/opt/seagate/cortx/ha/conf/support.yaml
  </code>
 </pre>
