### PR TITLE
Changes for EOS-26578  [K8S:RAW] System health bootstrap changes required for K8S Alert

### DIFF
--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -307,20 +307,6 @@ class SystemHealth(Subscriber):
         self.producer.publish(str(healthevent))
         healthevent.node_id = node_id
 
-    # Placeholder function to detect if status of all pods is collected
-    # before "sys_health_bootstrap_timeout". Function , logic to be deleted
-    # if the requried data for the same is not going to be avilable from cluster.conf
-    def _check_num_pods(self):
-        """
-        Check if intial health status collected for all pods that are configured
-        """
-
-        #total_pods = Conf.get(const.HA_GLOBAL_INDEX, "total_num_pods")
-        # if number of pods definde  in confstore = number of pods for which status collected
-        # return true since intialization is done for all pods
-        # To be implemented
-        return False
-
     def _bootstrap_in_progress(self):
         """
         Check if we are in intial bootstrap time
@@ -349,12 +335,9 @@ class SystemHealth(Subscriber):
             self.healthmanager.set_key("sys_health_bootstrap_timeout", timeout)
             init_health_in_progress = True
         else:
-            # check if data for all pods already collected (optional check ;
-            # can be removed if total_num_pods will not be avilable in confstore)
-            if self._check_num_pods():
-                self.healthmanager.set_key("init_system_health", "0")
-                init_health_in_progress = False
-                return init_health_in_progress
+            # TBD Following logic can be added after EOS-26597 is resolved.
+            # Once total number of pods and service types of the pods are avilable in the config,
+            # use the same to expediate bootstrap process i.e. to exit bootstrap mode before timeout
 
             # check if within timeout period
             curr_time = int(time.time())

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -341,11 +341,11 @@ class SystemHealth(Subscriber):
             self.healthmanager.set_key("init_system_health", "1")
 
             curr_time = str(int(time.time()))
-            # Currently this timecout is started form the time first event is received till timout
+            # Currently this timeout is started form the time first event is received till timout
             # Confirm that this fine.. or should be started from bootstrap time.
             # ideally both will be almost identical.
             self.healthmanager.set_key("inital_time", curr_time)
-            timeout = Conf.get(const.HA_GLOBAL_INDEX, "sys_health_bootstrap_timeout")
+            timeout = Conf.get(const.HA_GLOBAL_INDEX,  f"SYSTEM_HEALTH{_DELIM}sys_health_bootstrap_timeout")
             self.healthmanager.set_key("sys_health_bootstrap_timeout", timeout)
             init_health_in_progress = True
         else:

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -307,9 +307,9 @@ class SystemHealth(Subscriber):
         self.producer.publish(str(healthevent))
         healthevent.node_id = node_id
 
-    # Placeholder function to detect if status of all pods is collected before "sys_health_bootstrap_timeout"
-    # Function , logic to be deleted
-    # if the requried data for the same is not going to be avilable from cluster.conf 
+    # Placeholder function to detect if status of all pods is collected
+    # before "sys_health_bootstrap_timeout". Function , logic to be deleted
+    # if the requried data for the same is not going to be avilable from cluster.conf
     def _check_num_pods(self):
         """
         Check if intial health status collected for all pods that are configured
@@ -342,28 +342,29 @@ class SystemHealth(Subscriber):
 
             curr_time = str(int(time.time()))
             # Currently this timecout is started form the time first event is received till timout
-            # Confirm that this fine.. or should be started from bootstrap time.ideally both will be almost identical. 
-            self.healthmanager.set_key( "inital_time", curr_time)
+            # Confirm that this fine.. or should be started from bootstrap time.
+            # ideally both will be almost identical.
+            self.healthmanager.set_key("inital_time", curr_time)
             timeout = Conf.get(const.HA_GLOBAL_INDEX, "sys_health_bootstrap_timeout")
-            self.healthmanager.set_key( "sys_health_bootstrap_timeout", timeout)
+            self.healthmanager.set_key("sys_health_bootstrap_timeout", timeout)
             init_health_in_progress = True
         else:
             # check if data for all pods already collected (optional check ;
             # can be removed if total_num_pods will not be avilable in confstore)
             if self._check_num_pods():
-                self.healthmanager.set_key( "init_system_health", "0")
+                self.healthmanager.set_key("init_system_health", "0")
                 init_health_in_progress = False
                 return init_health_in_progress
 
             # check if within timeout period
             curr_time = int(time.time())
-            init_time = int(self.healthmanager.get_key( "inital_time"))
-            timeout = int(self.healthmanager.get_key( "sys_health_bootstrap_timeout"))
+            init_time = int(self.healthmanager.get_key("inital_time"))
+            timeout = int(self.healthmanager.get_key("sys_health_bootstrap_timeout"))
 
             if curr_time - init_time <= timeout:
-                init_health_in_progress =  True
+                init_health_in_progress = True
             else:
-                self.healthmanager.set_key( "init_system_health", "0")
+                self.healthmanager.set_key("init_system_health", "0")
                 init_health_in_progress = False
 
         return init_health_in_progress
@@ -376,7 +377,7 @@ class SystemHealth(Subscriber):
         comp_type = healthevent.resource_type.split(':')[-1]
         comp_id = healthevent.resource_id
 
-        bootstrp_in_progress =  self._bootstrap_in_progress()
+        bootstrp_in_progress = self._bootstrap_in_progress()
 
         key = self._prepare_key(component, cluster_id=self.node_map['cluster_id'], site_id=self.node_map['site_id'],
                                 rack_id=self.node_map['rack_id'], storageset_id=self.node_map['storageset_id'],

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -327,9 +327,7 @@ class SystemHealth(Subscriber):
             self.healthmanager.set_key("init_system_health", "1")
 
             curr_time = str(int(time.time()))
-            # Currently this timeout is started form the time first event is received till timout
-            # Confirm that this fine.. or should be started from bootstrap time.
-            # ideally both will be almost identical.
+            # Timeout counting starts form the time first event is received by system health
             self.healthmanager.set_key("inital_time", curr_time)
             timeout = Conf.get(const.HA_GLOBAL_INDEX,  f"SYSTEM_HEALTH{_DELIM}sys_health_bootstrap_timeout")
             self.healthmanager.set_key("sys_health_bootstrap_timeout", timeout)

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -205,6 +205,12 @@ class ConfigCmd(Cmd):
             # Note: machine id key is not available in pod event hence using pod name
             #       but once it is available machine id key we will using it
             machine_id_key = 'metadata/name'
+            # Time till when system health can be collected in bootstrap mode
+            timeout = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}product_release')
+            timeout = '10' # in seconds ;  temporary value till the same is avilabe in cluster.conf
+            # Total number of pods for which health is to be maintained
+            num_pods = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}product_release')
+            num_pods = '10' #temporary value till the same is avilabe in cluster.conf
 
             conf_file_dict = {'LOG' : {'path' : const.HA_LOG_DIR, 'level' : const.HA_LOG_LEVEL},
                          'consul_config' : {'endpoint' : consul_endpoint},
@@ -216,7 +222,9 @@ class ConfigCmd(Cmd):
                          'FAULT_TOLERANCE' : {'message_type' : 'cluster_event', 'consumer_group' : 'event_listener',
                                               'consumer_id' : '1'},
                          'NODE': {'resource_type': 'node'},
-                         'SYSTEM_HEALTH' : {'num_entity_health_events' : 2}
+                         'SYSTEM_HEALTH' : {'num_entity_health_events' : 2},
+                         'sys_health_bootstrap_timeout' : timeout,
+                         'total_num_pods' : num_pods
                          }
 
             if not os.path.isdir(const.CONFIG_DIR):
@@ -247,6 +255,7 @@ class ConfigCmd(Cmd):
             with open(const.HA_CONFIG_FILE, 'w+') as conf_file:
                 yaml.dump(conf_file_dict, conf_file, default_flow_style=False)
             self._confstore = ConfigManager.get_confstore()
+
             Log.info(f'Populating the ha config file with consul_endpoint: {consul_endpoint}, \
                        data_pod_label: {data_pod_label}')
 

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -222,9 +222,9 @@ class ConfigCmd(Cmd):
                          'FAULT_TOLERANCE' : {'message_type' : 'cluster_event', 'consumer_group' : 'event_listener',
                                               'consumer_id' : '1'},
                          'NODE': {'resource_type': 'node'},
-                         'SYSTEM_HEALTH' : {'num_entity_health_events' : 2},
-                         'sys_health_bootstrap_timeout' : timeout,
-                         'total_num_pods' : num_pods
+                         'SYSTEM_HEALTH' : {'num_entity_health_events' : 2,
+                                            'sys_health_bootstrap_timeout' : timeout,
+                                            'total_num_pods' : num_pods }
                          }
 
             if not os.path.isdir(const.CONFIG_DIR):


### PR DESCRIPTION
# Problem Statement
  Create create resource map during bootstrap from the system health module

# Design
Events are received by system health from the k8s_monitor.
At the beginning, HA needs to identify the nodes (i.e. k8s pods) that are running in the system for which alerts need to be generated. This list needs to be maintained in confstore.  For this time duration, alerts should not be sent to Hare.
To get this list, system health uses timeout value available in ha.conf and alerts coming from k8s monitor are absorbed by system health. Hare events are not generated
After timeout is reached, alerts received after that are sent to hare
# Coding
-  [x] Coding conventions are followed and code is consistent : yes

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM : yes

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [x] Side effects on other features (deployment/upgrade)? [Y/N] N
- [ ] Dependencies on other component(s)? [Y/N] 
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]:  N

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
