### PR TITLE
EOS-24001: Get message type throws an Error

### DIFF
--- a/ha/core/event_manager/event_manager.py
+++ b/ha/core/event_manager/event_manager.py
@@ -323,7 +323,7 @@ class EventManager:
         except Exception as e:
             raise SubscribeException(f"Failed to subscribe {component}. Error: {e}")
 
-    def unsubscribe(self, component: str, events: list, action: str = None) -> None:
+    def unsubscribe(self, component: SUBSCRIPTION_LIST, events: list, action: str = None) -> None:
         """
         Deregister the event for the specific component and the component \
         for the event using consul deletion
@@ -356,7 +356,7 @@ class EventManager:
         except Exception as e:
             raise UnSubscribeException(f"Failed to unsubscribe {component}. Error: {e}")
 
-    def get_events(self, component : str) -> list:
+    def get_events(self, component : SUBSCRIPTION_LIST) -> list:
         """
         It returns list of registered events by the requested component.
 
@@ -404,13 +404,14 @@ class EventManager:
             Log.error(f"Failed sending message for {event.resource_type}, Error: {e}")
             raise PublishException(f"Failed sending message for {event.resource_type}, Error: {e}")
 
-    def message_type(self, component: str) -> str:
+    def message_type(self, component: SUBSCRIPTION_LIST) -> str:
         """
         It returns message type name (queue name) mapped with component.
         Args:
             component (str): component name.
         """
-        component = component.value
+        if isinstance(component, SUBSCRIPTION_LIST):
+            component = component.value
         key = EVENT_MANAGER_KEYS.MESSAGE_TYPE_KEY.value.replace("<component_id>", component)
         value = None
         Log.debug(f"Fetching message type for {key}")


### PR DESCRIPTION
Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any): https://jts.seagate.com/browse/EOS-24001
    EOS-24001: Get message type throws an Error
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    In get message type previously we are considering component type as string & because of that when we are calling component.value it returns error message.
  </code>
</pre>
## Solution
<pre>
  <code>
    component type changed to SUBSCRIPTION_LIST.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    >>> from ha.core.event_manager.event_manager import EventManager
    >>> from ha.core.event_manager.subscribe_event import SubscribeEvent
    >>> event_manager = EventManager.get_instance()
    >>> cluster = SubscribeEvent("enclosure:hw:controller", ["online", "failed", "offline"])
<h4>Test 1 : Subscribe Event </h4>
    >>> test = event_manager.subscribe("csm", [cluster])
    >>> print(test)
    ha_event_csm
Event is added in consul KV store: 
                     cortx/ha/v1/events/enclosure:hw:controller/failed:["csm"]
                     cortx/ha/v1/events/enclosure:hw:controller/offline:["csm"]
                     cortx/ha/v1/events/enclosure:hw:controller/online:["csm"]
                     cortx/ha/v1/events/subscribe/csm:["enclosure:hw:controller/online", "enclosure:hw:controller/failed",                      "enclosure:hw:controller/offline"]
                    cortx/ha/v1/message_type/csm:ha_event_csm
                    cortx/ha/v1/nodes/srvnode-1:
<h4>Test 2 : Get Events </h4>
    >>> test = event_manager.get_events("csm")
    >>> print(test)
    ['enclosure:hw:controller/online', 'enclosure:hw:controller/failed', 'enclosure:hw:controller/offline']
<h4>Test 3 : Get message type </h4>
    >>> test = event_manager.message_type("csm")
    >>> print(test)
    ha_event_csm
<h4>Test 4 : Unsubscribe Event </h4>
    >>> test = event_manager.unsubscribe("csm", [cluster])
    >>> print(test)
    None
    Confirmed that all events are deleted from consul KV store.
  </code>
</pre>
## Deployment Status
<pre>
  <code>
   3-Node VM Deployment was successful with custom build link http://cortx-storage.colo.seagate.com/releases/cortx/github/integration-custom-ci/centos-7.8.2003/custom-build-2622/
  </code>
</pre>