### PR TITLE
EOS-24275: Implement fault tolerance driver service

### DIFF
--- a/ha/core/event_analyzer/filter/filter.py
+++ b/ha/core/event_analyzer/filter/filter.py
@@ -192,7 +192,7 @@ class ClusterResourceFilter(Filter):
             event_resource_type = message.get("_resource_type")
 
             # namespace = Conf.get(const.HA_GLOBAL_INDEX, f"K8S:POD{_DELIM}namespace")
-            required_resource_type = Conf.get(const.HA_GLOBAL_INDEX, f"CLUSTER:NODE{_DELIM}resource_type")
+            required_resource_type = Conf.get(const.HA_GLOBAL_INDEX, f"NODE{_DELIM}resource_type")
             # pod_name = Conf.get(const.HA_GLOBAL_INDEX, f"K8S:POD{_DELIM}pods")
             # if event_namespace == namespace and event_pod_name.startswith(pod_name):
             if event_resource_type == required_resource_type:

--- a/ha/core/event_analyzer/filter/filter.py
+++ b/ha/core/event_analyzer/filter/filter.py
@@ -166,14 +166,14 @@ class IEMFilter(Filter):
         except Exception as e:
             raise EventFilterException(f"Failed to filter IEM event. Message: {msg}, Error: {e}")
 
-class K8SFilter(Filter):
+class ClusterResourceFilter(Filter):
     """ Filter unnecessary alert. """
 
     def __init__(self):
         """
         Init method
         """
-        super(K8SFilter, self).__init__()
+        super(ClusterResourceFilter, self).__init__()
         ConfigManager.init("event_analyzer")
 
     def filter_event(self, msg: str) -> bool:
@@ -183,24 +183,24 @@ class K8SFilter(Filter):
             msg (str): Msg
         """
         try:
-            K8S_alert_required = False
+            resource_alert_required = False
             message = json.dumps(ast.literal_eval(msg))
             message = json.loads(message)
 
-            Log.info('Received alert from fault tolerant')
+            Log.debug('Received alert from fault tolerance')
             # event_namespace = message.get("namespace")
             event_resource_type = message.get("_resource_type")
 
             # namespace = Conf.get(const.HA_GLOBAL_INDEX, f"K8S:POD{_DELIM}namespace")
-            required_resource_type = Conf.get(const.HA_GLOBAL_INDEX, f"K8S:POD{_DELIM}resource_type")
+            required_resource_type = Conf.get(const.HA_GLOBAL_INDEX, f"CLUSTER:NODE{_DELIM}resource_type")
             # pod_name = Conf.get(const.HA_GLOBAL_INDEX, f"K8S:POD{_DELIM}pods")
             # if event_namespace == namespace and event_pod_name.startswith(pod_name):
             if event_resource_type == required_resource_type:
-                K8S_alert_required = True
-                Log.info(f'This alert needs attention: resource_type: {event_resource_type}')
-                return K8S_alert_required
+                resource_alert_required = True
+                Log.info(f'This alert needs an attention: resource_type: {event_resource_type}')
+                return resource_alert_required
             else:
-                return K8S_alert_required
+                return resource_alert_required
 
         except Exception as e:
-            raise EventFilterException(f"Failed to filter K8S event. Message: {msg}, Error: {e}")
+            raise EventFilterException(f"Failed to filter cluster resource event. Message: {msg}, Error: {e}")

--- a/ha/core/event_analyzer/filter/filter.py
+++ b/ha/core/event_analyzer/filter/filter.py
@@ -188,19 +188,13 @@ class ClusterResourceFilter(Filter):
             message = json.loads(message)
 
             Log.debug('Received alert from fault tolerance')
-            # event_namespace = message.get("namespace")
             event_resource_type = message.get("_resource_type")
 
-            # namespace = Conf.get(const.HA_GLOBAL_INDEX, f"K8S:POD{_DELIM}namespace")
             required_resource_type = Conf.get(const.HA_GLOBAL_INDEX, f"NODE{_DELIM}resource_type")
-            # pod_name = Conf.get(const.HA_GLOBAL_INDEX, f"K8S:POD{_DELIM}pods")
-            # if event_namespace == namespace and event_pod_name.startswith(pod_name):
             if event_resource_type == required_resource_type:
                 resource_alert_required = True
                 Log.info(f'This alert needs an attention: resource_type: {event_resource_type}')
-                return resource_alert_required
-            else:
-                return resource_alert_required
+            return resource_alert_required
 
         except Exception as e:
             raise EventFilterException(f"Failed to filter cluster resource event. Message: {msg}, Error: {e}")

--- a/ha/core/event_analyzer/filter/filter.py
+++ b/ha/core/event_analyzer/filter/filter.py
@@ -187,7 +187,7 @@ class K8SFilter(Filter):
             message = json.dumps(ast.literal_eval(msg))
             message = json.loads(message)
 
-            Log.info(f'Received alert from fault tolerant')
+            Log.info('Received alert from fault tolerant')
             # event_namespace = message.get("namespace")
             event_resource_type = message.get("_resource_type")
 

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -29,6 +29,8 @@ from cortx.utils.message_bus import MessageConsumer
 from ha.core.config.config_manager import ConfigManager
 from ha import const
 from ha.k8s_setup.const import _DELIM
+from ha.core.event_analyzer.filter.filter import K8SFilter
+
 
 class FaultTolerant:
     """
@@ -55,6 +57,7 @@ class FaultTolerant:
                 Log.info('Ready to analyze faults in the system')
                 message = self._consumer.receive(timeout=0)
                 Log.debug(f'Received the message from message bus: {message}')
+                K8SFilter.filter_event(json.dumps(message.__dict__))
                 Log.error(f'Received the message from message bus: {message}')
                 time.sleep(self._poll_time)
         except Exception as exe:

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -20,7 +20,6 @@
 """
 
 
-import json
 import time
 
 from cortx.utils.conf_store import Conf
@@ -61,6 +60,7 @@ class FaultTolerant:
                 message = self._consumer.receive(timeout=0)
                 Log.info(f'Received the message from message bus: {message}')
                 result = self._k8s_filter.filter_event(message.decode('utf-8'))
+                Log.info(f'Alert required: {result}')
                 time.sleep(self._poll_time)
         except Exception as exe:
             raise(f'Oops, some issue in the fault tolerance_driver: {exe}')

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -37,12 +37,12 @@ class FaultTolerance:
     Module responsible for consuming messages from message bus,
     further analyzes that event and publishes it if required
     """
-    def __init__(self, poll_time=10):
+    def __init__(self, wait_time=10):
         """Init method"""
-        self._poll_time = poll_time
+        self._wait_time = wait_time
         self._cluster_resource_filter = ClusterResourceFilter()
         ConfigManager.init('fault_tolerance')
-        Log.info(f'poll time: {self._poll_time}')
+        Log.info(f'wait time: {self._wait_time}')
         self._consumer = self._get_consumer()
 
     def _get_consumer(self) -> MessageBusConsumer:
@@ -79,7 +79,7 @@ class FaultTolerance:
                 # with the help of event analyzer filter and publish to message bus
                 # if required
                 Log.info('Ready to analyze faults in the system')
-                time.sleep(self._poll_time)
+                time.sleep(self._wait_time)
         except Exception as exe:
             raise(f'Oops, some issue in the fault tolerance_driver: {exe}')
 

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -20,6 +20,7 @@
 """
 
 
+import json
 import time
 
 from cortx.utils.conf_store import Conf
@@ -40,6 +41,7 @@ class FaultTolerant:
     def __init__(self, poll_time=10):
         """Init method"""
         self._poll_time = poll_time
+        self._k8s_filter = K8SFilter()
         ConfigManager.init('fault_tolerance_driver')
         self._message_type = Conf.get(const.HA_GLOBAL_INDEX, f'MONITOR{_DELIM}message_type')
         self._consumer = MessageConsumer(consumer_id='1', consumer_group='consumer-group', \
@@ -50,15 +52,15 @@ class FaultTolerant:
     def poll(self):
         """Contineously polls for message bus for k8s_event message type"""
         try:
+            result = False
             while True:
                 # Get alert from message. Analyze changes
                 # with the help of event analyzer filter and publish to message bus
                 # if required
                 Log.info('Ready to analyze faults in the system')
                 message = self._consumer.receive(timeout=0)
-                Log.debug(f'Received the message from message bus: {message}')
-                K8SFilter.filter_event(json.dumps(message.__dict__))
-                Log.error(f'Received the message from message bus: {message}')
+                Log.info(f'Received the message from message bus: {message}')
+                result = self._k8s_filter.filter_event(message.decode('utf-8'))
                 time.sleep(self._poll_time)
         except Exception as exe:
             raise(f'Oops, some issue in the fault tolerance_driver: {exe}')

--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -22,5 +22,5 @@ HA_CONFIG_FILE="{}/ha.conf".format(CONFIG_DIR)
 _DELIM=">"
 
 # Event_manager keys
-POD_EVENT="k8s:pod"
+POD_EVENT="cluster:node"
 EVENT_COMPONENT="hare"

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -201,7 +201,7 @@ class ConfigCmd(Cmd):
             ConfigManager.init("ha_setup")
             self._confstore = ConfigManager.get_confstore()
             Log.info(f'Populating the ha config file with consul_endpoint: {consul_endpoint}, \
-                      prometheus_endpoint:')
+                       data_pod_label: {data_pod_label}')
 
             Log.info('Performing event_manager subscription')
             event_manager = EventManager.get_instance()

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -186,7 +186,8 @@ class ConfigCmd(Cmd):
                          'data_pod_label' : data_pod_label,
                          'MONITOR' : {'message_type' : 'k8s_event', 'producer_id' : 'k8s_monitor'},
                          'EVENT_MANAGER' : {'message_type' : 'health_events', 'producer_id' : 'system_health',
-                                            'consumer_group' : 'health_monitor', 'consumer_id' : '1'}
+                                            'consumer_group' : 'health_monitor', 'consumer_id' : '1'},
+                         'K8S:POD': {'namespace': 'cortx', 'resource_type': 'k8s:pod'}
                          }
 
             if not os.path.isdir(const.CONFIG_DIR):

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -189,7 +189,7 @@ class ConfigCmd(Cmd):
                                             'consumer_group' : 'health_monitor', 'consumer_id' : '1'},
                          'FAULT_TOLERANCE' : {'message_type' : 'cluster_event', 'consumer_group' : 'event_listener',
                                               'consumer_id' : '1'},
-                         'CLUSTER:NODE': {'namespace': 'cortx', 'resource_type': 'cluster:node'}
+                         'NODE': {'resource_type': 'node'}
                          }
 
             if not os.path.isdir(const.CONFIG_DIR):

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -184,10 +184,12 @@ class ConfigCmd(Cmd):
                          'consul_config' : {'endpoint' : consul_endpoint},
                          'event_topic' : 'hare',
                          'data_pod_label' : data_pod_label,
-                         'MONITOR' : {'message_type' : 'k8s_event', 'producer_id' : 'k8s_monitor'},
+                         'MONITOR' : {'message_type' : 'cluster_event', 'producer_id' : 'cluster_monitor'},
                          'EVENT_MANAGER' : {'message_type' : 'health_events', 'producer_id' : 'system_health',
                                             'consumer_group' : 'health_monitor', 'consumer_id' : '1'},
-                         'K8S:POD': {'namespace': 'cortx', 'resource_type': 'k8s:pod'}
+                         'FAULT_TOLERANCE' : {'message_type' : 'cluster_event', 'consumer_group' : 'event_listener',
+                                              'consumer_id' : '1'},
+                         'CLUSTER:NODE': {'namespace': 'cortx', 'resource_type': 'cluster:node'}
                          }
 
             if not os.path.isdir(const.CONFIG_DIR):

--- a/ha/monitor/k8s/alert.py
+++ b/ha/monitor/k8s/alert.py
@@ -35,7 +35,7 @@ class K8sAlert:
 
     @resource_type.setter
     def resource_type(self, res_type):
-        self._resource_type = f"cluster:{res_type}"
+        self._resource_type = f"{res_type}"
 
     @property
     def resource_name(self):

--- a/ha/monitor/k8s/alert.py
+++ b/ha/monitor/k8s/alert.py
@@ -35,7 +35,7 @@ class K8sAlert:
 
     @resource_type.setter
     def resource_type(self, res_type):
-        self._resource_type = f"k8s:{res_type}"
+        self._resource_type = f"cluster:{res_type}"
 
     @property
     def resource_name(self):

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -37,7 +37,7 @@ class ObjectParser:
 class NodeEventParser(ObjectParser):
     def __init__(self):
         super().__init__()
-        self._type = 'node'
+        self._type = 'host'
 
     def parse(self, an_event, cached_state):
         alert = K8sAlert()
@@ -96,7 +96,7 @@ class NodeEventParser(ObjectParser):
 class PodEventParser(ObjectParser):
     def __init__(self):
         super().__init__()
-        self._type = 'pod'
+        self._type = 'node'
 
     def parse(self, an_event, cached_state):
         alert = K8sAlert()


### PR DESCRIPTION
# Problem Statement
Implement Fault Tolerance service

# Design
https://seagate-systems.atlassian.net/wiki/spaces/~445727228/pages/688881888/Design+page
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/730890496/Fault+tolerance+LLD

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide


Testing:
1. Started k8s monitor so that alerts will be pushed to k8s_event topic on message bus
2 started fault_tolerance service which will listen on k8s_event topic of message bus
3. Deleted the POD with label as **cortx-data**
4. Checked the alert is received or not in fault_tolerance log file 
[root@ssc-vm-g3-rhev4-1313 cortx-ha-1]# tail -f /var/log/seagate/cortx/ha/fault_tolerance_driver.log







2021-11-02 05:46:15 fault_tolerance_driver [56346]: INFO [__init__] MessageBus initialized as kafka
2021-11-02 05:46:15 fault_tolerance_driver [56346]: INFO [__init__] poll time: 10
2021-11-02 05:46:15 fault_tolerance_driver [56346]: INFO [poll] Ready to analyze faults in the system
2021-11-02 05:46:16 fault_tolerance_driver [56346]: ERROR [poll] Received the message from message bus: b"{'_resource_type': 'k8s:pod', '_resource_name': 'dummy-pod', '_event_type': 'failed', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-1313.colo.seagate.com', '_is_status': False, '_timestamp': '1635853304'}"


Added filter criteria to ha.conf
Use new filter criteria to check whether alert is required or not
Modified mini provisioning to apply these conf changes.

Tested filtering:
1. started k8s_monitor
2. started fault_tolerance
3. Created/deleted dummy pod which has label as cortx-data
- Alert was recevied by k8s_monitor and fault_tolerance. Further, it reached to event analyzer. resource type check as "k8s:pod" was successful and filter function returned True

k8s_monitor logs:
2021-11-10 00:32:23 pod_monitor [40191]: INFO [run] Sending alert on message bus {'_resource_type': 'k8s:pod', '_resource_name': 'dummy-pod', '_event_type': 'failed', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-1313.colo.seagate.com', '_is_status': False, '_timestamp': '1636529543'}

Fault_tolerance debug logs:

2021-11-10 00:32:23 fault_tolerance_driver [29866]: ERROR [filter_event] {"_resource_type": "k8s:pod", "_resource_name": "dummy-pod", "_event_type": "failed", "_k8s_container": null, "_pod": null, "_node": "ssc-vm-g3-rhev4-1313.colo.seagate.com", "_is_status": false, "_timestamp": "1636529543"}

2021-11-10 00:32:23 fault_tolerance_driver [29866]: ERROR [filter_event] filter: True
2021-11-10 00:32:23 fault_tolerance_driver [29866]: ERROR [poll] Received the message from message bus: b"{'_resource_type': 'k8s:pod', '_resource_name': 'dummy-pod', '_event_type': 'failed', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-1313.colo.seagate.com', '_is_status': False, '_timestamp': '1636529543'}" True



Latest testing details:
Alert received in pod_monitor:
2021-11-23 22:58:06 pod_monitor [22407]: INFO [run] Sending alert on message bus {'_resource_type': 'cluster:node', '_resource_name': 'dummy-pod', '_event_type': 'failed', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-1313.colo.seagate.com', '_is_status': False, '_timestamp': '1637733486'}

Alert received in fault_tolerance
2021-11-23 22:57:29 fault_tolerance [22258]: INFO [poll] Ready to analyze faults in the system
2021-11-23 22:57:39 fault_tolerance [22258]: INFO [poll] Ready to analyze faults in the system
2021-11-23 22:57:49 fault_tolerance [22258]: INFO [poll] Ready to analyze faults in the system
2021-11-23 22:57:59 fault_tolerance [22258]: INFO [poll] Ready to analyze faults in the system
2021-11-23 22:58:06 fault_tolerance [22258]: INFO [process_message] Received the message from message bus: b"{'_resource_type': 'cluster:node', '_resource_name': 'dummy-pod', '_event_type': 'failed', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-1313.colo.seagate.com', '_is_status': False, '_timestamp': '1637733486'}"
2021-11-23 22:58:06 fault_tolerance [22258]: INFO [filter_event] Received alert from fault tolerant
2021-11-23 22:58:06 fault_tolerance [22258]: INFO [filter_event] This alert needs attention: resource_type: cluster:node
2021-11-23 22:58:06 fault_tolerance [22258]: INFO [process_message] Alert required: True
2021-11-23 22:58:09 fault_tolerance [22258]: INFO [poll] Ready to analyze faults in the system


Latest consul keys, as there is change of event subscription key
[root@ssc-vm-g3-rhev4-1313 cortx-ha-1]# consul kv get -http-addr=127.0.0.1:80 --recurse cortx/ha/v1
cortx/ha/v1:
cortx/ha/v1/action/cluster:node/failed:["publish"]
cortx/ha/v1/action/cluster:node/online:["publish"]
cortx/ha/v1/events/cluster:node/failed:["hare"]
cortx/ha/v1/events/cluster:node/online:["hare"]
cortx/ha/v1/events/subscribe/hare:["cluster:node/online", "cluster:node/failed"]
cortx/ha/v1/message_type/hare:ha_event_hare
