### PR TITLE
CORTX-27894 - Use noarch architecture for HA package.

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -79,9 +79,9 @@ python3.6 setup.py bdist_rpm --version="${version}" --install-dir="${HA_INSTALL_
 
 # Above --force-arch flag and below code is just for backward compatibility.
 # Can be removed once integration is done with RE.
-rpm_file=`ls -1 ${BASE_DIR}/dist/ | grep x86_64 | grep -v debug`
-mkdir -p ${BASE_DIR}/dist/rpmbuild/RPMS/x86_64
-cp ${BASE_DIR}/dist/${rpm_file} ${BASE_DIR}/dist/rpmbuild/RPMS/x86_64/
+rpm_file=`ls -1 ${BASE_DIR}/dist/`
+mkdir -p ${BASE_DIR}/dist/rpmbuild/RPMS/noarch
+cp ${BASE_DIR}/dist/${rpm_file} ${BASE_DIR}/dist/rpmbuild/RPMS/noarch/
 
 # Show RPM
 cd ${BASE_DIR}/dist/rpmbuild

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -74,7 +74,7 @@ cp -rf ${BASE_DIR}/conf/etc/v2/ha.conf.template ${BASE_DIR}/conf/etc/v2/ha.conf
 sed -i -e "s|<VERSION>|${version}|g" ${BASE_DIR}/conf/etc/v2/ha.conf
 
 python3.6 setup.py bdist_rpm --version="${version}" --install-dir="${HA_INSTALL_PATH}" --release="$BUILD" \
---force-arch x86_64 --post-install jenkins/rpm/v2/k8s/post_install_script.sh \
+--post-install jenkins/rpm/v2/k8s/post_install_script.sh \
 --post-uninstall jenkins/rpm/v2/k8s/post_uninstall_script.sh
 
 # Above --force-arch flag and below code is just for backward compatibility.

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -73,13 +73,13 @@ rm -rf ${BASE_DIR}/dist
 cp -rf ${BASE_DIR}/conf/etc/v2/ha.conf.template ${BASE_DIR}/conf/etc/v2/ha.conf
 sed -i -e "s|<VERSION>|${version}|g" ${BASE_DIR}/conf/etc/v2/ha.conf
 
-python3.6 setup.py bdist_rpm --version="${version}" --install-dir="${HA_INSTALL_PATH}" --release="$BUILD" \
+python3.6 setup.py bdist_rpm --version="${version}" --install-dir="${HA_INSTALL_PATH}" --binary-only --release="$BUILD" \
 --post-install jenkins/rpm/v2/k8s/post_install_script.sh \
 --post-uninstall jenkins/rpm/v2/k8s/post_uninstall_script.sh
 
 # Above --force-arch flag and below code is just for backward compatibility.
 # Can be removed once integration is done with RE.
-rpm_file=`ls -1 ${BASE_DIR}/dist/`
+rpm_file=`ls -1 ${BASE_DIR}/dist/ | grep noarch`
 mkdir -p ${BASE_DIR}/dist/rpmbuild/RPMS/noarch
 cp ${BASE_DIR}/dist/${rpm_file} ${BASE_DIR}/dist/rpmbuild/RPMS/noarch/
 


### PR DESCRIPTION
# Problem Statement
-  cortx-ha package generation is failing in Rocky Linux 8.4. [build.sh](https://github.com/Seagate/cortx-ha/blob/main/jenkins/build.sh#L77) uses `x86_64` architecture for cortx-ha package. As cortx-ha contains Python scripts this should be arch indepndent. Removed `--force-arch x86_64` option from `python3.6 setup.py bdist_rpm bdist_rpm` command

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [x] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
