### PR TITLE
EOS-26559 added constant machine id key.

### DIFF
--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -198,13 +198,6 @@ class ConfigCmd(Cmd):
             # TBD delete once data_pod_label is avilable from confstore
             data_pod_label = ['cortx-data', 'cortx-server']
 
-            # Dummy value fetched for now. This will be replaced by the key/path for the service ID/machine ID once that is available in confstore
-            # Ref ticket EOS-???
-            machine_id_key = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}product_release')
-            # TBD delete once machine_id_key is avilable from confstore
-            # Note: machine id key is not available in pod event hence using pod name
-            #       but once it is available machine id key we will using it
-            machine_id_key = 'metadata/name'
             # Time till when system health can be collected in bootstrap mode
             timeout = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}product_release')
             timeout = '10' # in seconds ;  temporary value till the same is avilabe in cluster.conf
@@ -216,7 +209,7 @@ class ConfigCmd(Cmd):
                          'consul_config' : {'endpoint' : consul_endpoint},
                          'event_topic' : 'hare',
                          'data_pod_label' : data_pod_label,
-                         'MONITOR' : {'message_type' : 'cluster_event', 'producer_id' : 'cluster_monitor', 'machine_id_key' : machine_id_key},
+                         'MONITOR' : {'message_type' : 'cluster_event', 'producer_id' : 'cluster_monitor'},
                          'EVENT_MANAGER' : {'message_type' : 'health_events', 'producer_id' : 'system_health',
                                             'consumer_group' : 'health_monitor', 'consumer_id' : '1'},
                          'FAULT_TOLERANCE' : {'message_type' : 'cluster_event', 'consumer_group' : 'event_listener',

--- a/ha/monitor/k8s/const.py
+++ b/ha/monitor/k8s/const.py
@@ -21,6 +21,10 @@ class K8SEventsConst:
     RAW_OBJECT = 'raw_object'
     METADATA = 'metadata'
     NAME = 'name'
+    LABELS ='labels'
+    # cortx specific key for fetching machine id from event.
+    # k8s event: ['raw_object']['metadata']['labels']['cortx.io/machine-id']
+    MACHINEID = 'cortx.io/machine-id'
     SPEC = 'spec'
     NODE_NAME = 'nodeName'
     PHASE = 'phase'

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -110,29 +110,8 @@ class PodEventParser(ObjectParser):
         alert.resource_type = self._type
         alert.timestamp = str(int(time.time()))
 
-        # Imp Note: Below logic is required only if we are getting the absolute path where the machine-id exists in the event.
-        #           i.e. metadata/podInfo/machineId so it will be parsed like [raw_object][metadata][podInfo][machineId]
-        #           because k8s event we receive is multi-level nested dict and  the key can occur at multiple places
-        #           for different reasons as other many keys getting repeated so choosing required key will be difficult.
-        #           OR if once the key is added while creating pod and the fixed exact location in the event is found then,
-        #           the changes added in /k8s_setup/ha_setup.py for this key and the below logic for parsing this key
-        #           is also not required can add constants and directly fetch the value.
-
-        # Get value of machine id key (path of the machine id in k8s event)
-        machine_id_key = Conf.get(const.HA_GLOBAL_INDEX, f"MONITOR{_DELIM}machine_id_key")
-
-        # loop over keys and check if exist, then get the value.
-        # this code is flexible can be used for any key in an event, for example
-        # if value at the place event[raw_object][metadata][name] then input key will be 'metadata/name'
-        # note if the key is fixed and cannot change, then can use constant here also instead of parsing
-        machine_id_keys = machine_id_key.split('/')
-        machine_id = an_event[K8SEventsConst.RAW_OBJECT]
-        for key in machine_id_keys:
-            if key != None and isinstance(machine_id, dict) and key in machine_id:
-                machine_id = machine_id[key]
-        if  machine_id is not None and not isinstance(machine_id, dict):
-            alert.resource_name = machine_id
-
+        if K8SEventsConst.MACHINEID in an_event[K8SEventsConst.RAW_OBJECT][K8SEventsConst.METADATA][K8SEventsConst.LABELS]:
+            alert.resource_name = an_event[K8SEventsConst.RAW_OBJECT][K8SEventsConst.METADATA][K8SEventsConst.LABELS][K8SEventsConst.MACHINEID]
         if K8SEventsConst.TYPE in an_event:
             alert.event_type = an_event[K8SEventsConst.TYPE]
         if K8SEventsConst.NODE_NAME in an_event[K8SEventsConst.RAW_OBJECT][K8SEventsConst.SPEC]:

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -110,8 +110,9 @@ class PodEventParser(ObjectParser):
         alert.resource_type = self._type
         alert.timestamp = str(int(time.time()))
 
-        if K8SEventsConst.MACHINEID in an_event[K8SEventsConst.RAW_OBJECT][K8SEventsConst.METADATA][K8SEventsConst.LABELS]:
-            alert.resource_name = an_event[K8SEventsConst.RAW_OBJECT][K8SEventsConst.METADATA][K8SEventsConst.LABELS][K8SEventsConst.MACHINEID]
+        labels = an_event[K8SEventsConst.RAW_OBJECT][K8SEventsConst.METADATA][K8SEventsConst.LABELS]
+        if K8SEventsConst.MACHINEID in labels:
+            alert.resource_name = labels[K8SEventsConst.MACHINEID]
         if K8SEventsConst.TYPE in an_event:
             alert.event_type = an_event[K8SEventsConst.TYPE]
         if K8SEventsConst.NODE_NAME in an_event[K8SEventsConst.RAW_OBJECT][K8SEventsConst.SPEC]:


### PR DESCRIPTION
Signed-off-by: mukhtar inamdar <mukhtar.inamdar@seagate.com>

# Problem Statement
- finalize the machine id key as it is added in the pod definition
- so needs to remove from conf and get the actual machine-id from the event to alert.resource_name

# Design
-  Finalize the machine id key as it is added in the pod definition.
-  Removed from conf
- Added code to get the actual machine-id.
-  Fetch like this: event['raw_object']['metadata']['labels']['cortx.io/machine-id']

# Test scenarios
- **Tested by running the monitor service through python file, used rpm to install inside POD.**
- execute the monitor code and print the pod events (i.e. cortx node event)
- see below print logs

> sh-4.2# python3 /usr/lib/python3.6/site-packages/ha/monitor/k8s/monitor.py
---------------------------host-------------------------
---------------------------host-------------------------
---------------------------host-------------------------
---------------------------node-------------------------
{'_resource_type': 'node', '_resource_name': '19a7dfc86d424a5bb3c2bc22a19b236b', '_event_type': 'online', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-2370.colo.seagate.com', '_is_status': True, '_timestamp': '1639405577'}
---------------------------node-------------------------
{'_resource_type': 'node', '_resource_name': '3595344c9cc7469e8055d453e4fb738d', '_event_type': 'online', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-2374.colo.seagate.com', '_is_status': True, '_timestamp': '1639405578'}
---------------------------node-------------------------
{'_resource_type': 'node', '_resource_name': '2920c806b724430097d2108e3ae67975', '_event_type': 'online', '_k8s_container': None, '_pod': None, '_node': 'ssc-vm-g3-rhev4-2403.colo.seagate.com', '_is_status': True, '_timestamp': '1639405578'}
---------------------------------------------------------------------------------------------------------------------------------------
- I have cross verify the machine-id if it is actually present on the pod
- see below commands
`[root@ssc-vm-g3-rhev4-2370 ~]# kubectl exec -it pod/cortx-data-pod-ssc-vm-g3-rhev4-2370-765f44d8d5-x2kbw -- sh
Defaulting container name to cortx-s3-haproxy.
Use 'kubectl describe pod/cortx-data-pod-ssc-vm-g3-rhev4-2370-765f44d8d5-x2kbw -n default' to see all of the containers in this pod.
sh-4.2# cat /etc/machine-id
19a7dfc86d424a5bb3c2bc22a19b236b`

# snippet from event received from API server Kubenetes showing machine id place:
`'raw_object': {'kind': 'Pod', 'apiVersion': 'v1', 'metadata': {'name': 'cortx-data-pod-ssc-vm-g3-rhev4-2370-765f44d8d5-x2kbw', 'generateName': 'cortx-data-pod-ssc-vm-g3-rhev4-2370-765f44d8d5-', 'namespace': 'default', 'selfLink': '/api/v1/namespaces/default/pods/cortx-data-pod-ssc-vm-g3-rhev4-2370-765f44d8d5-x2kbw', 'uid': 'd8dbace9-b732-4998-9bac-059d4d3e7cb3', 'resourceVersion': '14423', 'creationTimestamp': '2021-12-13T06:31:08Z', 'labels': {'app': 'cortx-data-pod-ssc-vm-g3-rhev4-2370', 'cortx.io/machine-id': '19a7dfc86d424a5bb3c2bc22a19b236b', ...`

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path, and Scalability
- [x] Testing was performed with RPM or custom image installation?
        Tested by installing HA rpm on the control pod and running monitor service.
- [x]  Tested by running python files

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]:    **N**
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N]    **N**
- [x] Side effects on other features (deployment/upgrade)? [Y/N]    **N**
- [x] Dependencies on other component(s)? [Y/N]    **N**
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide **N/A**
