### PR TITLE
Change in Alex workflow

### DIFF
--- a/.github/workflows/alex_reviewdog.yml
+++ b/.github/workflows/alex_reviewdog.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
@@ -22,7 +22,7 @@ on:
   # Trigger the workflow on pull request labeled as cla-signed
   # and synchronize for the main branch
   pull_request:
-    types: [ labeled, synchronize ]
+    types: [ opened, synchronize ]
     branches:
       - main
   # Trigger the workflow on demand
@@ -31,7 +31,7 @@ jobs:
   # Let's start the alex to scan
   alex:
     name: Alex report
-    if: ${{ github.event.label.name == 'cla-signed' || github.event.action == 'synchronize' }}
+    #if: ${{ github.event.label.name == 'alex' || github.event.action == 'synchronize' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -40,4 +40,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           filter_mode: added
           reporter: github-pr-review
-          fail_on_error: false
+          fail_on_error: true
+          level: warning
+          


### PR DESCRIPTION
Problem Statement:
Triggering the Alex based on cla-signed is not appropriate because the label is not assigned for all the PRs .

Solution:
The Alex event will trigger whenever the PR is opened. Kindly refer the below document for more information about the tool Alex.

Signed-off-by: Venkatesh K venkatesh.k@seagate.com

Kindly refer Alex documentation
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/584778705/Alex+Workflow