### PR TITLE
EOS-27303: Log Location for HA should be picked up from confstore.

### DIFF
--- a/ha/const.py
+++ b/ha/const.py
@@ -22,6 +22,7 @@ CORTX_VERSION_2="2"
 HA_CLUSTER_SOFTWARE="corosync"
 HACLUSTER_KEY = "cortx"
 SERVER_NODE_KEY = "server_node"
+# RA_LOG_DIR this is deprecated.[#620 PR]
 RA_LOG_DIR="/var/log/seagate/cortx/ha"
 PACEMAKER_LOG="/var/log/pacemaker.log"
 AUTH_DIR="/var/lib/pcsd"
@@ -32,6 +33,7 @@ PCSD_DIR="/var/log/pcsd"
 LOG_DIR="/var/log"
 CONFIG_DIR="/etc/cortx/ha"
 SYSTEM_DIR="/etc/systemd/system"
+# Needs to be replaced by log path defined in cluster.conf[EOS-27352].
 SUPPORT_BUNDLE_ERR="{}/support_bundle.err".format(RA_LOG_DIR)
 SUPPORT_BUNDLE_LOGS=[RA_LOG_DIR, PCSD_LOG, PACEMAKER_LOG, COROSYNC_LOG]
 CORTX_SUPPORT_BUNDLE_LOGS=[RA_LOG_DIR, PCSD_LOG, PACEMAKER_LOG, CONFIG_DIR, COROSYNC_LOG]

--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -13,6 +13,7 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
+# Needs to be replaced by log path defined in cluster.conf[EOS-27352].
 HA_LOG_DIR="/var/log/seagate/cortx/ha"
 HA_LOG_LEVEL="INFO"
 CONFIG_DIR="/etc/cortx/ha"

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -188,6 +188,10 @@ class ConfigCmd(Cmd):
         Process config command.
         """
         try:
+            # Get log path from cluster.conf.
+            log_path = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}storage{_DELIM}log')
+            ha_log_path = os.path.join(log_path, f'ha/{Conf.machine_id}')
+
             consul_endpoints = Conf.get(self._index, f'cortx{_DELIM}external{_DELIM}consul{_DELIM}endpoints')
             #========================================================#
             # consul Service endpoints from cluster.conf             #
@@ -221,7 +225,7 @@ class ConfigCmd(Cmd):
             num_pods = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}product_release')
             num_pods = '10' #temporary value till the same is avilabe in cluster.conf
 
-            conf_file_dict = {'LOG' : {'path' : const.HA_LOG_DIR, 'level' : const.HA_LOG_LEVEL},
+            conf_file_dict = {'LOG' : {'path' : ha_log_path, 'level' : const.HA_LOG_LEVEL},
                          'consul_config' : {'endpoint' : consul_endpoint},
                          'kafka_config' : {'endpoints': kafka_endpoint},
                          'event_topic' : 'hare',

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -90,12 +90,6 @@ class Cmd:
         args = parser.parse_args(argv)
         return args.command(args)
 
-    def get_machine_id(self):
-        command = "cat /etc/machine-id"
-        machine_id, err, rc = self._execute.run_cmd(command, check_error=True)
-        Log.info(f"Read machine-id. Output: {machine_id}, Err: {err}, RC: {rc}")
-        return machine_id.strip()
-
     @staticmethod
     def add_args(parser: str, cls: str, name: str):
         """
@@ -190,7 +184,8 @@ class ConfigCmd(Cmd):
         try:
             # Get log path from cluster.conf.
             log_path = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}storage{_DELIM}log')
-            ha_log_path = os.path.join(log_path, f'ha/{Conf.machine_id}')
+            machine_id = Conf.machine_id
+            ha_log_path = os.path.join(log_path, f'ha/{machine_id}')
 
             consul_endpoints = Conf.get(self._index, f'cortx{_DELIM}external{_DELIM}consul{_DELIM}endpoints')
             #========================================================#
@@ -260,7 +255,6 @@ class ConfigCmd(Cmd):
             # in the similar way, confstore will have this key when
             # the cluster.conf load will taked place.
             # So, to get the cluster_id field from Confstore, we need machine_id
-            machine_id = self.get_machine_id()
             cluster_id = Conf.get(self._index, f'node{_DELIM}{machine_id}{_DELIM}cluster_id')
             # site_id = Conf.get(self._index, f'node{_DELIM}{machine_id}{_DELIM}site_id')
             site_id = '1'


### PR DESCRIPTION
Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>

# Problem Statement
- EOS-27303: Log Location for HA should be picked up from confstore

# Design
-  Get log location from /etc/cortx/cluster.conf [cortx>common>storage>log] and store all location as same place.

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
