### PR TITLE
EOS-27047: Sequentialize the alerts received from k8s monitor in case…

### DIFF
--- a/ha/core/event_analyzer/event_analyzerd.py
+++ b/ha/core/event_analyzer/event_analyzerd.py
@@ -104,7 +104,11 @@ class EventAnalyzerService:
 
 # This will be instantiated from the fault_tolerance
 class EventAnalyzer:
-
+    """
+    Analyzes an event, filter gets applied. Further it parses
+    an alert to create health event object required for system
+    health processing
+    """
     def __init__(self, msg=None):
         '''init method'''
         ConfigManager.init('event_analyzer')

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -381,7 +381,7 @@ class SystemHealth(Subscriber):
             return
 
     @staticmethod
-    def create_updated_event_object(event_timestamp: str, current_timestamp: str, status: str, spec_info: dict, updated_health: dict) -> dict:
+    def create_updated_event_object(event_timestamp: str, current_timestamp: str, status: str, spec_info: dict, updated_health: EntityHealth) -> str:
         """
         Creates objects of EntityEvent and EntityAction using incoming
         health status(coming from incoming health event from parser) and
@@ -399,7 +399,7 @@ class SystemHealth(Subscriber):
         updated_health = EntityHealth.write(updated_health)
         return updated_health
 
-    def _check_and_update(self, current_health, updated_health, healthevent, next_component):
+    def _check_and_update(self, current_health: str, updated_health: str, healthevent: HealthEvent, next_component: str) -> None:
         # Update in the store.
         if self._is_update_required(current_health, updated_health, healthevent):
             self._update(healthevent, updated_health, next_component=next_component)
@@ -443,49 +443,55 @@ class SystemHealth(Subscriber):
             if current_health:
                 current_health_dict = json.loads(current_health)
                 specific_info = current_health_dict["events"][0]["specific_info"]
-            if current_health and specific_info:
-                # If health is already stored and its a node_health, check further
-                stored_genration_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
-                incoming_generation_id = healthevent.specific_info["generation_id"]
-                incoming_health_status = current_health_dict["events"][0]["status"]
-                pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
-                # Update the current health value itself.
-                latest_health = EntityHealth.read(current_health)
-                if stored_genration_id != incoming_generation_id:
-                    if incoming_health_status == status:
-                        # If the generation id matches and stored node health matches
-                        # with incoming node health, means online event received first
-                        # instead of failed event in delete scenario
-                        healthevent.specific_info = {"generation_id": stored_genration_id, "pod_restart": 1}
-                        updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, "failed", healthevent.specific_info, latest_health)
-                        # Create a "failed" event and update it in system health and publish
-                        self._check_and_update(current_health, updated_health, healthevent, next_component)
-                        current_health = updated_health
-                        # Now create an "online" event and update it in system health and publish
-                        healthevent.specific_info = {"generation_id": incoming_generation_id, "pod_restart": 1}
-                        updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
-                        self._check_and_update(current_health, updated_health, healthevent, next_component)
-                    elif pod_restart_val is not None and pod_restart_val:
-                        # Check the pod_restart value assosciated with Node, if its 1,
-                        # means this alert is already updated. No need to send the alert again.
-                        # Just need to reset the pod_restart value
-                        key = self._prepare_key(component, cluster_id=self.node_map['cluster_id'], \
+                if current_health and specific_info:
+                    # If health is already stored and its a node_health, check further
+                    stored_genration_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
+                    incoming_generation_id = healthevent.specific_info["generation_id"]
+                    incoming_health_status = current_health_dict["events"][0]["status"]
+                    pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
+                    # Update the current health value itself.
+                    latest_health = EntityHealth.read(current_health)
+                    if stored_genration_id != incoming_generation_id:
+                        if incoming_health_status == status:
+                            # If the generation id matches and stored node health matches
+                            # with incoming node health, means online event received first
+                            # instead of failed event in delete scenario
+                            healthevent.specific_info = {"generation_id": stored_genration_id, "pod_restart": 1}
+                            healthevent.event_type = "failed"
+                            updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
+                            # Create a "failed" event and update it in system health and publish
+                            self._check_and_update(current_health, updated_health, healthevent, next_component)
+                            current_health = updated_health
+                            # Now create an "online" event and update it in system health and publish
+                            healthevent.specific_info = {"generation_id": incoming_generation_id, "pod_restart": 1}
+                            healthevent.event_type = "online"
+                            updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
+                            self._check_and_update(current_health, updated_health, healthevent, next_component)
+                        elif pod_restart_val is not None and pod_restart_val:
+                            # Check the pod_restart value assosciated with Node, if its 1,
+                            # means this alert is already updated. No need to send the alert again.
+                            # Just need to reset the pod_restart value
+                            # Check the pod_restart value assosciated with Node, if its 1,
+                            # means this alert is already updated. No need to send the alert again.
+                            # Just need to reset the pod_restart value
+                            key = self._prepare_key(component, cluster_id=self.node_map['cluster_id'], \
                                 site_id=self.node_map['site_id'], rack_id=self.node_map['rack_id'], \
                                 node_id=self.node_id)
-                        latest_health_dict = json.loads(current_health)
-                        new_spec_info = {"generation_id": stored_genration_id, "pod_restart": 0}
-                        latest_health_dict["events"][0]["specific_info"] = new_spec_info
-                        updated_health = EntityHealth.write(latest_health_dict)
-                        self.healthmanager.set_key(key, updated_health)
+                            latest_health_dict = json.loads(current_health)
+                            new_spec_info = {"generation_id": stored_genration_id, "pod_restart": 0}
+                            latest_health_dict["events"][0]["specific_info"] = new_spec_info
+                            updated_health = EntityHealth.write(latest_health_dict)
+                            self.healthmanager.set_key(key, updated_health)
+                    else:
+                        # current health is there and generation id is also already present.
+                        # That means its a normal failure scenario
+                        updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
+                        self._check_and_update(current_health, updated_health, healthevent, next_component)
                 else:
-                    # current health is there and generation id is also already present.
-                    # That means its a normal failure scenario
+                    # Update hierachical components. such as site, rack
+                    latest_health = EntityHealth.read(current_health)
                     updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
                     self._check_and_update(current_health, updated_health, healthevent, next_component)
-            elif current_health and not specific_info:
-                # Updates system health for cluster, rack and site
-                latest_health = EntityHealth.read(current_health)
-                updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
             else:
                 # Health value not present in the store currently, create now.
                 latest_health = EntityHealth()

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -380,6 +380,31 @@ class SystemHealth(Subscriber):
             self.process_event(new_event)
             return
 
+    @staticmethod
+    def create_updated_event_object(event_timestamp: str, current_timestamp: str, status: str, spec_info: dict, updated_health: dict) -> dict:
+        """
+        Creates objects of EntityEvent and EntityAction using incoming
+        health status(coming from incoming health event from parser) and
+        other required values and adds it to the latest health object.
+        converts it to a appropriate format which needs to be updated in
+        the system health
+        """
+        # Create a new event and action
+        entity_event = EntityEvent(event_timestamp, current_timestamp, status, spec_info)
+        entity_action = EntityAction(current_timestamp, const.ACTION_STATUS.PENDING.value)
+        # Add the new event and action to the health value
+        updated_health.add_event(entity_event)
+        updated_health.set_action(entity_action)
+        # Convert the health value as appropriate for writing to the store.
+        updated_health = EntityHealth.write(updated_health)
+        return updated_health
+
+    def _check_and_update(self, current_health, updated_health, healthevent, next_component):
+        # Update in the store.
+        if self._is_update_required(current_health, updated_health, healthevent):
+            self._update(healthevent, updated_health, next_component=next_component)
+            # Log.info(f"Updated health for component: {component}, Type: {component_type}, Id: {component_id}")
+
     def process_event(self, healthevent: HealthEvent):
         """
         Process Event method. This method could be called for updating the health status.
@@ -402,6 +427,11 @@ class SystemHealth(Subscriber):
             component_id = healthevent.resource_id
             Log.info(f"SystemHealth: Processing {component}:{component_type}:{component_id} with status {status}")
 
+            # Update the node map
+            self.node_id = healthevent.node_id
+            self.node_map = {'cluster_id':healthevent.cluster_id, 'site_id':healthevent.site_id,
+                             'rack_id':healthevent.rack_id, 'storageset_id':healthevent.storageset_id}
+
             # Read the currently stored health value
             current_health = self.get_status_raw(component, component_id, comp_type=component_type,
                                         cluster_id=healthevent.cluster_id, site_id=healthevent.site_id,
@@ -409,34 +439,60 @@ class SystemHealth(Subscriber):
                                         node_id=healthevent.node_id, server_id=healthevent.node_id,
                                         storage_id=healthevent.node_id)
 
+            current_timestamp = str(int(time.time()))
             if current_health:
+                current_health_dict = json.loads(current_health)
+                specific_info = current_health_dict["events"][0]["specific_info"]
+            if current_health and specific_info:
+                # If health is already stored and its a node_health, check further
+                stored_genration_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
+                incoming_generation_id = healthevent.specific_info["generation_id"]
+                incoming_health_status = current_health_dict["events"][0]["status"]
+                pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
                 # Update the current health value itself.
-                updated_health = EntityHealth.read(current_health)
+                latest_health = EntityHealth.read(current_health)
+                if stored_genration_id != incoming_generation_id:
+                    if incoming_health_status == status:
+                        # If the generation id matches and stored node health matches
+                        # with incoming node health, means online event received first
+                        # instead of failed event in delete scenario
+                        healthevent.specific_info = {"generation_id": stored_genration_id, "pod_restart": 1}
+                        updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, "failed", healthevent.specific_info, latest_health)
+                        # Create a "failed" event and update it in system health and publish
+                        self._check_and_update(current_health, updated_health, healthevent, next_component)
+                        current_health = updated_health
+                        # Now create an "online" event and update it in system health and publish
+                        healthevent.specific_info = {"generation_id": incoming_generation_id, "pod_restart": 1}
+                        updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
+                        self._check_and_update(current_health, updated_health, healthevent, next_component)
+                    elif pod_restart_val is not None and pod_restart_val:
+                        # Check the pod_restart value assosciated with Node, if its 1,
+                        # means this alert is already updated. No need to send the alert again.
+                        # Just need to reset the pod_restart value
+                        key = self._prepare_key(component, cluster_id=self.node_map['cluster_id'], \
+                                site_id=self.node_map['site_id'], rack_id=self.node_map['rack_id'], \
+                                node_id=self.node_id)
+                        latest_health_dict = json.loads(current_health)
+                        new_spec_info = {"generation_id": stored_genration_id, "pod_restart": 0}
+                        latest_health_dict["events"][0]["specific_info"] = new_spec_info
+                        updated_health = EntityHealth.write(latest_health_dict)
+                        self.healthmanager.set_key(key, updated_health)
+                else:
+                    # current health is there and generation id is also already present.
+                    # That means its a normal failure scenario
+                    updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
+                    self._check_and_update(current_health, updated_health, healthevent, next_component)
+            elif current_health and not specific_info:
+                # Updates system health for cluster, rack and site
+                latest_health = EntityHealth.read(current_health)
+                updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
             else:
                 # Health value not present in the store currently, create now.
-                updated_health = EntityHealth()
-
-            # Create a new event and action
-            current_timestamp = str(int(time.time()))
-            entity_event = EntityEvent(healthevent.timestamp, current_timestamp, status, healthevent.specific_info)
-            entity_action = EntityAction(current_timestamp, const.ACTION_STATUS.PENDING.value)
-            # Add the new event and action to the health value
-            updated_health.add_event(entity_event)
-            updated_health.set_action(entity_action)
-            # Convert the health value as appropriate for writing to the store.
-            updated_health = EntityHealth.write(updated_health)
-
-            # Update the node map
-            self.node_id = healthevent.node_id
-            self.node_map = {'cluster_id':healthevent.cluster_id, 'site_id':healthevent.site_id,
-                             'rack_id':healthevent.rack_id, 'storageset_id':healthevent.storageset_id}
-
-            # Update in the store.
-            if self._is_update_required(current_health, updated_health, healthevent):
-                self._update(healthevent, updated_health, next_component=next_component)
-                Log.info(f"Updated health for component: {component}, Type: {component_type}, Id: {component_id}")
-        except Exception as e:
-            Log.error(f"Failed processing system health event with Error: {e}")
+                latest_health = EntityHealth()
+                updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
+                self._check_and_update(current_health, updated_health, healthevent, next_component)
+        except Exception as err:
+            Log.error(f"Failed processing system health event with Error: {err}")
             raise HaSystemHealthException("Failed processing system health event")
 
     def get_health_event_template(self, nodeid: str, event_type: str) -> dict:

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -403,7 +403,6 @@ class SystemHealth(Subscriber):
         # Update in the store.
         if self._is_update_required(current_health, updated_health, healthevent):
             self._update(healthevent, updated_health, next_component=next_component)
-            # Log.info(f"Updated health for component: {component}, Type: {component_type}, Id: {component_id}")
 
     def process_event(self, healthevent: HealthEvent):
         """
@@ -468,9 +467,6 @@ class SystemHealth(Subscriber):
                             updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
                             self._check_and_update(current_health, updated_health, healthevent, next_component)
                         elif pod_restart_val is not None and pod_restart_val:
-                            # Check the pod_restart value assosciated with Node, if its 1,
-                            # means this alert is already updated. No need to send the alert again.
-                            # Just need to reset the pod_restart value
                             # Check the pod_restart value assosciated with Node, if its 1,
                             # means this alert is already updated. No need to send the alert again.
                             # Just need to reset the pod_restart value

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -71,7 +71,7 @@ class Cmd:
         sys.stderr.write(
             f"usage: {prog} [-h] <cmd> <--config url> <args>...\n"
             f"where:\n"
-            f"cmd   post_install, prepare, config, init, test, reset, cleanup\n"
+            f"cmd   post_install, prepare, config, init, test, reset, cleanup, upgrade\n"
             f"--config   Config URL.\n"
             f"--services   Service name.\n")
 
@@ -309,6 +309,24 @@ class InitCmd(Cmd):
         Process init command.
         """
         sys.stdout.write('HA initialization is done.\n')
+
+class UpgradeCmd(Cmd):
+    """
+    Setup Upgrade Cmd
+    """
+    name = "upgrade"
+
+    def __init__(self, args):
+        """
+        Init method.
+        """
+        super().__init__(args)
+
+    def process(self):
+        """
+        Process upgrade command.
+        """
+        sys.stdout.write("HA has been upgraded successfully\n")
 
 class TestCmd(Cmd):
     """


### PR DESCRIPTION
… of pod delete event

- New field generation_id and pod_restart will be associated with pod id in
  system health (new entry in system health specific info section)
- combination of generation_id and pod_restart value will be used to
  identify whether its a failed/online event for normal case or restart case
- If restart online event comes first, then process delete (create a health event for deletion manually)
  event first and then process the incoming online alert. And send these two alerts sequentially to a subscriber

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

# Problem Statement
Sequentialize the alerts received from k8s monitor in case of pod delete event

Right now, if POD gets restarted/deleted, pod online event comes first and failed event later. Because, when pod deletion gets triggered, internally deletion takes long time but new pod comes up in quickly

# Design
So, to achieve this, logic will be

New field generation_id and pod_restart will be associated with pod id in system health (new entry in system health specific info section)
combination of generation_id and pod_restart value will be used to identify whether its a failed/online event for normal case or restart case
If restart online event comes first, then process delete (create a health event for deletion manually) event first and then process the incoming online alert. And send these two alerts sequentially to a subscriber

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]:  N
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [x] Side effects on other features (deployment/upgrade)? [Y/N] N
- [x] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [x] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: Y

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide

Tests:
Normal startup online event for nodes and its system health keys:

sh-4.2# consul kv get -http-addr=consul-server.default.svc.cluster.local:8500 --recurse cortx/ha/v1
cortx/ha/v1:
cortx/ha/v1/action/node/failed:["publish"]
cortx/ha/v1/action/node/online:["publish"]
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263879", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1641263879", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263879", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1641263879", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263878", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1641263878", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/8f6e76bd96f44fdd8abc7fd7589bf925/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263881", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2693-68fb57f57-h6fgm", "pod_restart": 0}}], "action": {"modified_timestamp": "1641263881", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/af8c7051244c4a1ebc2303ceb1636437/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263880", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-lcqsm", "pod_restart": 0}}], "action": {"modified_timestamp": "1641263880", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/f17ac55fc9574694bdee9b155297c6a6/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263875", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj", "pod_restart": 0}}], "action": {"modified_timestamp": "1641263875", "status": "pending"}, "attributes": {}}
cortx/ha/v1/events/node/failed:["hare"]
cortx/ha/v1/events/node/online:["hare"]
cortx/ha/v1/events/subscribe/hare:["node/online", "node/failed"]
cortx/ha/v1/init_system_health:1
cortx/ha/v1/inital_time:1641263876
cortx/ha/v1/message_type/hare:ha_event_hare
cortx/ha/v1/sys_health_bootstrap_timeout:10
sh-4.2#


Deleted pod:
cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-lcqsm
machine_id: af8c7051244c4a1ebc2303ceb1636437

Logs from k8s_mon:
2022-01-04 02:39:05 pod_monitor [18355]: INFO [run] Sending alert on message bus {'_resource_type': 'node', '_resource_name': 'af8c7051244c4a1ebc2303ceb1636437', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-z7jzk', '_node': 'ssc-vm-g2-rhev4-2731.colo.seagate.com', '_is_status': False, '_timestamp': '1641263945'}
2022-01-04 02:39:24 pod_monitor [18355]: INFO [run] Sending alert on message bus {'_resource_type': 'node', '_resource_name': 'af8c7051244c4a1ebc2303ceb1636437', '_event_type': 'failed', '_k8s_container': None, '_generation_id': 'cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-lcqsm', '_node': 'ssc-vm-g2-rhev4-2731.colo.seagate.com', '_is_status': False, '_timestamp': '1641263964'}

Logs from health_mon
2022-01-04 02:39:07 health_monitor [18353]: INFO [evaluate] Evaluated action ['publish'] for key action/node/failed
2022-01-04 02:39:07 health_monitor [18353]: INFO [process_event] Evaluated {"event_id": "164126394590e4674325974134ab9b95e574075141", "event_type": "failed", "severity": "informational", "site_id": "1", "rack_id": "1", "cluster_id": "d6b77d52dc0a4fdc8dabd036f57b49eb", "storageset_id": "af8c7051244c4a1ebc2303ceb1636437", "node_id": "af8c7051244c4a1ebc2303ceb1636437", "host_id": "af8c7051244c4a1ebc2303ceb1636437", "resource_type": "node", "timestamp": "1641263945", "resource_id": "af8c7051244c4a1ebc2303ceb1636437", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-lcqsm", "pod_restart": 1}} with action ['publish']
2022-01-04 02:39:07 health_monitor [18353]: INFO [act] Default action handler with Event: 164126394590e4674325974134ab9b95e574075141 and actions : ['publish']
2022-01-04 02:39:07 health_monitor [18353]: INFO [publish] Sending action event {"version": "2.0", "event_type": "failed", "event_id": "164126394590e4674325974134ab9b95e574075141", "resource_type": "node", "cluster_id": "d6b77d52dc0a4fdc8dabd036f57b49eb", "site_id": "1", "rack_id": "1", "storageset_id": "af8c7051244c4a1ebc2303ceb1636437", "node_id": "af8c7051244c4a1ebc2303ceb1636437", "resource_id": "af8c7051244c4a1ebc2303ceb1636437", "timestamp": "1641263945", "event_specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-lcqsm", "pod_restart": 1}} to component hare
2022-01-04 02:39:08 health_monitor [18353]: INFO [evaluate] Evaluated action ['publish'] for key action/node/online
2022-01-04 02:39:08 health_monitor [18353]: INFO [process_event] Evaluated {"event_id": "164126394590e4674325974134ab9b95e574075141", "event_type": "online", "severity": "informational", "site_id": "1", "rack_id": "1", "cluster_id": "d6b77d52dc0a4fdc8dabd036f57b49eb", "storageset_id": "af8c7051244c4a1ebc2303ceb1636437", "node_id": "af8c7051244c4a1ebc2303ceb1636437", "host_id": "af8c7051244c4a1ebc2303ceb1636437", "resource_type": "node", "timestamp": "1641263945", "resource_id": "af8c7051244c4a1ebc2303ceb1636437", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-z7jzk", "pod_restart": 1}} with action ['publish']
2022-01-04 02:39:08 health_monitor [18353]: INFO [act] Default action handler with Event: 164126394590e4674325974134ab9b95e574075141 and actions : ['publish']
2022-01-04 02:39:08 health_monitor [18353]: INFO [publish] Sending action event {"version": "2.0", "event_type": "online", "event_id": "164126394590e4674325974134ab9b95e574075141", "resource_type": "node", "cluster_id": "d6b77d52dc0a4fdc8dabd036f57b49eb", "site_id": "1", "rack_id": "1", "storageset_id": "af8c7051244c4a1ebc2303ceb1636437", "node_id": "af8c7051244c4a1ebc2303ceb1636437", "resource_id": "af8c7051244c4a1ebc2303ceb1636437", "timestamp": "1641263945", "event_specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-z7jzk", "pod_restart": 1}} to component hare

consul keys:
sh-4.2# consul kv get -http-addr=consul-server.default.svc.cluster.local:8500 --recurse cortx/ha/v1
cortx/ha/v1:
cortx/ha/v1/action/node/failed:["publish"]
cortx/ha/v1/action/node/online:["publish"]
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263879", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1641263879", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263879", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1641263879", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263878", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1641263878", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/8f6e76bd96f44fdd8abc7fd7589bf925/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263881", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2693-68fb57f57-h6fgm", "pod_restart": 0}}], "action": {"modified_timestamp": "1641263881", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/af8c7051244c4a1ebc2303ceb1636437/health:{"events": [{"event_timestamp": "1641263945", "created_timestamp": "1641263945", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-z7jzk", "pod_restart": 1}}, {"event_timestamp": "1641263945", "created_timestamp": "1641263945", "status": "failed", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-lcqsm", "pod_restart": 1}}], "action": {"modified_timestamp": "1641263945", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/f17ac55fc9574694bdee9b155297c6a6/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263875", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj", "pod_restart": 0}}], "action": {"modified_timestamp": "1641263875", "status": "pending"}, "attributes": {}}
cortx/ha/v1/events/node/failed:["hare"]
cortx/ha/v1/events/node/online:["hare"]
cortx/ha/v1/events/subscribe/hare:["node/online", "node/failed"]
cortx/ha/v1/init_system_health:0
cortx/ha/v1/inital_time:1641263876
cortx/ha/v1/message_type/hare:ha_event_hare
cortx/ha/v1/sys_health_bootstrap_timeout:10

And after pod_restart reset:
sh-4.2# consul kv get -http-addr=consul-server.default.svc.cluster.local:8500 --recurse cortx/ha/v1
cortx/ha/v1:
cortx/ha/v1/action/node/failed:["publish"]
cortx/ha/v1/action/node/online:["publish"]
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263879", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1641263879", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263879", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1641263879", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263878", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1641263878", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/8f6e76bd96f44fdd8abc7fd7589bf925/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263881", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2693-68fb57f57-h6fgm", "pod_restart": 0}}], "action": {"modified_timestamp": "1641263881", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/af8c7051244c4a1ebc2303ceb1636437/health:{"events": [{"event_timestamp": "1641263945", "created_timestamp": "1641263945", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-z7jzk", "pod_restart": 0}}, {"event_timestamp": "1641263945", "created_timestamp": "1641263945", "status": "failed", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2731-68c6dd969b-lcqsm", "pod_restart": 1}}], "action": {"modified_timestamp": "1641263945", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/f17ac55fc9574694bdee9b155297c6a6/health:{"events": [{"event_timestamp": "1641263875", "created_timestamp": "1641263875", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj", "pod_restart": 0}}], "action": {"modified_timestamp": "1641263875", "status": "pending"}, "attributes": {}}
cortx/ha/v1/events/node/failed:["hare"]
cortx/ha/v1/events/node/online:["hare"]
cortx/ha/v1/events/subscribe/hare:["node/online", "node/failed"]
cortx/ha/v1/init_system_health:0
cortx/ha/v1/inital_time:1641263876
cortx/ha/v1/message_type/hare:ha_event_hare
cortx/ha/v1/sys_health_bootstrap_timeout:10
sh-4.2#

Normal failure:

k8s_mon logs:
2022-01-04 03:10:18 pod_monitor [18355]: INFO [run] Sending alert on message bus {'_resource_type': 'node', '_resource_name': 'f17ac55fc9574694bdee9b155297c6a6', '_event_type': 'failed', '_k8s_container': None, '_generation_id': 'cortx-data-pod-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj', '_node': 'ssc-vm-g2-rhev4-2692.colo.seagate.com', '_is_status': False, '_timestamp': '1641265818'}
2022-01-04 03:10:21 pod_monitor [18355]: INFO [run] Sending alert on message bus {'_resource_type': 'node', '_resource_name': 'f17ac55fc9574694bdee9b155297c6a6', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-data-pod-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj', '_node': 'ssc-vm-g2-rhev4-2692.colo.seagate.com', '_is_status': False, '_timestamp': '1641265821'}

health_mon logs
2022-01-04 03:10:20 health_monitor [18353]: INFO [evaluate] Evaluated action ['publish'] for key action/node/failed
2022-01-04 03:10:20 health_monitor [18353]: INFO [process_event] Evaluated {"event_id": "164126581902d65663412e4eafa1bb85beb67c011     d", "event_type": "failed", "severity": "error", "site_id": "1", "rack_id": "1", "cluster_id": "d6b77d52dc0a4fdc8dabd036f57b49eb",      "storageset_id": "f17ac55fc9574694bdee9b155297c6a6", "node_id": "f17ac55fc9574694bdee9b155297c6a6", "host_id": "f17ac55fc9574694b     dee9b155297c6a6", "resource_type": "node", "timestamp": "1641265818", "resource_id": "f17ac55fc9574694bdee9b155297c6a6", "specific     _info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj", "pod_restart": 0}} with action ['publish']
2022-01-04 03:10:20 health_monitor [18353]: INFO [act] Default action handler with Event: 164126581902d65663412e4eafa1bb85beb67c01     1d and actions : ['publish']
2022-01-04 03:10:20 health_monitor [18353]: INFO [publish] Sending action event {"version": "2.0", "event_type": "failed", "event_     id": "164126581902d65663412e4eafa1bb85beb67c011d", "resource_type": "node", "cluster_id": "d6b77d52dc0a4fdc8dabd036f57b49eb", "sit     e_id": "1", "rack_id": "1", "storageset_id": "f17ac55fc9574694bdee9b155297c6a6", "node_id": "f17ac55fc9574694bdee9b155297c6a6", "r     esource_id": "f17ac55fc9574694bdee9b155297c6a6", "timestamp": "1641265818", "event_specific_info": {"generation_id": "cortx-data-p     od-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj", "pod_restart": 0}} to component hare
2022-01-04 03:10:22 health_monitor [18353]: INFO [evaluate] Evaluated action ['publish'] for key action/node/online
2022-01-04 03:10:22 health_monitor [18353]: INFO [process_event] Evaluated {"event_id": "164126582117b8aa99fc524de3a9af59258f02190     5", "event_type": "online", "severity": "informational", "site_id": "1", "rack_id": "1", "cluster_id": "d6b77d52dc0a4fdc8dabd036f5     7b49eb", "storageset_id": "f17ac55fc9574694bdee9b155297c6a6", "node_id": "f17ac55fc9574694bdee9b155297c6a6", "host_id": "f17ac55fc     9574694bdee9b155297c6a6", "resource_type": "node", "timestamp": "1641265821", "resource_id": "f17ac55fc9574694bdee9b155297c6a6", "     specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj", "pod_restart": 0}} with action ['publish     ']
2022-01-04 03:10:22 health_monitor [18353]: INFO [act] Default action handler with Event: 164126582117b8aa99fc524de3a9af59258f0219     05 and actions : ['publish']
2022-01-04 03:10:22 health_monitor [18353]: INFO [publish] Sending action event {"version": "2.0", "event_type": "online", "event_     id": "164126582117b8aa99fc524de3a9af59258f021905", "resource_type": "node", "cluster_id": "d6b77d52dc0a4fdc8dabd036f57b49eb", "sit     e_id": "1", "rack_id": "1", "storageset_id": "f17ac55fc9574694bdee9b155297c6a6", "node_id": "f17ac55fc9574694bdee9b155297c6a6", "r     esource_id": "f17ac55fc9574694bdee9b155297c6a6", "timestamp": "1641265821", "event_specific_info": {"generation_id": "cortx-data-p     od-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj", "pod_restart": 0}} to component hare

system health for that node
cortx/ha/v1/cortx/ha/system/cluster/d6b77d52dc0a4fdc8dabd036f57b49eb/site/1/rack/1/node/f17ac55fc9574694bdee9b155297c6a6/health:{"events": [{"event_timestamp": "1641265821", "created_timestamp": "1641265821", "status": "online", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj", "pod_restart": 0}}, {"event_timestamp": "1641265818", "created_timestamp": "1641265819", "status": "failed", "specific_info": {"generation_id": "cortx-data-pod-ssc-vm-g2-rhev4-2692-6cb699b67c-9bqlj", "pod_restart": 0}}], "action": {"modified_timestamp": "1641265821", "status": "pending"}, "attributes": {}}

