### PR TITLE
EOS-26085: Redirect log to console

### DIFF
--- a/ha/core/config/config_manager.py
+++ b/ha/core/config/config_manager.py
@@ -54,7 +54,7 @@ class ConfigManager:
             if not log_path:
                 log_path = Conf.get(const.HA_GLOBAL_INDEX, f"LOG{_DELIM}path")
             level = Conf.get(const.HA_GLOBAL_INDEX, f"LOG{_DELIM}level")
-            # console_output=True will redirect all log to console
+            # console_output=True will redirect all log to console and log file both
             # TODO: filter redirect log for console and file
             Log.init(service_name=log_name, log_path=log_path, level=level,
                     backup_count=backup_count, file_size_in_mb=file_size_in_mb,

--- a/ha/core/config/config_manager.py
+++ b/ha/core/config/config_manager.py
@@ -55,7 +55,7 @@ class ConfigManager:
                 log_path = Conf.get(const.HA_GLOBAL_INDEX, f"LOG{_DELIM}path")
             level = Conf.get(const.HA_GLOBAL_INDEX, f"LOG{_DELIM}level")
             # console_output=True will redirect all log to console and log file both
-            # TODO: filter redirect log for console and file
+            # TODO: CORTX-28795 filter redirect log for console and file
             Log.init(service_name=log_name, log_path=log_path, level=level,
                     backup_count=backup_count, file_size_in_mb=file_size_in_mb,
                     syslog_server=syslog_server, syslog_port=syslog_port,

--- a/ha/core/config/config_manager.py
+++ b/ha/core/config/config_manager.py
@@ -41,7 +41,7 @@ class ConfigManager:
     @staticmethod
     def init(log_name, log_path=None, level="INFO",
             backup_count=5, file_size_in_mb=10, syslog_server=None,
-            syslog_port=None, console_output=False, config_file=None):
+            syslog_port=None, console_output=True, config_file=None):
         """
         Initialize ha conf and log
         Args:
@@ -58,6 +58,7 @@ class ConfigManager:
                     backup_count=backup_count, file_size_in_mb=file_size_in_mb,
                     syslog_server=syslog_server, syslog_port=syslog_port,
                     console_output=console_output)
+            Log.info(f"Started logging for service {log_name}")
 
     @staticmethod
     def _conf_init(config_file):

--- a/ha/core/config/config_manager.py
+++ b/ha/core/config/config_manager.py
@@ -54,6 +54,8 @@ class ConfigManager:
             if not log_path:
                 log_path = Conf.get(const.HA_GLOBAL_INDEX, f"LOG{_DELIM}path")
             level = Conf.get(const.HA_GLOBAL_INDEX, f"LOG{_DELIM}level")
+            # console_output=True will redirect all log to console
+            # TODO: filter redirect log for console and file
             Log.init(service_name=log_name, log_path=log_path, level=level,
                     backup_count=backup_count, file_size_in_mb=file_size_in_mb,
                     syslog_server=syslog_server, syslog_port=syslog_port,

--- a/ha/k8s_setup/ha_start.py
+++ b/ha/k8s_setup/ha_start.py
@@ -64,8 +64,6 @@ try:
             break
         if output:
             print(output.strip().decode("utf-8"))
-    rc = driver_process.poll()
-
-    exit(driver_process.wait())
+    exit(driver_process.poll())
 except Exception as proc_err:
     sys.stderr.write(f'Driver execution stopped because of some reason: {proc_err}')

--- a/ha/k8s_setup/ha_start.py
+++ b/ha/k8s_setup/ha_start.py
@@ -53,7 +53,7 @@ try:
     signal.signal(signal.SIGSEGV, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 
-    driver_process = Popen(['/usr/bin/python3', service_entry_mapping[args.services], "--start"], shell=False, stdout=PIPE, stderr=STDOUT) # nosec
+    driver_process = Popen(['/usr/bin/python3', service_entry_mapping[args.services]], shell=False, stdout=PIPE, stderr=STDOUT) # nosec
 
     sys.stdout.write(f"The driver process with pid {driver_process.pid}, and args {driver_process.args} started successfully.")
 


### PR DESCRIPTION
Signed-off-by: Ajay Paratmandali <ajay.paratmandali@seagate.com>

# Problem Statement
- Log redirection to console

# Design
-  Redirect log to stdout and stderr
driver_process.stdout.readline() allow to capture buffer console output of child process in parent process
and poll check if child process is running or not.
So if child process is running readline will get output and print it in console.

```
 while True:
        output = driver_process.stdout.readline()
        if driver_process.poll() is not None:
            break
        if output:
            print(output.strip().decode("utf-8"))
    exit(driver_process.poll())
```

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
