### PR TITLE
CORTX-29106: Alert is getting modified and timestamp field is not present in published alert

### DIFF
--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -15,6 +15,7 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
+import copy
 import json
 import threading
 from kubernetes import config, client, watch
@@ -178,7 +179,7 @@ class ObjectMonitor(threading.Thread):
                 break
         Log.info(f"Stopping the {self.name}...")
 
-    def _is_published_alert(self, incoming_alert) -> bool:
+    def _is_published_alert(self, alert) -> bool:
         """
         Check incoming alert is already published or not.
         If incoming alert is not found in published alerts, then
@@ -189,8 +190,10 @@ class ObjectMonitor(threading.Thread):
             True if it is published already
             False if it is a new alert
         """
-        if not isinstance(incoming_alert, dict):
+        if not isinstance(alert, dict):
             return False
+
+        incoming_alert = copy.deepcopy(alert)
 
         header = incoming_alert["event"]["header"]
         payload = incoming_alert["event"]["payload"]

--- a/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
+++ b/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
@@ -114,8 +114,8 @@ if __name__ == "__main__":
 
         monitor = ObjectMonitor(mock_producer, 'pod', **kwargs)
 
-        host_alert = MockAlert.get_pod_alert()
-        pod_alert = MockAlert.get_host_alert()
+        host_alert = MockAlert.get_host_alert()
+        pod_alert = MockAlert.get_pod_alert()
 
         # Check the alert is a new alert
         assert monitor._is_published_alert(host_alert) == False, "Failed to publish new alert"
@@ -129,6 +129,10 @@ if __name__ == "__main__":
         assert monitor._is_published_alert(host_alert) == True, "Duplicate host alert is published"
         assert monitor._is_published_alert(pod_alert) == True, "Duplicate pod alert is published"
 
+        # Check alert is not getting modified by is_published_alert validation
+        actual_pod_alert = MockAlert.get_pod_alert()
+        assert pod_alert == actual_pod_alert
+
         # Change pod status
         pod_alert = MockAlert.toggle_status(pod_alert)
         mock_producer.publish(pod_alert)
@@ -139,6 +143,7 @@ if __name__ == "__main__":
 
         # we are exiting here so no needs to join the thread
         mock_producer._stop_alert_processing = True
+
 
     except Exception as e:
        print(f"Failed to verify the alert is already published or not. Error: {e}")

--- a/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
+++ b/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
@@ -144,6 +144,5 @@ if __name__ == "__main__":
         # we are exiting here so no needs to join the thread
         mock_producer._stop_alert_processing = True
 
-
     except Exception as e:
        print(f"Failed to verify the alert is already published or not. Error: {e}")


### PR DESCRIPTION
# Problem Statement
The timestamp field is removed from alert after validating it using is_published_alert method.

# Design
Before modifying the actual alert, must do deepcopy of the actual alert and proceed.

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
```
******** Testing K8s Not Publishing Duplicate Alerts ********
2022-02-28 06:54:26 test_k8s_resource_monitor [564]: INFO [init] Started logging for service test_k8s_resource_monitor
Producer id: mock_producer, message_type: mock_message, partition: 1
2022-02-28 06:54:26 test_k8s_resource_monitor [564]: INFO [__init__] Initialization done for pod monitor
Publishing alert..
{'event': {'header': {'version': '1.0', 'timestamp': '112255', 'event_id': '11225568919c5ba8f88ad24cc18f632a75de115aca'}, 'payload': {'source': 'monitor', 'cluster_id': 'None', 'site_id': 'None', 'rack_id': 'None', 'storageset_id': 'None', 'node_id': 'dummy.colo.seagate.com', 'resource_type': 'host', 'resource_id': 'dummy.colo.seagate.com', 'resource_status': 'online', 'specific_info': {}}}}
Publishing alert..
{'event': {'header': {'version': '1.0', 'timestamp': '112233', 'event_id': '11223368911c9b81b8d3c84305a49c191e6a8c3bb5'}, 'payload': {'source': 'monitor', 'cluster_id': 'None', 'site_id': 'None', 'rack_id': 'None', 'storageset_id': 'None', 'node_id': 'dummy0fff6f947e8aecc6a27a25b7329', 'resource_type': 'node', 'resource_id': 'dummy02fff6f947e8aecc6a27a25b7329', 'resource_status': 'online', 'specific_info': {'generation_id': 'cortx-data-dummy0'}}}}
Publishing alert..
{'event': {'header': {'version': '1.0', 'timestamp': '112233', 'event_id': '11223368911c9b81b8d3c84305a49c191e6a8c3bb5'}, 'payload': {'source': 'monitor', 'cluster_id': 'None', 'site_id': 'None', 'rack_id': 'None', 'storageset_id': 'None', 'node_id': 'dummy0fff6f947e8aecc6a27a25b7329', 'resource_type': 'node', 'resource_id': 'dummy02fff6f947e8aecc6a27a25b7329', 'resource_status': 'offline', 'specific_info': {'generation_id': 'cortx-data-dummy0'}}}}
Successfully verified the alert.
```


# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: N
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [x] Side effects on other features (deployment/upgrade)? [Y/N] N
- [x] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
