### PR TITLE
EOS-26971: Modify monitor service to use machine ids fetched from confstore to filter the API server alert

### DIFF
--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -207,17 +207,11 @@ class ConfigCmd(Cmd):
             if not kafka_endpoint:
                 sys.stderr.write(f'Failed to get kafka config. kafka_config: {kafka_endpoint}. \n')
                 sys.exit(1)
-            # Dummy value fetched for now. This will be replaced by the key/path for the pod label onces that is avilable in confstore
-            # Ref ticket EOS-25694
-            data_pod_label = Conf.get(self._index, f'cortx{_DELIM}common{_DELIM}product_release')
-            # TBD delete once data_pod_label is avilable from confstore
-            data_pod_label = ['cortx-data', 'cortx-server']
 
             conf_file_dict = {'LOG' : {'path' : ha_log_path, 'level' : const.HA_LOG_LEVEL},
                          'consul_config' : {'endpoint' : consul_endpoint},
                          'kafka_config' : {'endpoints': kafka_endpoint},
                          'event_topic' : 'hare',
-                         'data_pod_label' : data_pod_label,
                          'MONITOR' : {'message_type' : 'cluster_event', 'producer_id' : 'cluster_monitor'},
                          'EVENT_MANAGER' : {'message_type' : 'health_events', 'producer_id' : 'system_health',
                                             'consumer_group' : 'health_monitor', 'consumer_id' : '1'},
@@ -257,8 +251,7 @@ class ConfigCmd(Cmd):
                 yaml.dump(conf_file_dict, conf_file, default_flow_style=False)
             self._confstore = ConfigManager.get_confstore()
 
-            Log.info(f'Populating the ha config file with consul_endpoint: {consul_endpoint}, \
-                       data_pod_label: {data_pod_label}')
+            Log.info(f'Populating the ha config file with consul_endpoint: {consul_endpoint}')
 
             Log.info('Performing event_manager subscription')
             event_manager = EventManager.get_instance()

--- a/ha/monitor/k8s/monitor.py
+++ b/ha/monitor/k8s/monitor.py
@@ -28,6 +28,7 @@ from ha.k8s_setup.const import _DELIM
 from ha import const
 from ha.core.config.config_manager import ConfigManager
 from ha.util.message_bus import MessageBus
+from ha.util.conf_store import ConftStoreSearch
 from ha.monitor.k8s.object_monitor import ObjectMonitor
 from ha.monitor.k8s.const import K8SClientConst
 
@@ -40,41 +41,45 @@ class ResourceMonitor:
         Init method
         Create monitor objects and Sets the callbacks to sigterm
         """
-        # set sigterm handler
-        signal.signal(signal.SIGTERM, self.set_sigterm)
+        try:
+            # set sigterm handler
+            signal.signal(signal.SIGTERM, self.set_sigterm)
 
-        # Read I/O pod selector label from ha.conf . Will be received from provisioner confstore
-        # provisioner needs to be informed to add it in confstore  (to be added there )
-        ConfigManager.init("k8s_resource_monitor")
+            # Read I/O pod selector label from ha.conf . Will be received from provisioner confstore
+            # provisioner needs to be informed to add it in confstore  (to be added there )
+            ConfigManager.init("k8s_resource_monitor")
+            self._conf_stor_search = ConftStoreSearch()
 
-        self.monitors = []
+            self.monitors = []
 
-        # event output in pretty format
-        kwargs = {K8SClientConst.PRETTY : True}
+            # event output in pretty format
+            kwargs = {K8SClientConst.PRETTY : True}
 
-        # Seting a timeout value, 'timout_seconds', for the stream.
-        # timeout value for connection to the server
-        # If do not set then we will not able to stop immediately,
-        # becuase synchronus function watch.stream() will not come back
-        # until catch any event on which it is waiting.
-        kwargs[K8SClientConst.TIMEOUT_SECONDS] = K8SClientConst.VAL_WATCH_TIMEOUT_DEFAULT
+            # Seting a timeout value, 'timout_seconds', for the stream.
+            # timeout value for connection to the server
+            # If do not set then we will not able to stop immediately,
+            # becuase synchronus function watch.stream() will not come back
+            # until catch any event on which it is waiting.
+            kwargs[K8SClientConst.TIMEOUT_SECONDS] = K8SClientConst.VAL_WATCH_TIMEOUT_DEFAULT
 
-        # Get MessageBus producer object for all monitor threads
-        producer = self._get_producer()
+            # Get MessageBus producer object for all monitor threads
+            producer = self._get_producer()
 
-        # Change to multiprocessing
-        # Creating NODE monitor object
-        node_monitor = ObjectMonitor(producer, K8SClientConst.NODE, **kwargs)
-        self.monitors.append(node_monitor)
+            # Change to multiprocessing
+            # Creating NODE monitor object
+            node_monitor = ObjectMonitor(producer, K8SClientConst.NODE, **kwargs)
+            self.monitors.append(node_monitor)
 
-        pod_labels = Conf.get(const.HA_GLOBAL_INDEX, "data_pod_label")
-        pod_label_str = ', '.join(pod_label for pod_label in pod_labels)
-        # TODO : Change 'name' field to 'app' in label_selector if required.
-        kwargs[K8SClientConst.LABEL_SELECTOR] = f'name in ({pod_label_str})'
+            _, nodes_list = self._conf_stor_search.get_cluster_cardinality()
+            nodes_list = ['27d9b5122785444444444444444']
+            watcher_node_ids = ', '.join(node_id for node_id in nodes_list)
+            kwargs[K8SClientConst.LABEL_SELECTOR] = f'cortx.io/machine-id in ({watcher_node_ids})'
 
-        # Creating POD monitor object
-        pod_monitor = ObjectMonitor(producer, K8SClientConst.POD, **kwargs)
-        self.monitors.append(pod_monitor)
+            # Creating POD monitor object
+            pod_monitor = ObjectMonitor(producer, K8SClientConst.POD, **kwargs)
+            self.monitors.append(pod_monitor)
+        except Exception as err:
+            Log.error(f'Monitor failed to start watchers: {err}')
 
     def _get_producer(self):
         """

--- a/ha/monitor/k8s/monitor.py
+++ b/ha/monitor/k8s/monitor.py
@@ -48,7 +48,7 @@ class ResourceMonitor:
             # Read I/O pod selector label from ha.conf . Will be received from provisioner confstore
             # provisioner needs to be informed to add it in confstore  (to be added there )
             ConfigManager.init("k8s_resource_monitor")
-            self._conf_stor_search = ConftStoreSearch()
+            _conf_stor_search = ConftStoreSearch()
 
             self.monitors = []
 
@@ -70,8 +70,11 @@ class ResourceMonitor:
             node_monitor = ObjectMonitor(producer, K8SClientConst.NODE, **kwargs)
             self.monitors.append(node_monitor)
 
-            _, nodes_list = self._conf_stor_search.get_cluster_cardinality()
-            nodes_list = ['27d9b5122785444444444444444']
+            _, nodes_list = _conf_stor_search.get_cluster_cardinality()
+            if not nodes_list:
+                Log.warn(f"No nodes in the cluster to watch for nodes_list: {nodes_list}")
+            else:
+                Log.info(f"Starting watch for: nodes_list: {nodes_list}")
             watcher_node_ids = ', '.join(node_id for node_id in nodes_list)
             kwargs[K8SClientConst.LABEL_SELECTOR] = f'cortx.io/machine-id in ({watcher_node_ids})'
 


### PR DESCRIPTION
…fstore to filter the API server alert

- Use conf store search API HA wrapper class to get the cluster
  cardinality(list of machind_ids).
- Use cortx.io/machine-id label of a Node to match its value with machine_id
  list fetched from above API to filter the alert.
- Remove hardcoded label from ha_setup

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

# Problem Statement
https://jts.seagate.com/browse/EOS-26971
Use list of machine_ids of a data and server POD to filter the API server alert in HA monitor service.


# Design
- Use conf store search API wrapper class to get the cluster cardinality(list of machind_ids).
- Use **cortx.io/machine-id** label of a Node to match the value of its with list fetched from above API to filter the alert.
- Based on the fact that every data and server pod will have **cortx.io/machine-id** field in its labels section.

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: N
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N] N
- [x] Side effects on other features (deployment/upgrade)? [Y/N] N
- [x] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: Y

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide

Testing on local machine:

Created a dummy-pod:
`
kind: Pod
apiVersion: v1
metadata:
name: dummy-pod
labels:
cortx.io/machine-id: 27d9b5122785444444444444444
app: cortx-data
spec:
containers:
name: dummy-pod-con
image: rabbitmq
imagePullPolicy: IfNotPresent
restartPolicy: Never
`

Started k8s_monitor service:
Alert received by k8s:
`
2022-01-12 02:40:15 k8s_resource_monitor [21623]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': '27d9b5122785444444444444444', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'dummy-pod', '_node': 'ssc-vm-g3-rhev4-1315.colo.seagate.com', '_is_status': True, '_timestamp': '1641980415'}
`
2. Performed POD deletion:
`
2022-01-12 02:41:02 k8s_resource_monitor [21623]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': '27d9b5122785444444444444444', '_event_type': 'failed', '_k8s_container': None, '_generation_id': 'dummy-pod', '_node': 'ssc-vm-g3-rhev4-1315.colo.seagate.com', '_is_status': False, '_timestamp': '1641980462'}
`

New testing:
k8s_mon logs:

`
2022-01-12 11:23:08 k8s_resource_monitor [155]: INFO [__init__] Starting watch for: nodes_list: ['5f3dc3a153454a918277ee4a2c57f36b', 'cb8d65f147c8476e84120cd91ac0527c', 'e10ba54560044d0aa2c413de18f596ce', '8cc8b13101e34b3ca1e51ed6e3228d5b', '6203a14bde204e8ea798ad9d42583fb5', 'e2f7125f68ff49f0bcfdf360d1dc7457']
`

`
2022-01-12 11:23:09 k8s_resource_monitor [155]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': 'cb8d65f147c8476e84120cd91ac0527c', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-server-ssc-vm-g4-rhev4-0147-955fcf89b-plwph', '_node': 'ssc-vm-g4-rhev4-0147.colo.seagate.com', '_is_status': True, '_timestamp': '1641986589'}
2022-01-12 11:23:10 k8s_resource_monitor [155]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': 'e10ba54560044d0aa2c413de18f596ce', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-server-ssc-vm-g4-rhev4-0146-64495f5ccd-whxxq', '_node': 'ssc-vm-g4-rhev4-0146.colo.seagate.com', '_is_status': True, '_timestamp': '1641986590'}
2022-01-12 11:23:14 k8s_resource_monitor [155]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': '6203a14bde204e8ea798ad9d42583fb5', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-data-ssc-vm-g4-rhev4-0147-f5df7bb79-j4bbg', '_node': 'ssc-vm-g4-rhev4-0147.colo.seagate.com', '_is_status': True, '_timestamp': '1641986594'}
2022-01-12 11:23:19 k8s_resource_monitor [155]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': '8cc8b13101e34b3ca1e51ed6e3228d5b', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-data-ssc-vm-g4-rhev4-0148-d48c6fd44-h7xv5', '_node': 'ssc-vm-g4-rhev4-0148.colo.seagate.com', '_is_status': True, '_timestamp': '1641986599'}
2022-01-12 11:23:19 k8s_resource_monitor [155]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': '5f3dc3a153454a918277ee4a2c57f36b', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-data-ssc-vm-g4-rhev4-0146-84b6d87d74-hcmkc', '_node': 'ssc-vm-g4-rhev4-0146.colo.seagate.com', '_is_status': True, '_timestamp': '1641986599'}
2022-01-12 11:23:19 k8s_resource_monitor [155]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': 'e2f7125f68ff49f0bcfdf360d1dc7457', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-server-ssc-vm-g4-rhev4-0148-868db5c598-zf8zp', '_node': 'ssc-vm-g4-rhev4-0148.colo.seagate.com', '_is_status': True, '_timestamp': '1641986599'}
`
System health keys:
`
cortx/ha/v1/cortx/ha/system/cluster/0603f86cb68a46c68dcfc22f2053a044/site/1/rack/1/node/5f3dc3a153454a918277ee4a2c57f36b/health:{"events": [{"event_timestamp": "1641986590", "created_timestamp": "1641986590", "status": "online", "specific_info": "specific_info"}], "action": {"modified_timestamp": "1641986590", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/0603f86cb68a46c68dcfc22f2053a044/site/1/rack/1/node/6203a14bde204e8ea798ad9d42583fb5/health:{"events": [{"event_timestamp": "1641986590", "created_timestamp": "1641986590", "status": "online", "specific_info": "specific_info"}], "action": {"modified_timestamp": "1641986590", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/0603f86cb68a46c68dcfc22f2053a044/site/1/rack/1/node/8cc8b13101e34b3ca1e51ed6e3228d5b/health:{"events": [{"event_timestamp": "1641986590", "created_timestamp": "1641986590", "status": "online", "specific_info": "specific_info"}], "action": {"modified_timestamp": "1641986590", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/0603f86cb68a46c68dcfc22f2053a044/site/1/rack/1/node/cb8d65f147c8476e84120cd91ac0527c/health:{"events": [{"event_timestamp": "1641986589", "created_timestamp": "1641986589", "status": "online", "specific_info": "specific_info"}], "action": {"modified_timestamp": "1641986589", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/0603f86cb68a46c68dcfc22f2053a044/site/1/rack/1/node/e10ba54560044d0aa2c413de18f596ce/health:{"events": [{"event_timestamp": "1641986590", "created_timestamp": "1641986590", "status": "online", "specific_info": "specific_info"}], "action": {"modified_timestamp": "1641986590", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/0603f86cb68a46c68dcfc22f2053a044/site/1/rack/1/node/e2f7125f68ff49f0bcfdf360d1dc7457/health:{"events": [{"event_timestamp": "1641986590", "created_timestamp": "1641986591", "status": "online", "specific_info": "specific_info"}], "action": {"modified_timestamp": "1641986591", "status": "pending"}, "attributes": {}}
`


If the nodes_list coming as empty:
k8s_mon logs:
`
2022-01-12 11:31:18 k8s_resource_monitor [237]: WARNING [__init__] No nodes in the cluster to watch for nodes_list: []
`
No sys health keys:
`
sh-4.2# consul kv get -http-addr=consul-server.default.svc.cluster.local:8500 --recurse cortx/ha/v1
cortx/ha/v1/action/node/failed:["publish"]
cortx/ha/v1/action/node/online:["publish"]
cortx/ha/v1/cluster_cardinality:{"num_nodes": 6, "node_list": ["8cc8b13101e34b3ca1e51ed6e3228d5b", "5f3dc3a153454a918277ee4a2c57f36b", "cb8d65f147c8476e84120cd91ac0527c", "e2f7125f68ff49f0bcfdf360d1dc7457", "e10ba54560044d0aa2c413de18f596ce", "6203a14bde204e8ea798ad9d42583fb5"]}
cortx/ha/v1/events/node/failed:["hare"]
cortx/ha/v1/events/node/online:["hare"]
cortx/ha/v1/events/subscribe/hare:["node/online", "node/failed"]
cortx/ha/v1/message_type/hare:ha_event_hare
`
POD deleted:
`
2022-01-12 11:37:37 k8s_resource_monitor [296]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': 'e10ba54560044d0aa2c413de18f596ce', '_event_type': 'failed', '_k8s_container': None, '_generation_id': 'cortx-server-ssc-vm-g4-rhev4-0146-64495f5ccd-frl9m', '_node': 'ssc-vm-g4-rhev4-0146.colo.seagate.com', '_is_status': False, '_timestamp': '1641987457'}
2022-01-12 11:38:00 k8s_resource_monitor [296]: INFO [publish_alert] pod_monitor sending alert on message bus {'_resource_type': 'node', '_resource_name': 'e10ba54560044d0aa2c413de18f596ce', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-server-ssc-vm-g4-rhev4-0146-64495f5ccd-frl9m', '_node': 'ssc-vm-g4-rhev4-0146.colo.seagate.com', '_is_status': False, '_timestamp': '1641987480'}
`