### PR TITLE
CORTX-28560 & CORTX-29057 : Fix duplicate events published from k8s_monitor & Event parser issue

### DIFF
--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -182,16 +182,15 @@ class ObjectMonitor(threading.Thread):
         """
         Check incoming alert is already published or not.
         If incoming alert is not found in published alerts, then
-        it is a new alert to publish. Alert will be stored like,
-        self._published_alerts = {
-            resource_name: { generation_id : alert }
-            }
-
+        it is a new alert to publish.
+        Alert will be stored and mapped to its unique key,
+            self._published_alerts = { alert_key : alert }
         Returns:
             True if it is published already
             False if it is a new alert
         """
         incoming_alert = alert.to_dict().copy()
+        incoming_resource_type = incoming_alert.get('_resource_type')
         incoming_resource_name = incoming_alert.get('_resource_name')
         incoming_generation_id = incoming_alert.get('_generation_id')
 
@@ -204,21 +203,23 @@ class ObjectMonitor(threading.Thread):
         if "_is_status" in incoming_alert.keys():
             del incoming_alert['_is_status']
 
-        incoming_alert_msg = json.dumps(incoming_alert, sort_keys=True)
-        published_alerts = self._published_alerts.get(incoming_resource_name)
+        if incoming_generation_id:
+            alert_key = f"{incoming_resource_type}_{incoming_generation_id}"
+        else:
+            alert_key = f"{incoming_resource_type}_{incoming_resource_name}"
 
-        if published_alerts:
-            incoming_generation_id = incoming_alert.get('_generation_id')
-            published_alert = published_alerts.get(incoming_generation_id)
+        incoming_alert_msg = json.dumps(incoming_alert, sort_keys=True)
+        published_alert = self._published_alerts.get(alert_key)
+
+        if published_alert:
             if incoming_alert_msg == published_alert:
                 # Published already
                 return True
             else:
                 # New alert
-                self._published_alerts[incoming_resource_name][incoming_generation_id] = incoming_alert_msg
+                self._published_alerts[alert_key] = incoming_alert_msg
+
         else:
-            self._published_alerts[incoming_resource_name] = {
-                incoming_generation_id: incoming_alert_msg
-                }
+            self._published_alerts[alert_key] = incoming_alert_msg
 
         return False

--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -186,10 +186,10 @@ class ObjectMonitor(threading.Thread):
         self._published_alerts = { resource_name: [alert1, alert2] }
 
         Returns:
-            True if incoming alert is a new alert
-            False, otherwise.
+            True if it is published already
+            False if it is a new alert
         """
-        incoming_alert = alert.to_dict()
+        incoming_alert = alert.to_dict().copy()
 
         # Alert with no status change also has new timestamp.
         # So timestamp field should be ignored for validation.

--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -195,16 +195,13 @@ class ObjectMonitor(threading.Thread):
         incoming_resource_name = incoming_alert.get('_resource_name')
         incoming_generation_id = incoming_alert.get('_generation_id')
 
-        if incoming_alert.get('_timestamp') is None or incoming_resource_name is None:
-            # Consider any other alerts to be published
-            return False
-
         # Alert which is getting repeated also has new timestamp.
         # So timestamp field should be ignored for validation.
-        del incoming_alert['_timestamp']
+        if "_timestamp" in incoming_alert.keys():
+            del incoming_alert['_timestamp']
 
         # Remove user added fields those aren't exist in raw event
-        if incoming_alert.get('_is_status') is not None:
+        if "_is_status" in incoming_alert.keys():
             del incoming_alert['_is_status']
 
         incoming_alert_msg = json.dumps(incoming_alert, sort_keys=True)

--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -199,7 +199,7 @@ class ObjectMonitor(threading.Thread):
             # Consider any other alerts to be published
             return False
 
-        # Alert with no status change also has new timestamp.
+        # Alert which is getting repeated also has new timestamp.
         # So timestamp field should be ignored for validation.
         del incoming_alert['_timestamp']
 

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -83,7 +83,7 @@ class NodeEventParser(ObjectParser):
         if ready_status is None:
             Log.debug(f"ready_status is None for node resource {resource_name}")
             cached_state[resource_name] = ready_status
-            return None
+            return (None, None)
 
         if event_type == EventStates.ADDED:
             cached_state[resource_name] = ready_status.lower()
@@ -93,7 +93,7 @@ class NodeEventParser(ObjectParser):
                 return health_alert, self.event
             else:
                 Log.debug(f"[EventStates ADDED] No change detected for node resource {resource_name}")
-                return None
+                return (None, None)
 
         if event_type == EventStates.MODIFIED:
             if resource_name in cached_state:
@@ -109,14 +109,14 @@ class NodeEventParser(ObjectParser):
                     return health_alert, self.event
                 else:
                     Log.debug(f"[EventStates MODIFIED] No change detected for node resource {resource_name}")
-                    return None
+                    return (None, None)
             else:
                 Log.debug(f"[EventStates MODIFIED] No cached state detected for node resource {resource_name}")
-                return None
+                return (None, None)
 
         # Handle DELETED event - Not required for Cortx
 
-        return None
+        return (None, None)
 
 
 class PodEventParser(ObjectParser):
@@ -173,13 +173,13 @@ class PodEventParser(ObjectParser):
         if ready_status is None:
             Log.debug(f"ready_status is None for pod resource {resource_name}")
             cached_state[resource_name] = ready_status
-            return None
+            return (None, None)
 
         if an_event[K8SEventsConst.TYPE] == EventStates.ADDED:
             cached_state[resource_name] = ready_status.lower()
             if ready_status.lower() != K8SEventsConst.true:
                 Log.debug(f"[EventStates ADDED] No change detected for pod resource {resource_name}")
-                return None
+                return (None, None)
             else:
                 event_type = AlertStates.ONLINE
                 health_alert = self._create_health_alert(resource_type, resource_name, event_type, generation_id)
@@ -199,14 +199,14 @@ class PodEventParser(ObjectParser):
                     return health_alert, self.event
                 else:
                     Log.debug(f"[EventStates MODIFIED] No change detected for pod resource {resource_name}")
-                    return None
+                    return (None, None)
             else:
                 Log.debug(f"[EventStates MODIFIED] No cached state detected for pod resource {resource_name}")
-                return None
+                return (None, None)
 
         # Handle DELETED event - Not required for Cortx
 
-        return None
+        return (None, None)
 
 
 class EventParser:

--- a/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
+++ b/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+import os
+import pathlib
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..', '..'))
+
+from ha.monitor.k8s.object_monitor import ObjectMonitor
+from ha.core.config.config_manager import ConfigManager
+
+
+class MockProducer:
+
+    def __init__(self, producer_id: str, message_type: str, partitions: int):
+       print(f"Producer id: {producer_id}, message_type: {message_type}, partition: {partitions}")
+       self.is_publish = False
+       self.mock_message = None
+
+    def publish(self, message: any):
+        if self.mock_message:
+            message = self.mock_message
+        print(f"Publishing..\n{message.to_dict()}")
+        return message
+
+class MockAlert:
+
+    alert = {
+        '_resource_type': 'node',
+        '_resource_name': '0000759b5d544cad8ea8cc6ee8ef0000',
+        '_alert_type': 'online',
+        '_k8s_container': None,
+        '_generation_id': 'cortx-data-dummy',
+        '_node': 'dummy-host.colo.seagate.com',
+        '_is_status': True,
+        '_timestamp': '1645601710'}
+
+    @staticmethod
+    def to_dict():
+        return MockAlert.alert
+
+
+if __name__ == "__main__":
+    print("******** Testing K8s Alert Parsing ********")
+    try:
+        ConfigManager.init("test_k8s_resource_monitor")
+
+        pod_labels =  ['cortx-data', 'cortx-server']
+        pod_label_str = ', '.join(pod_label for pod_label in pod_labels)
+
+        kwargs = {'pretty': True}
+        kwargs['label_selector'] = f'name in ({pod_label_str})'
+
+        #  Setting mock producer to publish
+        mock_producer = MockProducer("mock_producer", "mock_message", 1)
+
+        monitor = ObjectMonitor(mock_producer, 'pod', **kwargs)
+
+        alert = MockAlert()
+
+        # Check the alert is a new alert
+        assert monitor._is_published_alert(alert) == False
+
+        # Publish
+        mock_producer.publish(alert)
+
+        # Check the alert is already published
+        assert monitor._is_published_alert(alert) == True, "Publishing duplicate alert"
+        print("Successfully verified the alert.")
+
+        # we are exiting here so no needs to join the thread
+        mock_producer._stop_alert_processing = True
+
+    except Exception as e:
+       print(f"Failed to verify the alert is already published or not. Error: {e}")

--- a/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
+++ b/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
@@ -29,14 +29,11 @@ class MockProducer:
 
     def __init__(self, producer_id: str, message_type: str, partitions: int):
        print(f"Producer id: {producer_id}, message_type: {message_type}, partition: {partitions}")
-       self.is_publish = False
-       self.mock_message = None
 
     def publish(self, message: any):
-        if self.mock_message:
-            message = self.mock_message
-        print(f"Publishing..\n{message.to_dict()}")
+        print(f"Publishing alert..\n{message.to_dict()}")
         return message
+
 
 class MockAlert:
 
@@ -56,7 +53,7 @@ class MockAlert:
 
 
 if __name__ == "__main__":
-    print("******** Testing K8s Alert Parsing ********")
+    print("******** Testing K8s Not Publishing Duplicate Alerts ********")
     try:
         ConfigManager.init("test_k8s_resource_monitor")
 
@@ -80,7 +77,7 @@ if __name__ == "__main__":
         mock_producer.publish(alert)
 
         # Check the alert is already published
-        assert monitor._is_published_alert(alert) == True, "Publishing duplicate alert"
+        assert monitor._is_published_alert(alert) == True, "Duplicate alert is published"
         print("Successfully verified the alert.")
 
         # we are exiting here so no needs to join the thread


### PR DESCRIPTION
# Problem Statement
CORTX-28560 - k8s_monitor is repeating previously sent alert event there is no status change on monitoring objects.
CORTX-29057 - Unpacking issue with Event parser when it returns None

# Design
CORTX-28560 - Fix is to publish only new alert by checking whether incoming alert is already sent or not.
CORTX-29057 - Return required number of values as client code expects

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
    Test is added. Logs are also validated.
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
**Log:** https://jts.seagate.com/secure/attachment/505658/DEV_fix_log_23FEB2022.txt

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: N
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N] N.A
- [x] Side effects on other features (deployment/upgrade)? [Y/N] N
- [x] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
