### PR TITLE
EOS-24089: Unsubscribe the event twice throws an improper exception

### DIFF
--- a/ha/core/event_manager/error.py
+++ b/ha/core/event_manager/error.py
@@ -23,7 +23,10 @@ class EventManagerException(HAError):
         """
         Handle event manager function error.
         """
-        _desc = "Failed event manager action"
+        if desc is None:
+            _desc = "Failed event manager action"
+        else:
+            _desc = desc
         _message_id = HA_EVENT_MANAGER_ERROR
         _rc = 1
         super(EventManagerException, self).__init__(rc=_rc, desc=_desc, message_id=_message_id)

--- a/ha/core/event_manager/event_manager.py
+++ b/ha/core/event_manager/event_manager.py
@@ -244,7 +244,7 @@ class EventManager:
             else:
                 # If component key is not there, means event with that key will not be there,
                 # hence safely raise exception here so that _delete_event_key will not be called
-                raise UnSubscribeException(f"Can not unsubscribe the component: {component} as it was not registered earlier")
+                raise InvalidComponent(f"Can not unsubscribe the component: {component} as it was not registered earlier")
 
     def _delete_event_key(self, component: str, resource_type: str, states: list = None):
         '''
@@ -353,6 +353,8 @@ class EventManager:
                     if not self._confstore.key_exists(key):
                         self._monitor_rule.remove_rule(event.resource_type, state, self._default_action)
             Log.info(f"Successfully UnSubscribed component {component}")
+        except InvalidComponent:
+            raise
         except Exception as e:
             raise UnSubscribeException(f"Failed to unsubscribe {component}. Error: {e}")
 


### PR DESCRIPTION
Signed-off-by: Amol Shinde <amol.shinde@seagate.com>

## Problem Statement
<pre>
  <code>
  Story Ref (if any):
    EOS-24089: Unsubscribe the event twice throws an improper exception
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Unsubscribe the event twice throws an improper exception
  </code>
</pre>
## Solution
<pre>
  <code>
    Handle exception properly to show proper error message to client
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>

>>> from ha.core.event_manager.event_manager import EventManager
>>> from ha.core.event_manager.subscribe_event import SubscribeEvent
>>> cluster = SubscribeEvent("enclosure:hw:controller", ["online", "failed"])
>>> test = event_manager.unsubscribe("csm",[cluster])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'event_manager' is not defined
>>> event_manager = EventManager.get_instance()
>>> test = event_manager.unsubscribe("csm",[cluster])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/ha/core/event_manager/event_manager.py", line 348, in unsubscribe
    self._delete_component_key(component, event.resource_type, event.states)
  File "/usr/lib/python3.6/site-packages/ha/core/event_manager/event_manager.py", line 247, in _delete_component_key
    raise InvalidComponent(f"Can not unsubscribe the component: {component} as it was not registered earlier")
**ha.core.event_manager.error.InvalidComponent: error(1): Can not unsubscribe the component: csm as it was not registered earlier**
>
  </code>
</pre>
