### PR TITLE
Changes for EOS-27056 Mechanism to receive stop message from CSM in case of cluster stop

### DIFF
--- a/ha/fault_tolerance/cluster_stop_monitor.py
+++ b/ha/fault_tolerance/cluster_stop_monitor.py
@@ -49,6 +49,7 @@ class ClusterStopMonitor:
         self._consumer_id = Conf.get(const.HA_GLOBAL_INDEX, f'CLUSTER_STOP_MON{_DELIM}consumer_id')
         self._consumer_group = Conf.get(const.HA_GLOBAL_INDEX, f'CLUSTER_STOP_MON{_DELIM}consumer_group')
         self._message_type = Conf.get(const.HA_GLOBAL_INDEX, f'CLUSTER_STOP_MON{_DELIM}message_type')
+        MessageBus.init()
         return MessageBus.get_consumer(consumer_id=self._consumer_id, \
                                 consumer_group=self._consumer_group, \
                                 message_type=self._message_type, \

--- a/ha/fault_tolerance/cluster_stop_monitor.py
+++ b/ha/fault_tolerance/cluster_stop_monitor.py
@@ -56,7 +56,6 @@ class ClusterStopMonitor:
 
     def process_message(self, message: str):
         """Callback method for MessageConsumer"""
-        #Log.debug(f'Received the message from message bus: {message}')
         Log.debug(f'Received the message from message bus: {message}')
         try:
             # parse the message and check if cluster stop received

--- a/ha/fault_tolerance/cluster_stop_monitor.py
+++ b/ha/fault_tolerance/cluster_stop_monitor.py
@@ -20,12 +20,8 @@ Handler for handling cluster stop events received from CSM
 
 import json
 import ast
-import re
-import time
-import uuid
 
 from cortx.utils.conf_store import Conf
-from ha.core.config.config_manager import ConfigManager
 from cortx.utils.log import Log
 from ha.util.message_bus import MessageBus, CONSUMER_STATUS, MessageBusConsumer
 

--- a/ha/fault_tolerance/cluster_stop_monitor.py
+++ b/ha/fault_tolerance/cluster_stop_monitor.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+"""
+Handler for handling cluster stop events received from CSM
+"""
+
+import json
+import ast
+import re
+import time
+import uuid
+
+from cortx.utils.conf_store import Conf
+from ha.core.config.config_manager import ConfigManager
+from cortx.utils.log import Log
+from ha.util.message_bus import MessageBus, CONSUMER_STATUS, MessageBusConsumer
+
+from ha import const
+from ha.k8s_setup.const import _DELIM
+
+class ClusterStopMonitor:
+
+    def __init__(self):
+        """Init method"""
+        self._consumer = self._get_consumer()
+
+    def start(self):
+        """
+        Start to listen messages.
+        """
+        self._consumer.start()
+
+    def _get_consumer(self) -> MessageBusConsumer:
+        """
+           Returns an object of MessageBusConsumer class which will listen on
+           cluster_event message type and callback will be executed
+        """
+
+        self._consumer_id = Conf.get(const.HA_GLOBAL_INDEX, f'CLUSTER_STOP_MON{_DELIM}consumer_id')
+        self._consumer_group = Conf.get(const.HA_GLOBAL_INDEX, f'CLUSTER_STOP_MON{_DELIM}consumer_group')
+        self._message_type = Conf.get(const.HA_GLOBAL_INDEX, f'CLUSTER_STOP_MON{_DELIM}message_type')
+        return MessageBus.get_consumer(consumer_id=self._consumer_id, \
+                                consumer_group=self._consumer_group, \
+                                message_type=self._message_type, \
+                                callback=self.process_message)
+
+    def process_message(self, message: str):
+        """Callback method for MessageConsumer"""
+        #Log.debug(f'Received the message from message bus: {message}')
+        Log.debug(f'Received the message from message bus: {message}')
+        try:
+            # parse the message and check if cluster stop received
+            msg_decode = message.decode('utf-8')
+            msg = json.dumps(ast.literal_eval(msg_decode))
+            cluster_alert = json.loads(msg)
+
+            if cluster_alert["start_cluster_shutdown"] == '1':
+                # Placeholder function, to be replaced by appropriate function as part of EOS-24900
+                self.stop_cluster()
+        except Exception as err:
+            Log.error(f'Failed to analyze the event: {message} error: {err}')
+            return CONSUMER_STATUS.SUCCESS
+        return CONSUMER_STATUS.SUCCESS
+
+    def stop_cluster(self):
+        """
+        Placeholder function
+        """
+        Log.info('Cluster stop received ')

--- a/ha/fault_tolerance/fault_monitor.py
+++ b/ha/fault_tolerance/fault_monitor.py
@@ -71,6 +71,7 @@ class NodeFaultMonitor(FaultMonitor):
         self._consumer_id = Conf.get(const.HA_GLOBAL_INDEX, f'FAULT_TOLERANCE{_DELIM}consumer_id')
         self._consumer_group = Conf.get(const.HA_GLOBAL_INDEX, f'FAULT_TOLERANCE{_DELIM}consumer_group')
         self._message_type = Conf.get(const.HA_GLOBAL_INDEX, f'FAULT_TOLERANCE{_DELIM}message_type')
+        MessageBus.init()
         return MessageBus.get_consumer(consumer_id=self._consumer_id, \
                                 consumer_group=self._consumer_group, \
                                 message_type=self._message_type, \

--- a/ha/fault_tolerance/fault_monitor.py
+++ b/ha/fault_tolerance/fault_monitor.py
@@ -48,8 +48,10 @@ class FaultMonitor:
         """
         Start to listen messages.
         """
-        self._consumer.start()
-
+        if self._consumer is not None:
+            self._consumer.start()
+        else:
+            Log.warn(f"Consumer not found for message type  {self._message_type} ")
 
 class NodeFaultMonitor(FaultMonitor):
     """

--- a/ha/fault_tolerance/fault_monitor.py
+++ b/ha/fault_tolerance/fault_monitor.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+"""
+Handler for handling events received from k8s monitor service
+"""
+
+
+from cortx.utils.conf_store import Conf
+from cortx.utils.log import Log
+from ha.util.message_bus import MessageBus, CONSUMER_STATUS, MessageBusConsumer
+from ha.core.config.config_manager import ConfigManager
+from ha import const
+from ha.core.event_analyzer.event_analyzerd import EventAnalyzer
+from ha.k8s_setup.const import _DELIM
+
+from consul.base import ConsulException
+from cortx.utils.conf_store.error import ConfError
+from ha.core.event_analyzer.event_analyzer_exceptions import EventFilterException
+from ha.core.event_analyzer.event_analyzer_exceptions import EventParserException
+from ha.core.event_analyzer.event_analyzer_exceptions import SubscriberException
+
+class FaultMonitor:
+    """
+    Base class for all faults received from k8s monitor
+    Faults can be for host, node, container, pvc etc
+    Seperate derived class to be written for each of the above modules as and when required
+    """
+
+    def __init__(self):
+        """Init method"""
+        self._consumer = self._get_consumer()
+
+    def start(self):
+        """
+        Start to listen messages.
+        """
+        self._consumer.start()
+
+
+class NodeFaultMonitor(FaultMonitor):
+    """
+    Module responsible for:
+    -  consuming node messages from k8s monitor that come on message bus
+    -  analyzing the message and and publishing alert if required
+    """
+    def __init__(self):
+        """Init method"""
+        super().__init__()
+
+    def _get_consumer(self) -> MessageBusConsumer:
+        """
+           Returns an object of MessageBusConsumer class which will listen on
+           cluster_event message type and callback will be executed
+        """
+        self._consumer_id = Conf.get(const.HA_GLOBAL_INDEX, f'FAULT_TOLERANCE{_DELIM}consumer_id')
+        self._consumer_group = Conf.get(const.HA_GLOBAL_INDEX, f'FAULT_TOLERANCE{_DELIM}consumer_group')
+        self._message_type = Conf.get(const.HA_GLOBAL_INDEX, f'FAULT_TOLERANCE{_DELIM}message_type')
+        return MessageBus.get_consumer(consumer_id=self._consumer_id, \
+                                consumer_group=self._consumer_group, \
+                                message_type=self._message_type, \
+                                callback=self.process_message)
+
+    def process_message(self, message: str):
+        """Callback method for MessageConsumer"""
+        Log.debug(f'Received the message from message bus: {message}')
+        try:
+            EventAnalyzer(message.decode('utf-8'))
+            return CONSUMER_STATUS.SUCCESS
+        except ConsulException as e:
+            Log.error(f"consule exception {e} {traceback.format_exc()} for {message}. Ack Message.")
+            return CONSUMER_STATUS.SUCCESS
+        except ConfError as e:
+            Log.error(f"config exception {e} {traceback.format_exc()} for {message}. Ack Message.")
+            return CONSUMER_STATUS.SUCCESS
+        except EventFilterException as e:
+            Log.error(f"Filter exception {e} {traceback.format_exc()} for {message}. Ack Message.")
+            return CONSUMER_STATUS.SUCCESS
+        except EventParserException as e:
+            Log.error(f"Parser exception {e} {traceback.format_exc()} for {message}.  Ack Message.")
+            return CONSUMER_STATUS.SUCCESS
+        except SubscriberException as e:
+            Log.error(f"Subscriber exception {e} {traceback.format_exc()} for {message}, retry without ack.")
+            return CONSUMER_STATUS.FAILED
+        except Exception as e:
+            Log.error(f"Unknown Exception caught {e} {traceback.format_exc()}")
+            Log.error(f"Forcefully ack as success. msg: {message}")
+            return CONSUMER_STATUS.SUCCESS
+

--- a/ha/fault_tolerance/fault_monitor.py
+++ b/ha/fault_tolerance/fault_monitor.py
@@ -19,6 +19,7 @@ Handler for handling events received from k8s monitor service
 """
 
 
+import traceback
 from cortx.utils.conf_store import Conf
 from cortx.utils.log import Log
 from ha.util.message_bus import MessageBus, CONSUMER_STATUS, MessageBusConsumer

--- a/ha/fault_tolerance/fault_monitor.py
+++ b/ha/fault_tolerance/fault_monitor.py
@@ -94,7 +94,7 @@ class NodeFaultMonitor(FaultMonitor):
             return CONSUMER_STATUS.SUCCESS
         except SubscriberException as e:
             Log.error(f"Subscriber exception {e} {traceback.format_exc()} for {message}, retry without ack.")
-            return CONSUMER_STATUS.FAILED
+            return CONSUMER_STATUS.SUCCESS
         except Exception as e:
             Log.error(f"Unknown Exception caught {e} {traceback.format_exc()}")
             Log.error(f"Forcefully ack as success. msg: {message}")

--- a/ha/fault_tolerance/fault_monitor.py
+++ b/ha/fault_tolerance/fault_monitor.py
@@ -22,7 +22,6 @@ Handler for handling events received from k8s monitor service
 from cortx.utils.conf_store import Conf
 from cortx.utils.log import Log
 from ha.util.message_bus import MessageBus, CONSUMER_STATUS, MessageBusConsumer
-from ha.core.config.config_manager import ConfigManager
 from ha import const
 from ha.core.event_analyzer.event_analyzerd import EventAnalyzer
 from ha.k8s_setup.const import _DELIM

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -23,77 +23,36 @@
 import time
 import traceback
 
-from cortx.utils.conf_store import Conf
 from cortx.utils.log import Log
-from ha.util.message_bus import MessageBus, CONSUMER_STATUS, MessageBusConsumer
 
+from cortx.utils.conf_store import Conf
 from ha import const
 from ha.core.config.config_manager import ConfigManager
-from ha.core.event_analyzer.event_analyzerd import EventAnalyzer
+from ha.fault_tolerance.fault_monitor import NodeFaultMonitor
+from ha.fault_tolerance.cluster_stop_monitor import ClusterStopMonitor
 from ha.k8s_setup.const import _DELIM
-
-from consul.base import ConsulException
-from cortx.utils.conf_store.error import ConfError
-from ha.core.event_analyzer.event_analyzer_exceptions import EventFilterException
-from ha.core.event_analyzer.event_analyzer_exceptions import EventParserException
-from ha.core.event_analyzer.event_analyzer_exceptions import SubscriberException
 
 class FaultTolerance:
     """
     Module responsible for consuming messages from message bus,
     further analyzes that event and publishes it if required
     """
+    #def __init__(self, wait_time=600):
     def __init__(self, wait_time=10):
         """Init method"""
         self._wait_time = wait_time
         ConfigManager.init("fault_tolerance")
-        self._consumer = self._get_consumer()
+        self.node_fault_monitor = NodeFaultMonitor()
+        self.cluster_stop_monitor = ClusterStopMonitor()
 
-    def _get_consumer(self) -> MessageBusConsumer:
-        """
-           Returns an object of MessageBusConsumer class which will listen on
-           cluster_event message type and callback will be executed
-        """
-        self._consumer_id = Conf.get(const.HA_GLOBAL_INDEX, f'FAULT_TOLERANCE{_DELIM}consumer_id')
-        self._consumer_group = Conf.get(const.HA_GLOBAL_INDEX, f'FAULT_TOLERANCE{_DELIM}consumer_group')
-        self._message_type = Conf.get(const.HA_GLOBAL_INDEX, f'FAULT_TOLERANCE{_DELIM}message_type')
-        MessageBus.init()
-        return MessageBus.get_consumer(consumer_id=self._consumer_id, \
-                                consumer_group=self._consumer_group, \
-                                message_type=self._message_type, \
-                                callback=self.process_message)
-
-    def process_message(self, message: str):
-        """Callback method for MessageConsumer"""
-        Log.debug(f'Received the message from message bus: {message}')
-        try:
-            EventAnalyzer(message.decode('utf-8'))
-            return CONSUMER_STATUS.SUCCESS
-        except ConsulException as e:
-            Log.error(f"consule exception {e} {traceback.format_exc()} for {message}. Ack Message.")
-            return CONSUMER_STATUS.SUCCESS
-        except ConfError as e:
-            Log.error(f"config exception {e} {traceback.format_exc()} for {message}. Ack Message.")
-            return CONSUMER_STATUS.SUCCESS
-        except EventFilterException as e:
-            Log.error(f"Filter exception {e} {traceback.format_exc()} for {message}. Ack Message.")
-            return CONSUMER_STATUS.SUCCESS
-        except EventParserException as e:
-            Log.error(f"Parser exception {e} {traceback.format_exc()} for {message}.  Ack Message.")
-            return CONSUMER_STATUS.SUCCESS
-        except SubscriberException as e:
-            Log.error(f"Subscriber exception {e} {traceback.format_exc()} for {message}, retry without ack.")
-            return CONSUMER_STATUS.FAILED
-        except Exception as e:
-            Log.error(f"Unknown Exception caught {e} {traceback.format_exc()}")
-            Log.error(f"Forcefully ack as success. msg: {message}")
-            return CONSUMER_STATUS.SUCCESS
+    def start(self):
+        self.node_fault_monitor.start()
+        self.cluster_stop_monitor.start()
 
     def poll(self):
-        """Contineously polls for message bus for k8s_event message type"""
+        Log.debug("FaultTolerance poll")
+
         try:
-            Log.info(f'Starting poll for fault tolerance alterts with consumer id: {self._consumer_id}.')
-            self._consumer.start()
             while True:
                 # Get alert condition from ALertGenerator. Analyze changes
                 # with the help of event analyzer and notify if required
@@ -102,5 +61,7 @@ class FaultTolerance:
             raise(f'Oops, some issue in the fault tolerance_driver: {exe}')
 
 if __name__ == '__main__':
+
     fault_tolerance = FaultTolerance()
+    fault_tolerance.start()
     fault_tolerance.poll()

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -21,7 +21,6 @@
 
 
 import time
-import traceback
 
 from cortx.utils.log import Log
 

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -33,7 +33,6 @@ class FaultTolerance:
     Module responsible for consuming messages from message bus,
     further analyzes that event and publishes it if required
     """
-    #def __init__(self, wait_time=600):
     def __init__(self, wait_time=10):
         """Init method"""
         self._wait_time = wait_time
@@ -42,16 +41,19 @@ class FaultTolerance:
         self.cluster_stop_monitor = ClusterStopMonitor()
 
     def start(self):
+        """
+        start the threads
+        """
         self.node_fault_monitor.start()
         self.cluster_stop_monitor.start()
 
     def poll(self):
         Log.debug("FaultTolerance poll")
-
+        """
+        wait method for receiving events
+        """
         try:
             while True:
-                # Get alert condition from ALertGenerator. Analyze changes
-                # with the help of event analyzer and notify if required
                 time.sleep(self._wait_time)
         except Exception as exe:
             raise(f'Oops, some issue in the fault tolerance_driver: {exe}')

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -25,12 +25,9 @@ import traceback
 
 from cortx.utils.log import Log
 
-from cortx.utils.conf_store import Conf
-from ha import const
 from ha.core.config.config_manager import ConfigManager
 from ha.fault_tolerance.fault_monitor import NodeFaultMonitor
 from ha.fault_tolerance.cluster_stop_monitor import ClusterStopMonitor
-from ha.k8s_setup.const import _DELIM
 
 class FaultTolerance:
     """

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -231,6 +231,8 @@ class ConfigCmd(Cmd):
                                             'consumer_group' : 'health_monitor', 'consumer_id' : '1'},
                          'FAULT_TOLERANCE' : {'message_type' : 'cluster_event', 'consumer_group' : 'event_listener',
                                               'consumer_id' : '1'},
+                         'CLUSTER_STOP_MON' : {'message_type' : 'cluster_stop', 'consumer_group' : 'cluster_mon',
+                                              'consumer_id' : '2'},
                          'NODE': {'resource_type': 'node'},
                          'SYSTEM_HEALTH' : {'num_entity_health_events' : 2,
                                             'sys_health_bootstrap_timeout' : timeout,

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -56,7 +56,7 @@ class NodeEventParser(ObjectParser):
                 if a_condition[K8SEventsConst.TYPE] == K8SEventsConst.READY:
                     ready_status = a_condition[K8SEventsConst.STATUS]
         except Exception as e:
-            Log.warn(f"Exception received during parsing {e}")
+            Log.debug(f"Exception received during parsing {e}")
 
         if ready_status is None:
             Log.debug(f"ready_status is None for node resource {alert.resource_name}")
@@ -125,7 +125,7 @@ class PodEventParser(ObjectParser):
                 if a_condition[K8SEventsConst.TYPE] == K8SEventsConst.READY:
                     ready_status = a_condition[K8SEventsConst.STATUS]
         except Exception as e:
-            Log.warn(f"Exception received during parsing {e}")
+            Log.debug(f"Exception received during parsing {e}")
 
         if ready_status is None:
             Log.debug(f"ready_status is None for pod resource {alert.resource_name}")


### PR DESCRIPTION
Signed-off-by: ArchanaLimaye <archana.limaye@seagate.com>

# Problem Statement
- Current fault tolerance service expects and can receive messages over message bus only from the k8s monitor service 
- The "cluster stop" message will be sent by CSM via message bus and fault tolerance needs to be able to receive this message
- 

# Design
   Modified the fault tolerance to start 2 watchers; one for messages from k8s monitor (topic cluster_event), other for messages from CSM (topic cluster_stop)

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM 

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]:  N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N] NA
- [ ] Side effects on other features (deployment/upgrade)? [Y/N] N
- [ ] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
