### PR TITLE
Upgrade PyYAML to 5.4.1

### DIFF
--- a/jenkins/pyinstaller/v1/requirements.txt
+++ b/jenkins/pyinstaller/v1/requirements.txt
@@ -3,7 +3,7 @@ pyinstaller==3.5
 aiohttp==3.6.1
 paramiko==2.7.1
 toml==0.10.0
-PyYAML==5.1.2
+PyYAML==5.4.1
 configparser==4.0.2
 argparse==1.4.0
 dict2xml==1.6.1

--- a/jenkins/pyinstaller/v2/requirements.txt
+++ b/jenkins/pyinstaller/v2/requirements.txt
@@ -1,6 +1,6 @@
 setuptools==36.0.1
 pyinstaller==3.5
-PyYAML==5.1.2
+PyYAML==5.4.1
 argparse==1.4.0
 dataclasses==0.7
 python-consul==1.1.0

--- a/jenkins/requirements.txt
+++ b/jenkins/requirements.txt
@@ -1,5 +1,5 @@
 setuptools==36.0.1
-PyYAML==5.1.2
+PyYAML==5.4.1
 argparse==1.4.0
 dataclasses==0.7
 python-consul==1.1.0


### PR DESCRIPTION
Signed-off-by: Swanand S Gadre <swanand.s.gadre@seagate.com>

# Problem Statement
- Problem statement

While in kubernetes branch cortx-ha had PyYAML upgraded to 5.4.1
However now if I see "main" branch, it still refers to PyYAML 5.1.2

at following locations

o	cortx-ha/jenkins/requirements.txt
o	cortx-ha/jenkins/pyinstaller/v1/requirements.txt
o	cortx-ha/jenkins/pyinstaller/v2/requirements.txt


# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

https://jts.seagate.com/browse/EOS-23696

# Coding
-  [X] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

Detailed testing is updated as document attached to JIRA -> https://jts.seagate.com/browse/EOS-23696
Please note: While testing, cortx-ha repo already had PyYAML version set to 5.4.1
But now I see its set back to 5.1.2

# Review Checklist 
- [X] PR is self reviewed
- [X] JIRA number/GitHub Issue added to PR
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained
- [X] Is there a change in filename/package/module or signature? [Y/N]: N
- [X] If yes for above point, is a notification sent to all other cortx components? [Y/N] N
- [X] Side effects on other features (deployment/upgrade)? [Y/N] - Not expecting 
- [X] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 
Not applicable

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

Not applicable