### PR TITLE
EOS-21183: Rename sspl-ll service to sspl

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -3,7 +3,7 @@
     "configMode": "LOCAL",
     "configExternalURL": "",
     "projectToken": "",
-    "baseBranches": ["main","stable"]
+    "baseBranches": ["main"]
   },
   "checkRunSettings": {
     "vulnerableCheckRunConclusionLevel": "failure",

--- a/conf/etc/v2/components/hw/sspl.json
+++ b/conf/etc/v2/components/hw/sspl.json
@@ -1,10 +1,10 @@
 {
-    "sspl-ll": {
+    "sspl": {
         "parameters": { },
         "group": "monitor_group",
         "provider": {
             "name": "systemd",
-            "service": "sspl-ll",
+            "service": "sspl",
             "intervals": [
                 "0s",
                 "30s",

--- a/conf/etc/v2/components/single_vm/sspl.json
+++ b/conf/etc/v2/components/single_vm/sspl.json
@@ -1,10 +1,10 @@
 {
-    "sspl-ll": {
+    "sspl": {
         "parameters": { },
         "group": "monitor_group",
         "provider": {
             "name": "systemd",
-            "service": "sspl-ll",
+            "service": "sspl",
             "intervals": [
                 "0s",
                 "30s",

--- a/conf/etc/v2/components/vm/sspl.json
+++ b/conf/etc/v2/components/vm/sspl.json
@@ -1,10 +1,10 @@
 {
-    "sspl-ll": {
+    "sspl": {
         "parameters": { },
         "group": "monitor_group",
         "provider": {
             "name": "systemd",
-            "service": "sspl-ll",
+            "service": "sspl",
             "intervals": [
                 "0s",
                 "30s",

--- a/conf/script/v1/build-ha-sspl
+++ b/conf/script/v1/build-ha-sspl
@@ -140,7 +140,7 @@ precheck() {
 systemd_disable() {
     log "${FUNCNAME[0]}: Disable sspl systemd unit"
     echo 'Disable sspl systemd unit...'
-    cmd='sudo systemctl stop sspl-ll && sudo systemctl disable sspl-ll'
+    cmd='sudo systemctl stop sspl && sudo systemctl disable sspl'
     run_on_both $cmd
 }
 

--- a/ha/core/controllers/pcs/node_controller.py
+++ b/ha/core/controllers/pcs/node_controller.py
@@ -411,8 +411,8 @@ class PcsHWNodeController(PcsNodeController):
                     return stop_status
 
             if storageoff:
-                # Stop services on node except sspl-ll
-                self._controllers[const.SERVICE_CONTROLLER].stop(node_id=node_name, excludeResourceList=[RESOURCE.SSPL_LL.value])
+                # Stop services on node except sspl
+                self._controllers[const.SERVICE_CONTROLLER].stop(node_id=node_name, excludeResourceList=[RESOURCE.SSPL.value])
 
                 # Stop the storage enclosure on the node
                 actuator_mgr = ActuatorManager()

--- a/ha/resource/sspl
+++ b/ha/resource/sspl
@@ -116,12 +116,12 @@ stateful_check_state() {
 }
 
 start_sspl_service() {
-        systemctl start sspl-ll
+        systemctl start sspl
         echo "START (master): $?"
 
         #check status
         for retry in {1..5}; do
-            status=$(systemctl is-active sspl-ll)
+            status=$(systemctl is-active sspl)
             case $status in
                 active )
                     return 0
@@ -152,8 +152,8 @@ stateful_start() {
 }
 
 stateful_demote() {
-    sspl_pid=`/sbin/pidof -s /usr/bin/sspl_ll_d`
-    sspl_state=`systemctl is-active sspl-ll`
+    sspl_pid=`/sbin/pidof -s /usr/bin/sspld`
+    sspl_state=`systemctl is-active sspl`
     log "DEMOTE: pid=$sspl_pid curr_state=$sspl_state"
     [ $sspl_state == 'active' -a $sspl_pid != '' ] ||
         return $(stateful_monitor)
@@ -171,8 +171,8 @@ stateful_demote() {
 
 stateful_promote() {
     sleep 8
-    sspl_pid=`/sbin/pidof -s /usr/bin/sspl_ll_d`
-    sspl_state=`systemctl is-active sspl-ll`
+    sspl_pid=`/sbin/pidof -s /usr/bin/sspld`
+    sspl_state=`systemctl is-active sspl`
     log "PROMOTE: pid=$sspl_pid curr_state=$sspl_state"
     [ $sspl_state == 'active' -a $sspl_pid != '' ] ||
         return $(stateful_monitor)
@@ -193,14 +193,14 @@ stateful_promote() {
 
 stateful_stop() {
     log "STOP..."
-    systemctl stop sspl-ll
+    systemctl stop sspl
     log "STOP: $?"
     rm -rf "${OCF_RESKEY_state}"
     return $OCF_SUCCESS
 }
 
 stateful_monitor() {
-    sspl_state=`systemctl is-active sspl-ll`
+    sspl_state=`systemctl is-active sspl`
     stateful_check_state "master"
     if [ $? -eq 0 ]; then
         log "MONITOR (master): $sspl_state"

--- a/ha/setup/const.py
+++ b/ha/setup/const.py
@@ -33,7 +33,7 @@ class RESOURCE(enum.Enum, metaclass=EnumListMeta):
     S3_BACK_PROD = "s3backprod"
     S3AUTH = "s3auth"
     HAPROXY = "haproxy"
-    SSPL_LL = "sspl-ll"
+    SSPL = "sspl"
     VIP_HEALTH_MONITOR = "vip_health"
     MGMT_VIP = "mgmt-vip"
     CSM_AGENT = "csm-agent"
@@ -59,7 +59,7 @@ TIMEOUT_MAP = {
         RESOURCE.S3_BACK_PROD.value: "90",
         RESOURCE.S3AUTH.value: "90",
         RESOURCE.HAPROXY.value: "90",
-        RESOURCE.SSPL_LL.value: "90",
+        RESOURCE.SSPL.value: "90",
         RESOURCE.VIP_HEALTH_MONITOR.value: "3",
         RESOURCE.MGMT_VIP.value: "60",
         RESOURCE.CSM_AGENT.value: "90",
@@ -81,7 +81,7 @@ TIMEOUT_MAP = {
         RESOURCE.S3_BACK_PROD.value: "90",
         RESOURCE.S3AUTH.value: "90",
         RESOURCE.HAPROXY.value: "90",
-        RESOURCE.SSPL_LL.value: "90",
+        RESOURCE.SSPL.value: "90",
         RESOURCE.VIP_HEALTH_MONITOR.value: "3",
         RESOURCE.MGMT_VIP.value: "60",
         RESOURCE.CSM_AGENT.value: "90",

--- a/ha/setup/create_pacemaker_resources.py
+++ b/ha/setup/create_pacemaker_resources.py
@@ -41,7 +41,7 @@ io_stack
     s3backcons
     s3backprod
 monitor
-    sspl-ll
+    sspl
 management
     mgmt-vip
     kibana
@@ -336,10 +336,10 @@ def haproxy(cib_xml, push=False, **kwargs):
 
 def sspl(cib_xml, push=False, **kwargs):
     """Create sspl clone resource in pacemaker."""
-    # Using sspl-ll service file according to the content of SSPL repo
-    sspl_start = str(get_res_timeout(RESOURCE.SSPL_LL.value, TIMEOUT_ACTION.START.value, "sspl-ll"))
-    sspl_stop = str(get_res_timeout(RESOURCE.SSPL_LL.value, TIMEOUT_ACTION.STOP.value, "sspl-ll"))
-    process.run_cmd(f"pcs -f {cib_xml} resource create {RESOURCE.SSPL_LL.value} systemd:sspl-ll \
+    # Using sspl service file according to the content of SSPL repo
+    sspl_start = str(get_res_timeout(RESOURCE.SSPL.value, TIMEOUT_ACTION.START.value, "sspl"))
+    sspl_stop = str(get_res_timeout(RESOURCE.SSPL.value, TIMEOUT_ACTION.STOP.value, "sspl"))
+    process.run_cmd(f"pcs -f {cib_xml} resource create {RESOURCE.SSPL.value} systemd:sspl \
         op start timeout={sspl_start}s interval=0s \
         op monitor timeout=29s interval=30s \
         op stop timeout={sspl_stop}s interval=0s --group monitor_group")

--- a/ha/setup/ha_setup.py
+++ b/ha/setup/ha_setup.py
@@ -397,10 +397,17 @@ class PostInstallCmd(Cmd):
                 raise HaPrerequisiteException("post_install command failed")
             else:
                 Log.info("hacluster is a part of the haclient group")
-            self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_HACLIENT}:rwx {const.RA_LOG_DIR}")
-            self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_ROOT}:rwx {const.RA_LOG_DIR}")
-            self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_HACLIENT}:r-x {const.CONFIG_DIR}")
-            self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_ROOT}:rwx {const.CONFIG_DIR}")
+            # For setting the acl, calling setfacl with -d option will set the
+            # passed acl as default for all new files and directories that would
+            # be created inside the parent directory, and then call setfacl with
+            # -R option to recursively set the same acls for existing files and
+            # directories.
+            self._execute.run_cmd(f"setfacl -d -R -m g:{const.USER_GROUP_HACLIENT}:rwx,g:{const.USER_GROUP_ROOT}:rwx {const.RA_LOG_DIR}")
+            self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_HACLIENT}:rwx,g:{const.USER_GROUP_ROOT}:rwx {const.RA_LOG_DIR}")
+
+            self._execute.run_cmd(f"setfacl -d -R -m g:{const.USER_GROUP_HACLIENT}:r-x,g:{const.USER_GROUP_ROOT}:rwx {const.CONFIG_DIR}")
+            self._execute.run_cmd(f"setfacl -R -m g:{const.USER_GROUP_HACLIENT}:r-x,g:{const.USER_GROUP_ROOT}:rwx {const.CONFIG_DIR}")
+
         except Exception as e:
             Log.error(f"Failed prerequisite with Error: {e}")
             raise HaPrerequisiteException("post_install command failed")

--- a/ha/test/unit/cluster_validation/test_cluster_validation.py
+++ b/ha/test/unit/cluster_validation/test_cluster_validation.py
@@ -59,7 +59,7 @@ class TestClusterLayout(unittest.TestCase):
                       "mgmt-vip.json",
                       "motr.json",
                       "s3servers.json",
-                      "sspl-ll.json",
+                      "sspl.json",
                       ]
         file_list = [prefix + s for s in components]
         node_list = ["srvnode-1", "srvnode-2", "srvnode-3"]

--- a/ha/util/message_bus.py
+++ b/ha/util/message_bus.py
@@ -184,8 +184,12 @@ class MessageBus:
             partitions (int): Number of partition.
         """
         admin = MessageBusAdmin(admin_id=MessageBus.ADMIN_ID)
-        if message_type not in admin.list_message_types():
-            admin.register_message_type(message_types=[message_type], partitions=partitions)
+        try:
+            if message_type not in admin.list_message_types():
+                admin.register_message_type(message_types=[message_type], partitions=partitions)
+        except Exception as e:
+            if "TOPIC_ALREADY_EXISTS" not in str(e):
+                raise(e)
 
     @staticmethod
     def deregister(message_type: str):

--- a/jenkins/dev_env/cortx_configure.sh
+++ b/jenkins/dev_env/cortx_configure.sh
@@ -102,8 +102,8 @@ chmod +x  ${DIR}/${SERVICE}
 cp -rf ${DUMMY_SERVICE} /usr/lib/systemd/system/${SERVICE}.service
 sed -i -e "s|<service>|${SERVICE}|g" /usr/lib/systemd/system/${SERVICE}.service
 
-# sspl-ll
-SERVICE="sspl-ll"
+# sspl
+SERVICE="sspl"
 cp -rf ${DUMMY_SCRIPT} ${DIR}/${SERVICE}
 chmod +x  ${DIR}/${SERVICE}
 cp -rf ${DUMMY_SERVICE} /usr/lib/systemd/system/${SERVICE}.service

--- a/whitesource.config
+++ b/whitesource.config
@@ -37,5 +37,5 @@ followSymbolicLinks=true
 
 # Linux package manager settings
 ################################
-scanPackageManager=true
+scanPackageManager=false
 


### PR DESCRIPTION
# Problem Statement
-  SSPL service has grown beyond its original design, and it doesn't need to limit to any internal domain name like low-level or high-level. So service needs to be renamed to sspl.

# Design
-  For Bug, Describe the fix here.
-  https://jts.seagate.com/browse/EOS-21183


# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: Y
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N] Y
- [x] Side effects on other features (deployment/upgrade)? [Y/N] Y
- [x] Dependencies on other component(s)? [Y/N] Y
-     SSPL: https://jts.seagate.com/browse/EOS-21183

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
