### PR TITLE
EOS-26969 Implement logic to get data and storage pod information from ConfStore

### DIFF
--- a/ha/test/integration/test_conf_store_search_api.py
+++ b/ha/test/integration/test_conf_store_search_api.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+import os
+import pathlib
+import sys
+import time
+
+from ha.util.conf_store import ConftStoreSearch
+from cortx.utils.conf_store import Conf
+from cortx.utils.cortx.const import Const
+from ha.core.config.config_manager import ConfigManager
+
+sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..', '..'))
+
+if __name__ == "__main__":
+    print("******** Testing confstore search APIs for data and server PODs ********")
+    try:
+        Conf.load("cortx", "yaml:///etc/cortx/cluster.conf")
+        ConfigManager.init("test_conf_store_search_api")
+        cluster_card  = ConftStoreSearch()
+        cluster_card.set_cluster_cardinality("cortx")
+        cc = cluster_card.get_cluster_cardinality()
+        print(f"Following clsuter cardinality is set: {cc}")
+
+    except Exception as e:
+        print(f"Failed to test confstore search APIs for data and server PODs, Error: {e}")

--- a/ha/test/integration/test_conf_store_search_api.py
+++ b/ha/test/integration/test_conf_store_search_api.py
@@ -16,11 +16,9 @@
 import os
 import pathlib
 import sys
-import time
 
 from ha.util.conf_store import ConftStoreSearch
 from cortx.utils.conf_store import Conf
-from cortx.utils.cortx.const import Const
 from ha.core.config.config_manager import ConfigManager
 
 sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..', '..'))

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -25,7 +25,7 @@ from cortx.utils.conf_store import Conf
 from cortx.utils.cortx.const import Const
 from ha.core.config.config_manager import ConfigManager
 from ha.k8s_setup.const import CLUSTER_CARDINALITY_KEY, CLUSTER_CARDINALITY_NUM_NODES, CLUSTER_CARDINALITY_LIST_NODES
-from ha.k8s_setup.const import NODE_CONST, SERVICE_CONST, _DELIM
+from ha.k8s_setup.const import NODE_CONST, SERVICE_CONST
 from cortx.utils.log import Log
 from ha.core.error import ClusterCardinalityError
 
@@ -98,7 +98,7 @@ class ConftStoreSearch:
 
         Log.info(f"Cluster cardinality: number of nodes {num_pods}, machine ids for nodes {watch_pods} ")
 
-        if num_pods is 0:
+        if num_pods == 0:
             Log.warn(f"Possible cluster cardinality issue; number of pods to be watched {num_pods}")
 
         # Update the same to consul; if KV already present, it will be modified.

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -44,8 +44,13 @@ class ConftStoreSearch:
         Get machine ids for data pods: returns list of machine ids.
         """
         machine_ids = []
-        keys = Conf.search(index, NODE_CONST, SERVICE_CONST, Const.SERVICE_MOTR_IO.value)
-        for key in keys:
+        # Sample output of the serach API
+        # ex: Conf.search("cortx", "node", "services", Const.SERVICE_MOTR_IO.value)
+        # ['node>5f3dc3a153454a918277ee4a2c57f36b>components[1]>services[0]',
+        # 'node>6203a14bde204e8ea798ad9d42583fb5>components[1]>services[0]', 'node>8cc8b13101e34b3ca1e51ed6e3228d5b>components[1]>services[0]']
+
+        data_pod_keys = Conf.search(index, NODE_CONST, SERVICE_CONST, Const.SERVICE_MOTR_IO.value)
+        for key in data_pod_keys:
             machine_id = key.split('>')[1]
             # Add machine id to list
             machine_ids.append(machine_id)
@@ -56,8 +61,8 @@ class ConftStoreSearch:
         Get machine ids for server pods: returns list of machine ids.
         """
         machine_ids = []
-        keys = Conf.search(index, NODE_CONST, SERVICE_CONST, Const.SERVICE_S3_HAPROXY.value)
-        for key in keys:
+        server_pod_keys = Conf.search(index, NODE_CONST, SERVICE_CONST, Const.SERVICE_S3_HAPROXY.value)
+        for key in server_pod_keys:
             machine_id = key.split('>')[1]
             # Add machine id to list
             machine_ids.append(machine_id)


### PR DESCRIPTION
Signed-off-by: ArchanaLimaye <archana.limaye@seagate.com>

# Problem Statement
- Need to get cluster cardinality using confstore APIs

# Design
Using the confstore APIs, got the list of (and machine ids of) data and server pods.
This list and the count stored in consul 

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]:  N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N] N
- [ ] Side effects on other features (deployment/upgrade)? [Y/N] N
- [ ] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
Fault tolerance LLD updated