### PR TITLE
Eos 27071 : HA POD Health-monitor container failing for consul enpoints[0] not reachable

### DIFF
--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -25,7 +25,7 @@ HEALTH_HIERARCHY_FILE = "{}/system_health_hierarchy.json".format(CONFIG_DIR)
 #Confstore delimiter
 _DELIM=">"
 
-# consule endpoint scheme: http
+# consul endpoint scheme: http
 consul_scheme = 'http'
 
 # Event_manager keys

--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -26,7 +26,7 @@ HEALTH_HIERARCHY_FILE = "{}/system_health_hierarchy.json".format(CONFIG_DIR)
 _DELIM=">"
 
 # consule endpoint scheme: http
-consule_scheme = 'http'
+consul_scheme = 'http'
 
 # Event_manager keys
 POD_EVENT="node"

--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -25,6 +25,9 @@ HEALTH_HIERARCHY_FILE = "{}/system_health_hierarchy.json".format(CONFIG_DIR)
 #Confstore delimiter
 _DELIM=">"
 
+# consule endpoint scheme: http
+consule_scheme = 'http'
+
 # Event_manager keys
 POD_EVENT="node"
 EVENT_COMPONENT="hare"

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -191,10 +191,11 @@ class ConfigCmd(Cmd):
             consul_endpoints = Conf.get(self._index, f'cortx{_DELIM}external{_DELIM}consul{_DELIM}endpoints')
             # search for supported consul endpoint url from list of configured consule endpoints
             consul_endpoint = list(filter(lambda x: urlparse(x).scheme == const.consule_scheme, consul_endpoints))
-            if not consul_endpoint:
+            if not consul_endpoint or len(consul_endpoint[0]) == 0:
                 sys.stderr.write(f'Failed to get consul config. consul_config: {consul_endpoint}. \n')
                 sys.exit(1)
-
+            # take first endpoint as it will be always 1
+            consul_endpoint = consul_endpoint[0]
             # Dummy value fetched for now. This will be replaced by the key/path for the pod label once that is available in confstore
             # Ref ticket EOS-25694
             data_pod_label = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}product_release')

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -196,12 +196,12 @@ class ConfigCmd(Cmd):
             # - tcp://consul-server.default.svc.cluster.local:8301   #
             # - http://consul-server.default.svc.cluster.local:8500  #
             #========================================================#
-            # search for supported consul endpoint url from list of configured consule endpoints
+            # search for supported consul endpoint url from list of configured consul endpoints
             filtered_consul_endpoints = list(filter(lambda x: urlparse(x).scheme == const.consul_scheme, consul_endpoints))
-            if not filtered_consul_endpoints or len(filtered_consul_endpoints[0]) == 0:
+            if not filtered_consul_endpoints:
                 sys.stderr.write(f'Failed to get consul config. consul_config: {filtered_consul_endpoints}. \n')
                 sys.exit(1)
-            # take first endpoint as it will be always 1
+            # discussed and confirmed to select the first hhtp endpoint
             consul_endpoint = filtered_consul_endpoints[0]
             # Dummy value fetched for now. This will be replaced by the key/path for the pod label once that is available in confstore
             # Ref ticket EOS-25694

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -22,6 +22,7 @@ import traceback
 import os
 import shutil
 import yaml
+from urllib.parse import urlparse
 
 from cortx.utils.conf_store import Conf
 from cortx.utils.log import Log
@@ -187,7 +188,9 @@ class ConfigCmd(Cmd):
         Process config command.
         """
         try:
-            consul_endpoint = Conf.get(self._index, f'cortx{_DELIM}external{_DELIM}consul{_DELIM}endpoints[0]')
+            consul_endpoints = Conf.get(self._index, f'cortx{_DELIM}external{_DELIM}consul{_DELIM}endpoints')
+            # search for supported consul endpoint url from list of configured consule endpoints
+            consul_endpoint = list(filter(lambda x: urlparse(x).scheme == const.consule_scheme, consul_endpoints))
             if not consul_endpoint:
                 sys.stderr.write(f'Failed to get consul config. consul_config: {consul_endpoint}. \n')
                 sys.exit(1)

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -189,13 +189,20 @@ class ConfigCmd(Cmd):
         """
         try:
             consul_endpoints = Conf.get(self._index, f'cortx{_DELIM}external{_DELIM}consul{_DELIM}endpoints')
+            #========================================================#
+            # consul Service endpoints from cluster.conf             #
+            #____________________ cluster.conf ______________________#
+            # endpoints:                                             #
+            # - tcp://consul-server.default.svc.cluster.local:8301   #
+            # - http://consul-server.default.svc.cluster.local:8500  #
+            #========================================================#
             # search for supported consul endpoint url from list of configured consule endpoints
-            consul_endpoint = list(filter(lambda x: urlparse(x).scheme == const.consule_scheme, consul_endpoints))
-            if not consul_endpoint or len(consul_endpoint[0]) == 0:
-                sys.stderr.write(f'Failed to get consul config. consul_config: {consul_endpoint}. \n')
+            filtered_consul_endpoints = list(filter(lambda x: urlparse(x).scheme == const.consul_scheme, consul_endpoints))
+            if not filtered_consul_endpoints or len(filtered_consul_endpoints[0]) == 0:
+                sys.stderr.write(f'Failed to get consul config. consul_config: {filtered_consul_endpoints}. \n')
                 sys.exit(1)
             # take first endpoint as it will be always 1
-            consul_endpoint = consul_endpoint[0]
+            consul_endpoint = filtered_consul_endpoints[0]
             # Dummy value fetched for now. This will be replaced by the key/path for the pod label once that is available in confstore
             # Ref ticket EOS-25694
             data_pod_label = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}product_release')

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -197,7 +197,7 @@ class ConfigCmd(Cmd):
             # - http://consul-server.default.svc.cluster.local:8500  #
             #========================================================#
             # search for supported consul endpoint url from list of configured consul endpoints
-            filtered_consul_endpoints = list(filter(lambda x: urlparse(x).scheme == const.consul_scheme, consul_endpoints))
+            filtered_consul_endpoints = list(filter(lambda x: isinstance(x, str) and urlparse(x).scheme == const.consul_scheme, consul_endpoints))
             if not filtered_consul_endpoints:
                 sys.stderr.write(f'Failed to get consul config. consul_config: {filtered_consul_endpoints}. \n')
                 sys.exit(1)


### PR DESCRIPTION
# Problem Statement
- HA POD Health-monitor container failing for consul enpoints[0] not reachable

# Design
-  should not use console enpoints[0] directly instead search the HTTP console end point and then use it.
- cluaster.conf will have a list of endpoints out of which needs to filter and take HTTP console endpoint and then use it.

# test scenarios
[test_scenarios_ha-monitor-logs_EOS-27071.txt](https://github.com/Seagate/cortx-ha/files/7767395/test_scenarios_ha-monitor-logs_EOS-27071.txt)

  *------------------------------------------
  sample endpoint entries of consul config from cluster.conf
   *------------------------------------------
  ...
    external:
    consul:
    admin: admin
    endpoints:
    - tcp://consul-server.default.svc.cluster.local:8301
    -
    - HTTP
    - HTTP:
    - http://
    - http://127.0.0.1:8500
    - https:///consul-server.default.svc.cluster.local:8500
    - http://consul-server.default.svc.cluster.local:8500
  ...
  *------------------------------------------
  
  so ha_setup will get the consul endpoints
  consul_endpoints:
  [
  'tcp://consul-server.default.svc.cluster.local:8301',
  None,
  'http',
  {'http': None},
  'http://',
  'http://127.0.0.1:8500',
  'https:///consul-server.default.svc.cluster.local:8500',
  'http://consul-server.default.svc.cluster.local:8500'
  ]

  filtered to below output:
  filtered_endpoints:
  [
  'http://',
  'http://127.0.0.1:8500',
  'http://consul-server.default.svc.cluster.local:8500'
  ]

  and out of filter if used invalid entry will get error like below
  HA Config failed. OS_error: Invalid URL '<url>': No host supplied.

# Coding
-  [x ] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N] NA
- [ ] Side effects on other features (deployment/upgrade)? [Y/N] N
- [ ] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
