### PR TITLE
CORTX-27830: Update K8s monitor, fault tolerance and system health fo…

### DIFF
--- a/ha/const.py
+++ b/ha/const.py
@@ -326,6 +326,7 @@ ACTUATOR_MSG_WAIT_TIME = 2
 
 # Health event attribute constants
 class EVENT_ATTRIBUTES:
+    SOURCE = "source"
     EVENT_ID = "event_id"
     EVENT_TYPE = "event_type"
     SEVERITY = "severity"

--- a/ha/core/event_analyzer/filter/filter.py
+++ b/ha/core/event_analyzer/filter/filter.py
@@ -187,7 +187,7 @@ class ClusterResourceFilter(Filter):
             message = json.loads(message)
 
             Log.debug('Received alert from fault tolerance')
-            event_resource_type = message.get("_resource_type")
+            event_resource_type = message.get("event").get("payload").get("resource_type")
 
             required_resource_type = Conf.get(const.HA_GLOBAL_INDEX, f"NODE{_DELIM}resource_type")
             if event_resource_type == required_resource_type:

--- a/ha/core/event_analyzer/filter/filter.py
+++ b/ha/core/event_analyzer/filter/filter.py
@@ -26,6 +26,9 @@ from ha.core.config.config_manager import ConfigManager
 from ha.const import _DELIM, ALERT_ATTRIBUTES
 from ha.core.event_analyzer.event_analyzer_exceptions import EventFilterException
 from ha.core.event_analyzer.event_analyzer_exceptions import InvalidFilterRules
+from ha.fault_tolerance.const import HEALTH_ATTRIBUTES, \
+    EVENT_ATTRIBUTES
+
 
 class MESSAGETYPE(Enum):
     ALERT = "ALERT"
@@ -187,7 +190,7 @@ class ClusterResourceFilter(Filter):
             message = json.loads(message)
 
             Log.debug('Received alert from fault tolerance')
-            event_resource_type = message.get("event").get("payload").get("resource_type")
+            event_resource_type = message.get("event").get(EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value).get(HEALTH_ATTRIBUTES.RESOURCE_TYPE.value)
 
             required_resource_type = Conf.get(const.HA_GLOBAL_INDEX, f"NODE{_DELIM}resource_type")
             if event_resource_type == required_resource_type:

--- a/ha/core/event_analyzer/parser/parser.py
+++ b/ha/core/event_analyzer/parser/parser.py
@@ -19,8 +19,6 @@ import abc
 import ast
 import json
 import re
-import time
-import uuid
 
 from cortx.utils.log import Log
 from cortx.utils.conf_store import Conf
@@ -32,7 +30,10 @@ from ha.core.event_analyzer.event_analyzer_exceptions import EventParserExceptio
 from ha.core.system_health.const import CLUSTER_ELEMENTS, HEALTH_EVENTS, EVENT_SEVERITIES
 from ha.core.system_health.status_mapper import StatusMapper
 from ha.core.config.config_manager import ConfigManager
-from ha.const import PVTFQDN_TO_NODEID_KEY, ALERT_ATTRIBUTES, EVENT_ATTRIBUTES
+from ha.const import PVTFQDN_TO_NODEID_KEY, ALERT_ATTRIBUTES, EVENT_ATTRIBUTES as event_attr
+from ha.fault_tolerance.const import HEALTH_ATTRIBUTES, \
+    EVENT_ATTRIBUTES
+
 
 class Parser(metaclass=abc.ABCMeta):
     """
@@ -77,23 +78,23 @@ class AlertParser(Parser):
             alert = json.loads(msg).get(ALERT_ATTRIBUTES.MESSAGE)
 
             event = {
-                EVENT_ATTRIBUTES.EVENT_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.ALERT_ID],
-                EVENT_ATTRIBUTES.EVENT_TYPE : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.ALERT_TYPE],
-                EVENT_ATTRIBUTES.SEVERITY : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SEVERITY],
-                EVENT_ATTRIBUTES.SITE_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.SITE_ID],
-                EVENT_ATTRIBUTES.RACK_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.RACK_ID],
-                EVENT_ATTRIBUTES.CLUSTER_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.CLUSTER_ID],
-                EVENT_ATTRIBUTES.STORAGESET_ID : "TBD",
-                EVENT_ATTRIBUTES.NODE_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.NODE_ID],
-                EVENT_ATTRIBUTES.HOST_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.HOST_ID],
-                EVENT_ATTRIBUTES.RESOURCE_TYPE : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.RESOURCE_TYPE],
-                EVENT_ATTRIBUTES.TIMESTAMP : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.EVENT_TIME],
-                EVENT_ATTRIBUTES.RESOURCE_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.RESOURCE_ID],
-                EVENT_ATTRIBUTES.SPECIFIC_INFO : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SPECIFIC_INFO]
+                event_attr.EVENT_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.ALERT_ID],
+                event_attr.EVENT_TYPE : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.ALERT_TYPE],
+                event_attr.SEVERITY : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SEVERITY],
+                event_attr.SITE_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.SITE_ID],
+                event_attr.RACK_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.RACK_ID],
+                event_attr.CLUSTER_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.CLUSTER_ID],
+                event_attr.STORAGESET_ID : "TBD",
+                event_attr.NODE_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.NODE_ID],
+                event_attr.HOST_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.HOST_ID],
+                event_attr.RESOURCE_TYPE : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.RESOURCE_TYPE],
+                event_attr.TIMESTAMP : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.EVENT_TIME],
+                event_attr.RESOURCE_ID : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.RESOURCE_ID],
+                event_attr.SPECIFIC_INFO : alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SPECIFIC_INFO]
             }
             Log.debug(f"Parsed {event} schema")
             health_event = HealthEvent.dict_to_object(event)
-            Log.info(f"Event {event[EVENT_ATTRIBUTES.EVENT_ID]} is parsed and converted to object.")
+            Log.info(f"Event {event[event_attr.EVENT_ID]} is parsed and converted to object.")
             return health_event
 
         except Exception as e:
@@ -127,27 +128,27 @@ class IEMParser(Parser):
             _, node_id = key_val.popitem()
 
             event = {
-                EVENT_ATTRIBUTES.EVENT_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.ALERT_ID],
-                EVENT_ATTRIBUTES.EVENT_TYPE : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.ALERT_TYPE],
-                EVENT_ATTRIBUTES.SEVERITY : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SEVERITY],
-                EVENT_ATTRIBUTES.SITE_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.SITE_ID],
-                EVENT_ATTRIBUTES.RACK_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.RACK_ID],
-                EVENT_ATTRIBUTES.CLUSTER_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.CLUSTER_ID],
-                EVENT_ATTRIBUTES.STORAGESET_ID : "TBD",
-                EVENT_ATTRIBUTES.NODE_ID : node_id, # TODO: Temporary fix till IEM framework is available.
-                EVENT_ATTRIBUTES.HOST_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.HOST_ID],
-                EVENT_ATTRIBUTES.RESOURCE_TYPE : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SPECIFIC_INFO][ALERT_ATTRIBUTES.MODULE].lower(),
-                EVENT_ATTRIBUTES.TIMESTAMP : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.EVENT_TIME],
-                EVENT_ATTRIBUTES.RESOURCE_ID : node_id,
-                EVENT_ATTRIBUTES.SPECIFIC_INFO : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SPECIFIC_INFO]
+                event_attr.EVENT_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.ALERT_ID],
+                event_attr.EVENT_TYPE : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.ALERT_TYPE],
+                event_attr.SEVERITY : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SEVERITY],
+                event_attr.SITE_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.SITE_ID],
+                event_attr.RACK_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.RACK_ID],
+                event_attr.CLUSTER_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.CLUSTER_ID],
+                event_attr.STORAGESET_ID : "TBD",
+                event_attr.NODE_ID : node_id, # TODO: Temporary fix till IEM framework is available.
+                event_attr.HOST_ID : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.HOST_ID],
+                event_attr.RESOURCE_TYPE : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SPECIFIC_INFO][ALERT_ATTRIBUTES.MODULE].lower(),
+                event_attr.TIMESTAMP : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.INFO][ALERT_ATTRIBUTES.EVENT_TIME],
+                event_attr.RESOURCE_ID : node_id,
+                event_attr.SPECIFIC_INFO : iem_alert[ALERT_ATTRIBUTES.SENSOR_RESPONSE_TYPE][ALERT_ATTRIBUTES.SPECIFIC_INFO]
             }
             # To be removed after HA starts populating IEM messages
-            if event.get(EVENT_ATTRIBUTES.RESOURCE_TYPE) == CLUSTER_ELEMENTS.NODE.value and event.get(EVENT_ATTRIBUTES.SEVERITY) == EVENT_SEVERITIES.WARNING.value:
-                event[EVENT_ATTRIBUTES.EVENT_TYPE] = HEALTH_EVENTS.FAILED.value
+            if event.get(event_attr.RESOURCE_TYPE) == CLUSTER_ELEMENTS.NODE.value and event.get(event_attr.SEVERITY) == EVENT_SEVERITIES.WARNING.value:
+                event[event_attr.EVENT_TYPE] = HEALTH_EVENTS.FAILED.value
 
             Log.debug(f"Parsed {event} schema")
             health_event = HealthEvent.dict_to_object(event)
-            Log.info(f"Event {event[EVENT_ATTRIBUTES.EVENT_ID]} is parsed and converted to object.")
+            Log.info(f"Event {event[event_attr.EVENT_ID]} is parsed and converted to object.")
             return health_event
 
         except Exception as e:
@@ -178,38 +179,38 @@ class ClusterResourceParser(Parser):
         try:
             message = json.dumps(ast.literal_eval(msg))
             cluster_resource_alert = json.loads(message)
-            timestamp = cluster_resource_alert["event"]["header"]["timestamp"]
-            event_id = cluster_resource_alert["event"]["header"]["event_id"]
-            source = cluster_resource_alert["event"]["payload"]["source"]
-            node_id = cluster_resource_alert["event"]["payload"]["node_id"]
-            resource_type = cluster_resource_alert["event"]["payload"]["resource_type"]
-            resource_id = cluster_resource_alert["event"]["payload"]["resource_id"]
-            event_type = cluster_resource_alert["event"]["payload"]["resource_status"]
-            specific_info = cluster_resource_alert["event"]["payload"]["specific_info"]
+            timestamp = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_HEADER.value][HEALTH_ATTRIBUTES.TIMESTAMP.value]
+            event_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_HEADER.value][HEALTH_ATTRIBUTES.EVENT_ID.value]
+            source = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SOURCE.value]
+            node_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.NODE_ID.value]
+            resource_type = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_TYPE.value]
+            resource_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_ID.value]
+            event_type = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_STATUS.value]
+            specific_info = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]
             if specific_info and specific_info["generation_id"] and source == "monitor":
-                generation_id = cluster_resource_alert["event"]["payload"]["specific_info"]["generation_id"]
+                generation_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]["generation_id"]
                 specific_info = {"generation_id": generation_id, "pod_restart": 0}
 
             event = {
-                EVENT_ATTRIBUTES.SOURCE : source,
-                EVENT_ATTRIBUTES.EVENT_ID : event_id,
-                EVENT_ATTRIBUTES.EVENT_TYPE : event_type,
-                EVENT_ATTRIBUTES.SEVERITY : StatusMapper.EVENT_TO_SEVERITY_MAPPING[event_type],
-                EVENT_ATTRIBUTES.SITE_ID : self.site_id, # TODO: Should be fetched from confstore
-                EVENT_ATTRIBUTES.RACK_ID : self.rack_id, # TODO: Should be fetched from confstore
-                EVENT_ATTRIBUTES.CLUSTER_ID : self.cluster_id, # TODO: Should be fetched from confstore
-                EVENT_ATTRIBUTES.STORAGESET_ID : node_id,
-                EVENT_ATTRIBUTES.NODE_ID : node_id,
-                EVENT_ATTRIBUTES.HOST_ID : node_id,
-                EVENT_ATTRIBUTES.RESOURCE_TYPE : resource_type,
-                EVENT_ATTRIBUTES.TIMESTAMP : timestamp,
-                EVENT_ATTRIBUTES.RESOURCE_ID : resource_id,
-                EVENT_ATTRIBUTES.SPECIFIC_INFO : specific_info
+                event_attr.SOURCE : source,
+                event_attr.EVENT_ID : event_id,
+                event_attr.EVENT_TYPE : event_type,
+                event_attr.SEVERITY : StatusMapper.EVENT_TO_SEVERITY_MAPPING[event_type],
+                event_attr.SITE_ID : self.site_id, # TODO: Should be fetched from confstore
+                event_attr.RACK_ID : self.rack_id, # TODO: Should be fetched from confstore
+                event_attr.CLUSTER_ID : self.cluster_id, # TODO: Should be fetched from confstore
+                event_attr.STORAGESET_ID : node_id,
+                event_attr.NODE_ID : node_id,
+                event_attr.HOST_ID : node_id,
+                event_attr.RESOURCE_TYPE : resource_type,
+                event_attr.TIMESTAMP : timestamp,
+                event_attr.RESOURCE_ID : resource_id,
+                event_attr.SPECIFIC_INFO : specific_info
             }
 
             Log.debug(f"Parsed {event} schema")
             health_event = HealthEvent.dict_to_object(event)
-            Log.debug(f"Event {event[EVENT_ATTRIBUTES.EVENT_ID]} is parsed and converted to object.")
+            Log.debug(f"Event {event[event_attr.EVENT_ID]} is parsed and converted to object.")
             return health_event
 
         except Exception as err:

--- a/ha/core/event_analyzer/parser/parser.py
+++ b/ha/core/event_analyzer/parser/parser.py
@@ -31,7 +31,7 @@ from ha.core.system_health.const import CLUSTER_ELEMENTS, HEALTH_EVENTS, EVENT_S
 from ha.core.system_health.status_mapper import StatusMapper
 from ha.core.config.config_manager import ConfigManager
 from ha.const import PVTFQDN_TO_NODEID_KEY, ALERT_ATTRIBUTES, EVENT_ATTRIBUTES as event_attr
-from ha.fault_tolerance.const import HEALTH_ATTRIBUTES, \
+from ha.fault_tolerance.const import HEALTH_ATTRIBUTES, HEALTH_EVENT_SOURCES, \
     EVENT_ATTRIBUTES
 
 
@@ -187,7 +187,7 @@ class ClusterResourceParser(Parser):
             resource_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_ID.value]
             event_type = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_STATUS.value]
             specific_info = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]
-            if specific_info and specific_info["generation_id"] and source == "monitor":
+            if specific_info and specific_info["generation_id"] and source == HEALTH_EVENT_SOURCES.MONITOR.value:
                 generation_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]["generation_id"]
                 specific_info = {"generation_id": generation_id, "pod_restart": 0}
 

--- a/ha/core/system_health/health_evaluators/element_health_evaluator.py
+++ b/ha/core/system_health/health_evaluators/element_health_evaluator.py
@@ -127,7 +127,8 @@ class ElementHealthEvaluator(metaclass=abc.ABCMeta):
         Update health event
         """
         new_event =  HealthEvent(
-            event_id=str(int(time.time())) + str(uuid.uuid4().hex),
+            source=subelement_event.source,
+            event_id=subelement_event.event_id,
             event_type=event_type,
             severity=subelement_event.severity,
             site_id=subelement_event.site_id,

--- a/ha/core/system_health/model/health_event.py
+++ b/ha/core/system_health/model/health_event.py
@@ -25,11 +25,12 @@ class HealthEvent:
 
     VERSION = const.DATASTORE_VERSION
 
-    def __init__(self, event_id: str, event_type: str, severity: str, site_id: int, rack_id: int, cluster_id: str, storageset_id: int,
+    def __init__(self, source: str, event_id: str, event_type: str, severity: str, site_id: int, rack_id: int, cluster_id: str, storageset_id: int,
                  node_id: int, host_id: str, resource_type: str, timestamp: str, resource_id: str, specific_info: dict=None):
         """
         Init method.
         """
+        self.source = source
         self.event_id = event_id
         self.event_type = event_type
         self.severity = severity
@@ -47,6 +48,7 @@ class HealthEvent:
     @staticmethod
     def dict_to_object(event):
         return HealthEvent(
+            source = event["source"],
             event_id = event["event_id"],
             event_type = event["event_type"],
             severity = event["severity"],
@@ -64,6 +66,7 @@ class HealthEvent:
 
     def __str__(self):
         return json.dumps({
+            "source": self.source,
             "event_id": self.event_id,
             "event_type": self.event_type,
             "severity": self.severity,

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -453,7 +453,7 @@ class SystemHealth(Subscriber):
             Log.error(f"Failed processing system health event with Error: {err}")
             raise HaSystemHealthException("Failed processing system health event")
 
-    def get_health_event_template(self, nodeid: str, event_type: str, source: str = None) -> dict:
+    def get_health_event_template(self, nodeid: str, event_type: str, source: str) -> dict:
         """
         Create health event
         Args:

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -453,10 +453,11 @@ class SystemHealth(Subscriber):
             Log.error(f"Failed processing system health event with Error: {err}")
             raise HaSystemHealthException("Failed processing system health event")
 
-    def get_health_event_template(self, nodeid: str, event_type: str) -> dict:
+    def get_health_event_template(self, nodeid: str, event_type: str, source: str = None) -> dict:
         """
         Create health event
         Args:
+            source: Source (Ex: monitor, hare) who wants this event template
             nodeid (str): nodeid
             event_type (str): event type will be offline, online, failed
 
@@ -472,6 +473,7 @@ class SystemHealth(Subscriber):
         timestamp = str(int(time.time()))
         event_id = timestamp + str(uuid.uuid4().hex)
         initial_event = {
+            const.EVENT_ATTRIBUTES.SOURCE: source,
             const.EVENT_ATTRIBUTES.EVENT_ID : event_id,
             const.EVENT_ATTRIBUTES.EVENT_TYPE : event_type,
             const.EVENT_ATTRIBUTES.SEVERITY : EVENT_SEVERITIES.WARNING.value,

--- a/ha/fault_tolerance/fault_monitor.py
+++ b/ha/fault_tolerance/fault_monitor.py
@@ -68,7 +68,7 @@ class FaultMonitor:
         if self._consumer is not None:
             self._consumer.join()
 
-class NodeFaultMonitor(FaultMonitor):
+class HealthStatusMonitor(FaultMonitor):
     """
     Module responsible for:
     -  consuming node messages from k8s monitor that come on message bus

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -23,7 +23,7 @@ import signal
 
 from cortx.utils.log import Log
 from ha.core.config.config_manager import ConfigManager
-from ha.fault_tolerance.fault_monitor import NodeFaultMonitor
+from ha.fault_tolerance.fault_monitor import HealthStatusMonitor
 from ha.fault_tolerance.cluster_stop_monitor import ClusterStopMonitor
 
 class FaultTolerance:
@@ -38,7 +38,7 @@ class FaultTolerance:
         """
         signal.signal(signal.SIGTERM, self.set_sigterm)
         ConfigManager.init("fault_tolerance")
-        self.node_fault_monitor = NodeFaultMonitor()
+        self.node_fault_monitor = HealthStatusMonitor()
         self.cluster_stop_monitor = ClusterStopMonitor()
 
     def set_sigterm(self, signum, frame):

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -36,6 +36,8 @@ from ha.k8s_setup.const import _DELIM
 from ha.core.event_manager.event_manager import EventManager
 from ha.core.event_manager.subscribe_event import SubscribeEvent
 from ha.util.conf_store import ConftStoreSearch
+from ha.fault_tolerance.const import FAULT_TOLERANCE_KEYS
+
 
 class Cmd:
     """
@@ -209,14 +211,16 @@ class ConfigCmd(Cmd):
                 sys.stderr.write(f'Failed to get kafka config. kafka_config: {kafka_endpoint}. \n')
                 sys.exit(1)
 
+            health_comm_msg_type = FAULT_TOLERANCE_KEYS.MONITOR_HA_MESSAGE_TYPE.value
+
             conf_file_dict = {'LOG' : {'path' : ha_log_path, 'level' : const.HA_LOG_LEVEL},
                          'consul_config' : {'endpoint' : consul_endpoint},
                          'kafka_config' : {'endpoints': kafka_endpoint},
                          'event_topic' : 'hare',
-                         'MONITOR' : {'message_type' : 'cluster_event', 'producer_id' : 'cluster_monitor'},
+                         'MONITOR' : {'message_type' : health_comm_msg_type, 'producer_id' : 'cluster_monitor'},
                          'EVENT_MANAGER' : {'message_type' : 'health_events', 'producer_id' : 'system_health',
                                             'consumer_group' : 'health_monitor', 'consumer_id' : '1'},
-                         'FAULT_TOLERANCE' : {'message_type' : 'cluster_event', 'consumer_group' : 'event_listener',
+                         'FAULT_TOLERANCE' : {'message_type' : health_comm_msg_type, 'consumer_group' : 'event_listener',
                                               'consumer_id' : '1'},
                          'CLUSTER_STOP_MON' : {'message_type' : 'cluster_stop', 'consumer_group' : 'cluster_mon',
                                               'consumer_id' : '2'},

--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -25,6 +25,9 @@ from ha.monitor.k8s.const import EventStates, K8SClientConst
 from ha.monitor.k8s.const import K8SEventsConst
 from cortx.utils.log import Log
 from ha import const
+from ha.fault_tolerance.event import Event
+from ha.fault_tolerance.const import HEALTH_ATTRIBUTES, \
+    EVENT_ATTRIBUTES
 
 
 class ObjectMonitor(threading.Thread):
@@ -154,7 +157,10 @@ class ObjectMonitor(threading.Thread):
                     continue
                 if self._starting_up:
                     if an_event[K8SEventsConst.TYPE] == EventStates.ADDED:
-                        alert = event.update_event(key_to_update={"is_status": True})
+                        spec_info = alert['event'][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]
+                        spec_info['is_status'] = True
+                        event.set_payload(spec_info)
+                        alert = event.ret_dict()
                     else:
                         self._starting_up = False
 

--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -25,7 +25,6 @@ from ha.monitor.k8s.const import EventStates, K8SClientConst
 from ha.monitor.k8s.const import K8SEventsConst
 from cortx.utils.log import Log
 from ha import const
-from ha.fault_tolerance.event import Event
 from ha.fault_tolerance.const import HEALTH_ATTRIBUTES, \
     EVENT_ATTRIBUTES
 

--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -25,7 +25,6 @@ from ha.monitor.k8s.const import EventStates, K8SClientConst
 from ha.monitor.k8s.const import K8SEventsConst
 from cortx.utils.log import Log
 from ha import const
-from ha.util.health_event_schema import Event
 
 
 class ObjectMonitor(threading.Thread):
@@ -62,7 +61,7 @@ class ObjectMonitor(threading.Thread):
     def check_for_signals(self, k8s_watch: watch.Watch, k8s_watch_stream):
         """
         Check if any pending signal while watching on kubernetes.watch.stream synchronusly.
-        Note: curretnly handling only SIGl
+        Note: curretnly handling only SIGTERM signal
         but if required we can make use of this function for convey some message/events/signals
         to handle while loopping  over synchronus watch.stream call
         """
@@ -111,7 +110,6 @@ class ObjectMonitor(threading.Thread):
         if self.is_publish_enable():
             # Write to message bus
             Log.info(f"{self._object}_monitor sending alert on message bus {alert}")
-            print(f"{self._object}_monitor sending alert on message bus {alert}")
             self._producer.publish(str(alert))
         else:
             Log.info(f"{self._object}_monitor received cluster stop message so skipping publish alert: {str(alert)}.")

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -22,7 +22,6 @@ from ha.monitor.k8s.error import NotSupportedObjectError
 from ha.monitor.k8s.const import K8SEventsConst
 from ha.monitor.k8s.const import AlertStates
 from ha.monitor.k8s.const import EventStates
-from ha.monitor.k8s.alert import K8sAlert
 
 from cortx.utils.log import Log
 from ha.util.health_event_schema import Event
@@ -74,7 +73,7 @@ class NodeEventParser(ObjectParser):
             Log.debug(f"Exception received during parsing {e}")
 
         if ready_status is None:
-            Log.debug(f"ready_status is None for node resource {alert}")
+            Log.debug(f"ready_status is None for node resource {resource_name}")
             cached_state[resource_name] = ready_status
             return None
 
@@ -165,7 +164,7 @@ class PodEventParser(ObjectParser):
         if an_event[K8SEventsConst.TYPE] == EventStates.ADDED:
             cached_state[resource_name] = ready_status.lower()
             if ready_status.lower() != K8SEventsConst.true:
-                Log.debug(f"[EventStates ADDED] No change detected for pod resource {alert.resource_name}")
+                Log.debug(f"[EventStates ADDED] No change detected for pod resource {resource_name}")
                 return None
             else:
                 event_type = AlertStates.ONLINE

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -25,10 +25,15 @@ from ha.monitor.k8s.const import EventStates
 from ha.monitor.k8s.alert import K8sAlert
 
 from cortx.utils.log import Log
+from ha.util.health_event_schema import Event
+
 
 class ObjectParser:
     def __init__(self):
-        pass
+        self.payload = {"source": "monitor", "cluster_id": None, "site_id": None, \
+                   "rack_id": None, "storageset_id": None, "node_id": None, \
+                   "resource_type": None, "resource_id": None, "resource_status": None, \
+                   "specific_info": {}}
 
     def parse(self, an_event, cached_state):
         pass
@@ -39,16 +44,26 @@ class NodeEventParser(ObjectParser):
         super().__init__()
         self._type = 'host'
 
+    def _create_health_alert(self, res_type, res_name, health_status):
+        """
+        Instantiates Event class which creates Health event object with necessary
+        attributes to pass it for further processing
+        """
+        self.event = Event()
+        self.payload["resource_type"] = res_type
+        self.payload["resource_id"] = self.payload["node_id"] = res_name
+        self.payload["resource_status"] = health_status
+        self.event.set_payload(self.payload)
+        return self.event.ret_dict()
+
     def parse(self, an_event, cached_state):
-        alert = K8sAlert()
-        alert.resource_type = self._type
-        alert.timestamp = str(int(time.time()))
+        resource_type = self._type
         raw_object = an_event[K8SEventsConst.RAW_OBJECT]
 
         if K8SEventsConst.TYPE in an_event:
-            alert.event_type = an_event[K8SEventsConst.TYPE]
+            event_type = an_event[K8SEventsConst.TYPE]
         if K8SEventsConst.NAME in raw_object[K8SEventsConst.METADATA]:
-            alert.resource_name = raw_object[K8SEventsConst.METADATA][K8SEventsConst.NAME]
+            resource_name = raw_object[K8SEventsConst.METADATA][K8SEventsConst.NAME]
 
         ready_status = None
         try:
@@ -59,34 +74,37 @@ class NodeEventParser(ObjectParser):
             Log.debug(f"Exception received during parsing {e}")
 
         if ready_status is None:
-            Log.debug(f"ready_status is None for node resource {alert.resource_name}")
-            cached_state[alert.resource_name] = ready_status
+            Log.debug(f"ready_status is None for node resource {alert}")
+            cached_state[resource_name] = ready_status
             return None
 
-        if alert.event_type == EventStates.ADDED:
-            cached_state[alert.resource_name] = ready_status.lower()
+        if event_type == EventStates.ADDED:
+            cached_state[resource_name] = ready_status.lower()
             if ready_status.lower() == K8SEventsConst.true:
-                alert.event_type = AlertStates.ONLINE
-                return alert
+                event_type = AlertStates.ONLINE
+                health_alert = self._create_health_alert(resource_type, resource_name, event_type)
+                return health_alert, self.event
             else:
-                Log.debug(f"[EventStates ADDED] No change detected for node resource {alert.resource_name}")
+                Log.debug(f"[EventStates ADDED] No change detected for node resource {resource_name}")
                 return None
 
-        if alert.event_type == EventStates.MODIFIED:
-            if alert.resource_name in cached_state:
-                if cached_state[alert.resource_name] != K8SEventsConst.true and ready_status.lower() == K8SEventsConst.true:
-                    cached_state[alert.resource_name] = ready_status.lower()
-                    alert.event_type = AlertStates.ONLINE
-                    return alert
-                elif cached_state[alert.resource_name] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
-                    cached_state[alert.resource_name] = ready_status.lower()
-                    alert.event_type = AlertStates.FAILED
-                    return alert
+        if event_type == EventStates.MODIFIED:
+            if resource_name in cached_state:
+                if cached_state[resource_name] != K8SEventsConst.true and ready_status.lower() == K8SEventsConst.true:
+                    cached_state[resource_name] = ready_status.lower()
+                    event_type = AlertStates.ONLINE
+                    health_alert = self._create_health_alert(resource_type, resource_name, event_type)
+                    return health_alert, self.event
+                elif cached_state[resource_name] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
+                    cached_state[resource_name] = ready_status.lower()
+                    event_type = AlertStates.FAILED
+                    health_alert = self._create_health_alert(resource_type, resource_name, event_type)
+                    return health_alert, self.event
                 else:
-                    Log.debug(f"[EventStates MODIFIED] No change detected for node resource {alert.resource_name}")
+                    Log.debug(f"[EventStates MODIFIED] No change detected for node resource {resource_name}")
                     return None
             else:
-                Log.debug(f"[EventStates MODIFIED] No cached state detected for node resource {alert.resource_name}")
+                Log.debug(f"[EventStates MODIFIED] No cached state detected for node resource {resource_name}")
                 return None
 
         # Handle DELETED event - Not required for Cortx
@@ -103,21 +121,32 @@ class PodEventParser(ObjectParser):
         #       hence while sending alert to cortx, below type is set to 'node'.
         self._type = 'node'
 
+    def _create_health_alert(self, res_type, res_name, health_status, generation_id):
+        """
+        Instantiates Event class which creates Health event object with necessary
+        attributes to pass it for further processing
+        """
+        self.event = Event()
+        self.payload["resource_type"] = res_type
+        self.payload["resource_id"] = self.payload["node_id"] = res_name
+        self.payload["resource_status"] = health_status
+        self.payload["specific_info"]["generation_id"] = generation_id
+        self.event.set_payload(self.payload)
+        return self.event.ret_dict()
+
     def parse(self, an_event, cached_state):
-        alert = K8sAlert()
-        alert.resource_type = self._type
-        alert.timestamp = str(int(time.time()))
+        resource_type = self._type
         raw_object = an_event[K8SEventsConst.RAW_OBJECT]
 
         labels = raw_object[K8SEventsConst.METADATA][K8SEventsConst.LABELS]
         if K8SEventsConst.MACHINEID in labels:
-            alert.resource_name = labels[K8SEventsConst.MACHINEID]
+            resource_name = labels[K8SEventsConst.MACHINEID]
         if K8SEventsConst.TYPE in an_event:
-            alert.event_type = an_event[K8SEventsConst.TYPE]
+            event_type = an_event[K8SEventsConst.TYPE]
         if K8SEventsConst.NODE_NAME in raw_object[K8SEventsConst.SPEC]:
-            alert.node = raw_object[K8SEventsConst.SPEC][K8SEventsConst.NODE_NAME]
+            node = raw_object[K8SEventsConst.SPEC][K8SEventsConst.NODE_NAME]
         if K8SEventsConst.NAME in raw_object[K8SEventsConst.METADATA]:
-            alert.generation_id = raw_object[K8SEventsConst.METADATA][K8SEventsConst.NAME]
+            generation_id = raw_object[K8SEventsConst.METADATA][K8SEventsConst.NAME]
 
         ready_status = None
         try:
@@ -129,28 +158,31 @@ class PodEventParser(ObjectParser):
 
         if ready_status is None:
             Log.debug(f"ready_status is None for pod resource {alert.resource_name}")
-            cached_state[alert.resource_name] = ready_status
+            cached_state[resource_name] = ready_status
             return None
 
         if an_event[K8SEventsConst.TYPE] == EventStates.ADDED:
-            cached_state[alert.resource_name] = ready_status.lower()
+            cached_state[resource_name] = ready_status.lower()
             if ready_status.lower() != K8SEventsConst.true:
                 Log.debug(f"[EventStates ADDED] No change detected for pod resource {alert.resource_name}")
                 return None
             else:
-                alert.event_type = AlertStates.ONLINE
-                return alert
+                event_type = AlertStates.ONLINE
+                health_alert = self._create_health_alert(resource_type, resource_name, event_type, generation_id)
+                return health_alert, self.event
 
-        if alert.event_type == EventStates.MODIFIED:
-            if alert.resource_name in cached_state:
-                if cached_state[alert.resource_name] != K8SEventsConst.true and ready_status.lower() == K8SEventsConst.true:
-                    cached_state[alert.resource_name] = ready_status.lower()
-                    alert.event_type = AlertStates.ONLINE
-                    return alert
-                elif cached_state[alert.resource_name] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
-                    cached_state[alert.resource_name] = ready_status.lower()
-                    alert.event_type = AlertStates.FAILED
-                    return alert
+        if event_type == EventStates.MODIFIED:
+            if resource_name in cached_state:
+                if cached_state[resource_name] != K8SEventsConst.true and ready_status.lower() == K8SEventsConst.true:
+                    cached_state[resource_name] = ready_status.lower()
+                    event_type = AlertStates.ONLINE
+                    health_alert = self._create_health_alert(resource_type, resource_name, event_type, generation_id)
+                    return health_alert, self.event
+                elif cached_state[resource_name] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
+                    cached_state[resource_name] = ready_status.lower()
+                    event_type = AlertStates.FAILED
+                    health_alert = self._create_health_alert(resource_type, resource_name, event_type, generation_id)
+                    return health_alert, self.event
                 else:
                     Log.debug(f"[EventStates MODIFIED] No change detected for pod resource {alert.resource_name}")
                     return None

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -47,7 +47,7 @@ class NodeEventParser(ObjectParser):
     def _create_health_alert(self, res_type, res_name, health_status):
         """
         Instantiates Event class which creates Health event object with necessary
-        attributes to pass it for further processing
+        attributes to pass it for further processing.
         """
         self.event = Event()
         self.payload["resource_type"] = res_type
@@ -124,7 +124,7 @@ class PodEventParser(ObjectParser):
     def _create_health_alert(self, res_type, res_name, health_status, generation_id):
         """
         Instantiates Event class which creates Health event object with necessary
-        attributes to pass it for further processing
+        attributes to pass it for further processing.
         """
         self.event = Event()
         self.payload["resource_type"] = res_type
@@ -143,8 +143,9 @@ class PodEventParser(ObjectParser):
             resource_name = labels[K8SEventsConst.MACHINEID]
         if K8SEventsConst.TYPE in an_event:
             event_type = an_event[K8SEventsConst.TYPE]
-        if K8SEventsConst.NODE_NAME in raw_object[K8SEventsConst.SPEC]:
-            node = raw_object[K8SEventsConst.SPEC][K8SEventsConst.NODE_NAME]
+        # Actual physical host information is not needed now.
+        # If required, can be available in K8SEventsConst.SPEC.
+        # So, removing it from now.
         if K8SEventsConst.NAME in raw_object[K8SEventsConst.METADATA]:
             generation_id = raw_object[K8SEventsConst.METADATA][K8SEventsConst.NAME]
 
@@ -157,7 +158,7 @@ class PodEventParser(ObjectParser):
             Log.debug(f"Exception received during parsing {e}")
 
         if ready_status is None:
-            Log.debug(f"ready_status is None for pod resource {alert.resource_name}")
+            Log.debug(f"ready_status is None for pod resource {resource_name}")
             cached_state[resource_name] = ready_status
             return None
 

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -25,8 +25,7 @@ from ha.monitor.k8s.const import EventStates
 
 from cortx.utils.log import Log
 from ha.fault_tolerance.event import Event
-from ha.fault_tolerance.const import HEALTH_ATTRIBUTES, \
-    EVENT_ATTRIBUTES, HEALTH_EVENT_SOURCES
+from ha.fault_tolerance.const import HEALTH_ATTRIBUTES, HEALTH_EVENT_SOURCES
 
 
 class ObjectParser:


### PR DESCRIPTION
…r new message schema

- Modify k8s_monitor service which will populate the alert with ew defined schema
- Change class name from NodeFaultMonitor to HealthStatusMonitor in
  fault tolerance service
- EventAnalyzer changes for filter and parser for scanning with new alert schema
- Some system health changes for change in the health event structure

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

# Problem Statement
HA services should adapt to new health event schema as defined in https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/891781277/Action+Status+Update+LLD. 
   https://jts.seagate.com/browse/CORTX-27830)
# Design
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/891781277/Action+Status+Update+LLD)

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]:  Y
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N] N/A
- [x] Side effects on other features (deployment/upgrade)? [Y/N] N
- [x] Dependencies on other component(s)? [Y/N] Y
-     If yes for above point, post link to the corresponding PR.
https://github.com/Seagate/cortx-utils/pull/735/files

# Review Checklist 
- [x] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide

Log file details

1. Event from k8s monitor:
pod_monitor sending alert on message bus {'event': {'header': {'version': '1.0', 'timestamp': '1645094183', 'event_id': '1645094183c4ed4d58a3584936a998ab5f0a115d42'}, 'payload': {'source': 'monitor', 'cluster_id': None, 'site_id': None, 'rack_id': None, 'storageset_id': None, 'node_id': '869e1a0029a04c7a8764893dfac6a06b', 'resource_type': 'node', 'resource_id': '869e1a0029a04c7a8764893dfac6a06b', 'resource_status': 'online', 'specific_info': {'generation_id': 'cortx-data-ssc-vm-g4-rhev4-0760-7fbd89567b-bmtgn', 'is_status': True}}}}
pod_monitor sending alert on message bus {'event': {'header': {'version': '1.0', 'timestamp': '1645094183', 'event_id': '1645094183dbfac4e47bfc46bab3c0df99bfd7f4d8'}, 'payload': {'source': 'monitor', 'cluster_id': None, 'site_id': None, 'rack_id': None, 'storageset_id': None, 'node_id': 'f7b4878d84f64ab28785c5c5c1127ae4', 'resource_type': 'node', 'resource_id': 'f7b4878d84f64ab28785c5c5c1127ae4', 'resource_status': 'online', 'specific_info': {'generation_id': 'cortx-data-ssc-vm-g4-rhev4-0759-79b9874d8-nv97n', 'is_status': True}}}}
pod_monitor sending alert on message bus {'event': {'header': {'version': '1.0', 'timestamp': '1645094183', 'event_id': '1645094183038b265a901f49eaa26c3af657a1735c'}, 'payload': {'source': 'monitor', 'cluster_id': None, 'site_id': None, 'rack_id': None, 'storageset_id': None, 'node_id': 'd6ac367e8b0742559deafece2c5c5338', 'resource_type': 'node', 'resource_id': 'd6ac367e8b0742559deafece2c5c5338', 'resource_status': 'online', 'specific_info': {'generation_id': 'cortx-server-ssc-vm-g4-rhev4-0758-bbfc95864-zfz8s', 'is_status': True}}}}

System health keys:
sh-4.2# consul kv get -http-addr=consul-server.default.svc.cluster.local:8500 --recurse cortx/ha/v1
cortx/ha/v1:
cortx/ha/v1/action/node/failed:["publish"]
cortx/ha/v1/action/node/online:["publish"]
cortx/ha/v1/cluster_cardinality:{"num_nodes": 6, "node_list": ["d6ac367e8b0742559deafece2c5c5338", "ef09d68a19a64292b3b0a28d7e5f5be4", "f7b4878d84f64ab28785c5c5c1127ae4", "869e1a0029a04c7a8764893dfac6a06b", "7a43f0a461e74bba96481e5f82fad217", "2757bb52dfce434f9d7fc4b434160210"]}
cortx/ha/v1/cortx/ha/system/cluster/26c6dcbb2b6b4fcfafc2c9346585b756/health:{"events": [{"event_timestamp": "1645094173", "created_timestamp": "1645094174", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1645094174", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/26c6dcbb2b6b4fcfafc2c9346585b756/site/1/health:{"events": [{"event_timestamp": "1645094173", "created_timestamp": "1645094174", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1645094174", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/26c6dcbb2b6b4fcfafc2c9346585b756/site/1/rack/1/health:{"events": [{"event_timestamp": "1645094173", "created_timestamp": "1645094174", "status": "online", "specific_info": null}], "action": {"modified_timestamp": "1645094174", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/26c6dcbb2b6b4fcfafc2c9346585b756/site/1/rack/1/node/2757bb52dfce434f9d7fc4b434160210/health:{"events": [{"event_timestamp": "1645094173", "created_timestamp": "1645094174", "status": "online", "specific_info": {"generation_id": "cortx-data-ssc-vm-g4-rhev4-0758-54fdfd67df-hrxjp", "pod_restart": 0}}], "action": {"modified_timestamp": "1645094174", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/26c6dcbb2b6b4fcfafc2c9346585b756/site/1/rack/1/node/7a43f0a461e74bba96481e5f82fad217/health:{"events": [{"event_timestamp": "1645094174", "created_timestamp": "1645094175", "status": "online", "specific_info": {"generation_id": "cortx-server-ssc-vm-g4-rhev4-0760-7f5c5fdb4b-h9b8j", "pod_restart": 0}}], "action": {"modified_timestamp": "1645094175", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/26c6dcbb2b6b4fcfafc2c9346585b756/site/1/rack/1/node/869e1a0029a04c7a8764893dfac6a06b/health:{"events": [{"event_timestamp": "1645094174", "created_timestamp": "1645094174", "status": "online", "specific_info": {"generation_id": "cortx-data-ssc-vm-g4-rhev4-0760-7fbd89567b-bmtgn", "pod_restart": 0}}], "action": {"modified_timestamp": "1645094174", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/26c6dcbb2b6b4fcfafc2c9346585b756/site/1/rack/1/node/d6ac367e8b0742559deafece2c5c5338/health:{"events": [{"event_timestamp": "1645094174", "created_timestamp": "1645094175", "status": "online", "specific_info": {"generation_id": "cortx-server-ssc-vm-g4-rhev4-0758-bbfc95864-zfz8s", "pod_restart": 0}}], "action": {"modified_timestamp": "1645094175", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/26c6dcbb2b6b4fcfafc2c9346585b756/site/1/rack/1/node/ef09d68a19a64292b3b0a28d7e5f5be4/health:{"events": [{"event_timestamp": "1645094174", "created_timestamp": "1645094175", "status": "online", "specific_info": {"generation_id": "cortx-server-ssc-vm-g4-rhev4-0759-6f9b45fc8-8txm7", "pod_restart": 0}}], "action": {"modified_timestamp": "1645094175", "status": "pending"}, "attributes": {}}
cortx/ha/v1/cortx/ha/system/cluster/26c6dcbb2b6b4fcfafc2c9346585b756/site/1/rack/1/node/f7b4878d84f64ab28785c5c5c1127ae4/health:{"events": [{"event_timestamp": "1645094174", "created_timestamp": "1645094174", "status": "online", "specific_info": {"generation_id": "cortx-data-ssc-vm-g4-rhev4-0759-79b9874d8-nv97n", "pod_restart": 0}}], "action": {"modified_timestamp": "1645094174", "status": "pending"}, "attributes": {}}
cortx/ha/v1/events/node/failed:["hare"]
cortx/ha/v1/events/node/online:["hare"]
cortx/ha/v1/events/subscribe/hare:["node/online", "node/failed"]
cortx/ha/v1/message_type/hare:ha_event_hare

Added a change for using new message type which got missed earlier. After that change, 

ha_setup.py

> [root@ssc-vm-g3-rhev4-1313 cortx-ha-1]# cat /etc/cortx/ha/ha.conf
CLUSTER_STOP_MON:
  consumer_group: cluster_mon
  consumer_id: '2'
  message_type: cluster_stop
COMMON_CONFIG:
  cluster_id: 26c6dcbb2b6b4fcfafc2c9346585b756
  rack_id: '1'
  site_id: '1'
EVENT_MANAGER:
  consumer_group: health_monitor
  consumer_id: '1'
  message_type: health_events
  producer_id: system_health
FAULT_TOLERANCE:
  consumer_group: event_listener
  consumer_id: '1'
  message_type: cortx_health_events
LOG:
  level: INFO
  path: /etc/cortx/log/ha/27d9b5122785444444444444444
MONITOR:
  message_type: cortx_health_events
  producer_id: cluster_monitor
NODE:
  resource_type: node
SYSTEM_HEALTH:
  num_entity_health_events: 2
consul_config:
  endpoint: http://consul-server.default.svc.cluster.local:8500
event_topic: hare
kafka_config:
  endpoints:
  - tcp://srvnode-1:9092

