### PR TITLE
EOS-25518: [K8S:RAW] Containerize K8S monitor

### DIFF
--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -49,9 +49,6 @@ class Cmd:
         if args is not None:
             self._url = args.config
             self._service = args.services
-            #if self._service != 'fault_tolerance':
-            #    sys.stderr.write('Invalid service name.\n')
-            #    sys.exit(1)
             Conf.load(self._index, self._url)
             self._args = args.args
         self._confstore = None

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -186,8 +186,8 @@ class ConfigCmd(Cmd):
                          'data_pod_label' : data_pod_label,
                          'MONITOR' : {'message_type' : 'k8s_event', 'producer_id' : 'k8s_monitor'},
                          'EVENT_MANAGER' : {'message_type' : 'health_events', 'producer_id' : 'system_health',
-                                            'consumer_group' : 'health_monitor', 'consumer_id' : '1'},
-                         'event_topic' : 'hare'}
+                                            'consumer_group' : 'health_monitor', 'consumer_id' : '1'}
+                         }
 
             if not os.path.isdir(const.CONFIG_DIR):
                 os.mkdir(const.CONFIG_DIR)

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -49,9 +49,9 @@ class Cmd:
         if args is not None:
             self._url = args.config
             self._service = args.services
-            if self._service != 'fault_tolerance':
-                sys.stderr.write('Invalid service name.\n')
-                sys.exit(1)
+            #if self._service != 'fault_tolerance':
+            #    sys.stderr.write('Invalid service name.\n')
+            #    sys.exit(1)
             Conf.load(self._index, self._url)
             self._args = args.args
         self._confstore = None
@@ -176,11 +176,6 @@ class ConfigCmd(Cmd):
             if not consul_endpoint:
                 sys.stderr.write(f'Failed to get consul config. consul_config: {consul_endpoint}. \n')
                 sys.exit(1)
-            # TODO: Uncomment whenever prometheus config will be available
-            # Conf.get(self._index, f'cortx{_DELIM}external{_DELIM}prometheus{_DELIM}endpoints[0]')
-
-            # command can be used to get scrape interval of prometheus
-            # kubectl describe configmap -n cortx | grep scrape_interval | awk \'{print $2}\'
 
             # Dummy value fetched for now. This will be replaced by the key/path for the pod label onces that is avilable in confstore
             # Ref ticket EOS-25694
@@ -190,13 +185,12 @@ class ConfigCmd(Cmd):
 
             conf_file_dict = {'LOG' : {'path' : const.HA_LOG_DIR, 'level' : const.HA_LOG_LEVEL},
                          'consul_config' : {'endpoint' : consul_endpoint},
-                         'prometheus_config' : {'endpoint' : None, 'poll_time': None},
                          'event_topic' : 'hare',
                          'data_pod_label' : data_pod_label,
-                         'MONITOR' : {'message_type' : 'k8s_event', 'producer_id' : 'k8s_monitor'}}
+                         'MONITOR' : {'message_type' : 'k8s_event', 'producer_id' : 'k8s_monitor'},
                          'EVENT_MANAGER' : {'message_type' : 'health_events', 'producer_id' : 'system_health',
-                                            'consumer_group' : 'health_monitor', 'consumer_id' : '1'}
-                         }
+                                            'consumer_group' : 'health_monitor', 'consumer_id' : '1'},
+                         'event_topic' : 'hare'}
 
             if not os.path.isdir(const.CONFIG_DIR):
                 os.mkdir(const.CONFIG_DIR)

--- a/ha/k8s_setup/ha_start.py
+++ b/ha/k8s_setup/ha_start.py
@@ -16,7 +16,8 @@ args = my_parser.parse_args()
 
 service_entry_mapping = {
                         'health_monitor': '/usr/lib/python3.6/site-packages/ha/core/health_monitor/health_monitord.py',
-                        'fault_tolerance': '/usr/lib/python3.6/site-packages/ha/fault_tolerance/fault_tolerance_driver.py'
+                        'fault_tolerance': '/usr/lib/python3.6/site-packages/ha/fault_tolerance/fault_tolerance_driver.py',
+                        'k8s_monitor': '/usr/lib/python3.6/site-packages/ha/monitor/k8s/monitor.py'
                         }
 
 def usage(prog: str):
@@ -26,7 +27,7 @@ def usage(prog: str):
         sys.stderr.write(
             f"usage: {prog} [-h] <--config url> <--services service to start>...\n"
             f"where:\n"
-            f"--services fault_tolerance, k8s_monitor\n"
+            f"--services health_monitor, fault_tolerance, k8s_monitor\n"
             f"--config   Config URL\n")
 
 try:
@@ -35,6 +36,5 @@ try:
         usage('ha_start')
         sys.exit(22)
     driver_process = Popen(['/usr/bin/python3', service_entry_mapping[args.services]], shell=False, stdout=PIPE, stderr=PIPE) # nosec
-
 except Exception as proc_err:
     sys.stderr.write(f'Driver execution stopped because of some reason: {proc_err}')

--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -54,7 +54,7 @@ class ObjectMonitor(Thread):
     def run(self):
 
         # Setup Credentials
-        config.load_kube_config()
+        config.load_incluster_config()
 
         # Initialize client
         k8s_client = client.CoreV1Api()

--- a/ha/test/cluster_role.yaml
+++ b/ha/test/cluster_role.yaml
@@ -1,0 +1,8 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pods-list
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list", "watch"]

--- a/ha/test/cluster_role_binding.yaml
+++ b/ha/test/cluster_role_binding.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pods-list
+subjects:
+- kind: ServiceAccount
+  name: ha-monitor
+  namespace: cortx
+roleRef:
+  kind: ClusterRole
+  name: pods-list
+  apiGroup: rbac.authorization.k8s.io
+

--- a/ha/test/ha_monitor_service_account.yaml
+++ b/ha/test/ha_monitor_service_account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ha-monitor
+  namespace: cortx
+


### PR DESCRIPTION
# Problem Statement
- Containerize K8S monitor service

# Design
Implementation will be done as part of https://jts.seagate.com/browse/EOS-25520. 

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: Y
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]: N/A
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

1. Crated a simple POD file which will use the cortx-all image and which will have my branch code
2. Performed exec to the container. As, right now, its printing the events, manually executed the entrypoint
sh-4.2# python3 /usr/lib/python3.6/site-packages/ha/monitor/k8s/monitor.py
Received Node-alert
Thread = Monitor-node-Thread Alert = {'_resource_type': 'k8s:node', '_resource_name': 'ssc-vm-g3-rhev4-1313.colo.seagate.com', '_event_type': 'online', '_k8s_container': None, '_pod': None, '_node': None, '_is_status': True}
Thread = Monitor-node-Thread Alert = {'_resource_type': 'k8s:node', '_resource_name': 'ssc-vm-g3-rhev4-1314.colo.seagate.com', '_event_type': 'online', '_k8s_container': None, '_pod': None, '_node': None, '_is_status': True}
Thread = Monitor-node-Thread Alert = {'_resource_type': 'k8s:node', '_resource_name': 'ssc-vm-g3-rhev4-1315.colo.seagate.com', '_event_type': 'online', '_k8s_container': None, '_pod': None, '_node': None, '_is_status': True}

Then created a dummy-pod with label as dummy.
Received pod online alert
Thread = Monitor-pod-Thread Alert = {'_resource_type': 'k8s:pod', '_resource_name': 'dummy-pod', '_event_type': 'online', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-1313.colo.seagate.com', '_is_status': True}

Performed deletion of that POD
Thread = Monitor-pod-Thread Alert = {'_resource_type': 'k8s:pod', '_resource_name': 'dummy-pod', '_event_type': 'failed', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-1313.colo.seagate.com', '_is_status': False}

Performed Node shutdown
Thread = Monitor-node-Thread Alert = {'_resource_type': 'k8s:node', '_resource_name': 'ssc-vm-g3-rhev4-1314.colo.seagate.com', '_event_type': 'failed', '_k8s_container': None, '_pod': None, '_node': None, '_is_status': False}

Now, Node up
Thread = Monitor-node-Thread Alert = {'_resource_type': 'k8s:node', '_resource_name': 'ssc-vm-g3-rhev4-1314.colo.seagate.com', '_event_type': 'online', '_k8s_container': None, '_pod': None, '_node': None, '_is_status': False}

