### PR TITLE
EOS-22373 : Fix for issues found in deployment

### DIFF
--- a/ha/core/config/config_manager.py
+++ b/ha/core/config/config_manager.py
@@ -143,3 +143,17 @@ class ConfigManager:
                 node_name = key.split('/')[-1]
                 return node_name
         raise HAInvalidNode(f"node_id {node_id} is not valid.")
+
+    @staticmethod
+    def get_node_id(node_name: str) -> str:
+        """
+        Get node_id from node_name
+        Args:
+            node_name (str): Node name from cluster nodes.
+        Returns: str
+            node_id (str): Node ID from cluster nodes.
+        """
+        confstore = ConfigManager.get_confstore()
+        key_val  = confstore.get(f"{const.PVTFQDN_TO_NODEID_KEY}/{node_name}")
+        _, node_id = key_val.popitem()
+        return node_id

--- a/ha/core/controllers/pcs/node_controller.py
+++ b/ha/core/controllers/pcs/node_controller.py
@@ -295,7 +295,7 @@ class PcsVMNodeController(PcsNodeController):
             ([dict]): Return dictionary. {"status": "", "output": "", "error": ""}
                 status: Succeeded, Failed, InProgress
         """
-        return super().start(node_id, **op_kwargs)
+        return json.loads(super().start(node_id, **op_kwargs))
 
     @controller_error_handler
     def stop(self, node_id: str, timeout: int= -1, **op_kwargs) -> dict:


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    Deployment was failing 
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
 No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Deployment was failing 
  </code>
</pre>
## Solution
<pre>
  <code>
    Following issues were found and fixed 
    1. function get _get_node_name deleted from controller and new function added in configManager
    2. node start for VM returning str instead of dict
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   On the 3 node VM deployment added the fixes and verified following scenarios 
   - cluster start and cluster stop using HA CLIs
  -  In cluster stop : forced the 3 nodes to stop (to verify that node_id change is handled here ) This ensured that the ndoe_id change is happening in the currently unused code also
  - From CSM CLI
     Verified that node start and stop is working fine  
     status confirmed using CLI "health show cluster"
 - From CSM GUI :
     Verified that node start and stop is working fine  
     status confirmed using CLI "health show cluster" and also on the GUI
  </code>
</pre>
