### PR TITLE
EOS-23620 : Fix for enable stonith after cluster start

### DIFF
--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -778,15 +778,6 @@ class InitCmd(Cmd):
         Process init command.
         """
         Log.info("Processing init command")
-        env_type = self.get_installation_type().lower()
-        if env_type == const.INSTALLATION_TYPE.HW.value.lower():
-            Log.info("Enabling the stonith.")
-            self._execute.run_cmd(const.PCS_STONITH_ENABLE)
-            Log.info("Stonith enabled successfully.")
-        elif env_type == const.INSTALLATION_TYPE.VM.value.lower():
-            Log.warn(f"Stonith configuration not available, detected {env_type} env")
-        else:
-            raise HaConfigException(f"Invalid env detected, {env_type}")
         Log.info("init command is successful")
 
 class TestCmd(Cmd):


### PR DESCRIPTION
Signed-off-by: Amol Shinde <amol.shinde@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-23620: Secondary nodes (HW) stonith seen during deployment
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    If the stonith is enabled before the full cluster configuration, stonith behaves weirdly and does the node power off 
  </code>
</pre>
## Solution
<pre>
  <code>
    Enable stonith after the cluster start
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
  

 [root@sm17-r18 cluster]# pcs property list
Cluster Properties:
 cluster-infrastructure: corosync
 cluster-name: cortx_cluster
 dc-version: 1.1.23-1.el7-9acf116022
 have-watchdog: false
 last-lrm-refresh: 1629883606
 stonith-enabled: false


[root@sm17-r18 cluster]# cortx cluster start
{"status": "InProgress", "output": "Cluster start operation performed", "error": ""}[root@sm17-r18 cluster]#

[root@sm17-r18 cluster]# pcs property list
Cluster Properties:
 cluster-infrastructure: corosync
 cluster-name: cortx_cluster
 dc-version: 1.1.23-1.el7-9acf116022
 have-watchdog: false
 last-lrm-refresh: 1629883606
 stonith-enabled: true
  
  </code>
</pre>
