### PR TITLE
EOS-22373:  _get_node_name issue

### DIFF
--- a/ha/core/controllers/pcs/node_controller.py
+++ b/ha/core/controllers/pcs/node_controller.py
@@ -62,7 +62,7 @@ class PcsNodeController(NodeController, PcsController):
         """
         try:
             # Get the node_name (pvtfqdn) from node_id
-            node_name = self._get_node_name(node_id=node_id)
+            node_name = ConfigManager.get_node_name(node_id=node_id)
             self._is_node_in_cluster(node_id=node_name)
             node_status = self.nodes_status([node_name])[node_name]
             Log.debug(f"Node {node_name} cluster status is {node_status}")
@@ -355,7 +355,7 @@ class PcsHWNodeController(PcsNodeController):
         """
         try:
             poweron = op_kwargs.get("poweron") if op_kwargs.get("poweron") is not None else False
-            node_name = self._get_node_name(node_id=node_id)
+            node_name = ConfigManager.get_node_name(node_id=node_id)
             self._is_node_in_cluster(node_id=node_name)
             power_status = self.fencing_agent.power_status(node_id=node_name)
             if power_status == const.SERVER_POWER_STATUS.OFF.value and poweron is False:


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    Replaced the _get_node_name method with ConfigManager.get_node_name
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Replaced the _get_node_name method with ConfigManager.get_node_name
  </code>
</pre>
## Solution
<pre>
  <code>
    Replaced the removed  _get_node_name method with ConfigManager.get_node_name
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
