### PR TITLE
EOS-27939 : Integration issue - set value 'start_cluster_shutdown' to 1 (in integer format).

### DIFF
--- a/ha/fault_tolerance/cluster_stop_monitor.py
+++ b/ha/fault_tolerance/cluster_stop_monitor.py
@@ -85,7 +85,7 @@ class ClusterStopMonitor:
             msg = json.dumps(ast.literal_eval(msg_decode))
             cluster_alert = json.loads(msg)
 
-            if cluster_alert["start_cluster_shutdown"] == '1':
+            if cluster_alert["start_cluster_shutdown"] == 1:
                 self.stop_cluster()
         except Exception as err:
             Log.error(f'Failed to analyze the event: {message} error: {err}')
@@ -97,7 +97,7 @@ class ClusterStopMonitor:
         Sets the cluster stop key in confstore for the k8s monitor
         to notify cltuster shutdown is started
         """
-        Log.info('The cluster stop message on message bus ({self._message_type}) is received.')
+        Log.info(f'The cluster stop message on message bus ({self._message_type}) is received.')
         confstore = ConfigManager.get_confstore()
         if not confstore.key_exists(const.CLUSTER_STOP_KEY):
             Log.info(f'Setting key {const.CLUSTER_STOP_KEY} to {const.CLUSTER_STOP_VAL_ENABLE} in confstore.')

--- a/ha/test/integration/test_sigterm_to_ha_services.py
+++ b/ha/test/integration/test_sigterm_to_ha_services.py
@@ -64,7 +64,7 @@ class TestSigtermHandling(unittest.TestCase):
         producer_id="csm_producer"
         self.message_type = Conf.get(const.HA_GLOBAL_INDEX, f'CLUSTER_STOP_MON{const._DELIM}message_type')
         self.producer = MessageBus.get_producer(producer_id=producer_id, message_type=self.message_type)
-        self.producer.publish({"start_cluster_shutdown":"1"})
+        self.producer.publish({"start_cluster_shutdown":1})
         # The consumer 'ClusterStopMonitor' will checking this message/key as cluster_alert["start_cluster_shutdown"] == '1'
 
     def check_cluster_stop_key(self, should_exists):


### PR DESCRIPTION
…tween CSM and HA

Signed-off-by: mukhtar inamdar <mukhtar.p.inamdar@seagate.com>

# Problem Statement
- EOS-27939 Integration issue for message 'start_cluster_shutdown' between CSM and HA

# Design
-  use 1 (integer value) instead '1' (string value)

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path, and Scalability
- [] Testing was performed with RPM
Tested with CSM as well as test script already added in test
csm calls:
----------------------------------- Login call ---------------------------------------------------------
post: https://ssc-vm-g4-rhev4-0247.colo.seagate.com:31169/api/v2/login?debug
body (json): {"username": "cortxadmin","password": "Cortxadmin@123"}
------------------------------------- Result -----------------------------------------------------------
Authorization: Bearer 4f4bc005b4e240a594b4ff4b16aac22f
----------------------------------- start shutdown call ------------------------------------------------
https://ssc-vm-g4-rhev4-0247.colo.seagate.com:31169/api/v2/system/management/cluster?debug
Headers:
Authorization: Bearer 4f4bc005b4e240a594b4ff4b16aac22f
body (json): {"operation": "shutdown_signal", "arguments" : {}}
------------------------------------- Result -----------------------------------------------------------
{
    "message": "Shutdown signal sent successfully."
}
--------------------------------------------------------------------------------------------------------

\------------------------------------------- logs ------------------------------------------------------
fault-tolerance logs for stop_cluster monitor (snippet)
\-------------------------------------------------------------------------------------------------------
`2022-01-25 16:28:17 fault_tolerance [8]: INFO [stop_cluster] The cluster stop message on message bus (cluster_stop) is received.`
`2022-01-25 16:28:17 fault_tolerance [8]: INFO [stop_cluster] Setting key cluster_stop_key to 1 in confstore.`
\-------------------------------------------------------------------------------------------------------
k8s monitor logs (snippet):
\-------------------------------------------------------------------------------------------------------
`2022-01-25 17:02:48 k8s_resource_monitor [7]: INFO [publish_alert] node_monitor received cluster stop message so skipping publish alert: {'_resource_type': 'host', '_resource_name': 'ssc-vm-g4-rhev4-0247.colo.seagate.com', '_event_type': 'online', '_k8s_container': None, '_generation_id': None, '_node': None, '_is_status': True, '_timestamp': '1643130168'}.`
`2022-01-25 17:02:48 k8s_resource_monitor [7]: INFO [publish_alert] node_monitor received cluster stop message so skipping publish alert: {'_resource_type': 'host', '_resource_name': 'ssc-vm-g4-rhev4-0248.colo.seagate.com', '_event_type': 'online', '_k8s_container': None, '_generation_id': None, '_node': None, '_is_status': True, '_timestamp': '1643130168'}.`
`2022-01-25 17:02:48 k8s_resource_monitor [7]: INFO [publish_alert] pod_monitor received cluster stop message so skipping publish alert: {'_resource_type': 'node', '_resource_name': 'd8abe4712410471a8f98b475b5bacada', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-data-ssc-vm-g4-rhev4-0247-96f9b69fb-b56pt', '_node': 'ssc-vm-g4-rhev4-0247.colo.seagate.com', '_is_status': True, '_timestamp': '1643130168'}.`
`2022-01-25 17:02:48 k8s_resource_monitor [7]: INFO [publish_alert] pod_monitor received cluster stop message so skipping publish alert: {'_resource_type': 'node', '_resource_name': '537467e19c1340419287b124898b447d', '_event_type': 'online', '_k8s_container': None, '_generation_id': 'cortx-data-ssc-vm-g4-rhev4-0246-6d4b9867df-s2b8w', '_node': 'ssc-vm-g4-rhev4-0246.colo.seagate.com', '_is_status': True, '_timestamp': '1643130168'}.`
\-------------------------------------------------------------------------------------------------------

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: **N**
- x ] If yes for the above point, is a notification sent to all other cortx components? [Y/N] **N.A.**
- [x] Side effects on other features (deployment/upgrade)? [Y/N] **N**
- [x] Dependencies on other component(s)? [Y/N] **N**
-     If yes for the above point, post a link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
