### PR TITLE
EOS-27248: support for Mock Upgrade Miniprovisioner for HA

### DIFF
--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -71,7 +71,7 @@ class Cmd:
         sys.stderr.write(
             f"usage: {prog} [-h] <cmd> <--config url> <args>...\n"
             f"where:\n"
-            f"cmd   post_install, prepare, config, init, test, reset, cleanup\n"
+            f"cmd   post_install, prepare, config, init, test, reset, cleanup, upgrade\n"
             f"--config   Config URL.\n"
             f"--services   Service name.\n")
 
@@ -305,6 +305,24 @@ class InitCmd(Cmd):
         Process init command.
         """
         sys.stdout.write('HA initialization is done.\n')
+
+class UpgradeCmd(Cmd):
+    """
+    Setup Upgrade Cmd
+    """
+    name = "upgrade"
+
+    def __init__(self, args):
+        """
+        Init method.
+        """
+        super().__init__(args)
+
+    def process(self):
+        """
+        Process upgrade command.
+        """
+        sys.stdout.write("HA has been upgraded successfully\n")
 
 class TestCmd(Cmd):
     """


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- EOS-27248: added support for Mock Upgrade Miniprovisioner for HA in ha_setup 

# Design
-  Ticket ref: https://jts.seagate.com/browse/EOS-27248 

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]: N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [x] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: Y

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
