### PR TITLE
EOS-23620: Secondary nodes (HW) stonith seen during deployment

### DIFF
--- a/ha/core/config/config_manager.py
+++ b/ha/core/config/config_manager.py
@@ -143,3 +143,17 @@ class ConfigManager:
                 node_name = key.split('/')[-1]
                 return node_name
         raise HAInvalidNode(f"node_id {node_id} is not valid.")
+
+    @staticmethod
+    def get_node_id(node_name: str) -> str:
+        """
+        Get node_id from node_name
+        Args:
+            node_name (str): Node name from cluster nodes.
+        Returns: str
+            node_id (str): Node ID from cluster nodes.
+        """
+        confstore = ConfigManager.get_confstore()
+        key_val = confstore.get(f"{const.PVTFQDN_TO_NODEID_KEY}/{node_name}")
+        _, node_id = key_val.popitem()
+        return node_id

--- a/ha/core/controllers/pcs/node_controller.py
+++ b/ha/core/controllers/pcs/node_controller.py
@@ -62,7 +62,7 @@ class PcsNodeController(NodeController, PcsController):
         """
         try:
             # Get the node_name (pvtfqdn) from node_id
-            node_name = self._get_node_name(node_id=node_id)
+            node_name = ConfigManager.get_node_name(node_id=node_id)
             self._is_node_in_cluster(node_id=node_name)
             node_status = self.nodes_status([node_name])[node_name]
             Log.debug(f"Node {node_name} cluster status is {node_status}")
@@ -355,7 +355,7 @@ class PcsHWNodeController(PcsNodeController):
         """
         try:
             poweron = op_kwargs.get("poweron") if op_kwargs.get("poweron") is not None else False
-            node_name = self._get_node_name(node_id=node_id)
+            node_name = ConfigManager.get_node_name(node_id)
             self._is_node_in_cluster(node_id=node_name)
             power_status = self.fencing_agent.power_status(node_id=node_name)
             if power_status == const.SERVER_POWER_STATUS.OFF.value and poweron is False:

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -787,15 +787,6 @@ class InitCmd(Cmd):
         Process init command.
         """
         Log.info("Processing init command")
-        env_type = self.get_installation_type().lower()
-        if env_type == const.INSTALLATION_TYPE.HW.value.lower():
-            Log.info("Enabling the stonith.")
-            self._execute.run_cmd(const.PCS_STONITH_ENABLE)
-            Log.info("Stonith enabled successfully.")
-        elif env_type == const.INSTALLATION_TYPE.VM.value.lower():
-            Log.warn(f"Stonith configuration not available, detected {env_type} env")
-        else:
-            raise HaConfigException(f"Invalid env detected, {env_type}")
         Log.info("init command is successful")
 
 class TestCmd(Cmd):


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-23620: Secondary nodes (HW) stonith seen during deployment
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    If the stonith is enabled before the full cluster configuration, stonith behaves weirdly and does the node power off 
  </code>
</pre>
## Solution
<pre>
  <code>
    Enable stonith after the cluster start
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>

 [root@sm17-r18 cluster]# pcs property list
Cluster Properties:
 cluster-infrastructure: corosync
 cluster-name: cortx_cluster
 dc-version: 1.1.23-1.el7-9acf116022
 have-watchdog: false
 last-lrm-refresh: 1629883606
 stonith-enabled: false


[root@sm17-r18 cluster]# cortx cluster start
{"status": "InProgress", "output": "Cluster start operation performed", "error": ""}[root@sm17-r18 cluster]#

[root@sm17-r18 cluster]# pcs property list
Cluster Properties:
 cluster-infrastructure: corosync
 cluster-name: cortx_cluster
 dc-version: 1.1.23-1.el7-9acf116022
 have-watchdog: false
 last-lrm-refresh: 1629883606
 stonith-enabled: true
  </code>
</pre>
