### PR TITLE
CORTX-27679: on new setup if data pod scale to 0 and then 1 no online event is sent to hare

### DIFF
--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -407,7 +407,7 @@ class SystemHealth(Subscriber):
                     pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
                     # Update the current health value itself.
                     latest_health = EntityHealth.read(current_health)
-                    if stored_genration_id != incoming_generation_id:
+                    if (component_type == "node") and (stored_genration_id != incoming_generation_id):
                         if incoming_health_status == HEALTH_EVENTS.ONLINE.value:
                             # In delete scenario, online event comes first, followed by failed event.
                             # System health is expected to update the failed event first, then online event.

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -403,7 +403,6 @@ class SystemHealth(Subscriber):
                     # If health is already stored and its a node_health, check further
                     stored_genration_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
                     incoming_generation_id = healthevent.specific_info["generation_id"]
-                    stored_health_status = current_health_dict["events"][0]["status"]
                     incoming_health_status = healthevent.event_type
                     pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
                     # Update the current health value itself.

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -38,11 +38,11 @@ from ha.core.system_health.system_health_manager import SystemHealthManager
 from ha.core.error import HaSystemHealthException
 from ha.core.system_health.health_evaluator_factory import HealthEvaluatorFactory
 from ha.core.cluster.const import SYSTEM_HEALTH_OUTPUT_V2, GET_SYS_HEALTH_ARGS
-from ha.core.system_health.const import (
-    CLUSTER_ELEMENTS, HEALTH_STATUSES, HEALTH_EVENT_ACTIONS, HEALTH_EVENTS)
+from ha.core.system_health.const import CLUSTER_ELEMENTS, HEALTH_STATUSES, HEALTH_EVENT_ACTIONS, HEALTH_EVENTS
 from ha.core.system_health.model.health_status import StatusOutput, ComponentStatus
 from ha.core.system_health.system_health_hierarchy import HealthHierarchy
 from ha.core.event_manager.resources import RESOURCE_TYPES
+from ha.fault_tolerance.const import HEALTH_EVENT_SOURCES
 
 class SystemHealth(Subscriber):
     """
@@ -399,53 +399,58 @@ class SystemHealth(Subscriber):
             if current_health:
                 current_health_dict = json.loads(current_health)
                 specific_info = current_health_dict["events"][0]["specific_info"]
-                if current_health and specific_info:
-                    # If health is already stored and its a node_health, check further
-                    stored_genration_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
-                    incoming_generation_id = healthevent.specific_info["generation_id"]
-                    incoming_health_status = healthevent.event_type
-                    pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
-                    # Update the current health value itself.
-                    latest_health = EntityHealth.read(current_health)
-                    if (component_type == "node") and (stored_genration_id != incoming_generation_id):
-                        if incoming_health_status == HEALTH_EVENTS.ONLINE.value:
-                            # In delete scenario, online event comes first, followed by failed event.
-                            # System health is expected to update the failed event first, then online event.
-                            # If incoming is online event, change the stored event type to failed.
-                            # Update the failed event in system health and followed by incoming online event.
-                            healthevent.specific_info = {"generation_id": stored_genration_id, "pod_restart": 1}
-                            healthevent.event_type = "failed"
-                            updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
-                            # Create a "failed" event and update it in system health and publish
+                if healthevent.source == HEALTH_EVENT_SOURCES.MONITOR.value:
+                    # Process event from source monitor
+                    if current_health and specific_info and (component_type == CLUSTER_ELEMENTS.NODE.value):
+                        # If health is already stored and its a node_health, check further
+                        stored_genration_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
+                        incoming_generation_id = healthevent.specific_info["generation_id"]
+                        incoming_health_status = healthevent.event_type
+                        pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
+                        # Update the current health value itself.
+                        latest_health = EntityHealth.read(current_health)
+                        if stored_genration_id and (stored_genration_id != incoming_generation_id):
+                            if incoming_health_status == HEALTH_EVENTS.ONLINE.value:
+                                # In delete scenario, online event comes first, followed by failed event.
+                                # System health is expected to update the failed event first, then online event.
+                                # If incoming is online event, change the stored event type to failed.
+                                # Update the failed event in system health and followed by incoming online event.
+                                healthevent.specific_info = {"generation_id": stored_genration_id, "pod_restart": 1}
+                                healthevent.event_type = "failed"
+                                updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
+                                # Create a "failed" event and update it in system health and publish
+                                self._check_and_update(current_health, updated_health, healthevent, next_component)
+                                current_health = updated_health
+                                # Now create an "online" event and update it in system health and publish
+                                healthevent.specific_info = {"generation_id": incoming_generation_id, "pod_restart": 1}
+                                healthevent.event_type = "online"
+                                updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
+                                self._check_and_update(current_health, updated_health, healthevent, next_component)
+                            elif pod_restart_val is not None and pod_restart_val:
+                                # Check the pod_restart value associated with Node, if its 1,
+                                # means this alert is already updated. No need to send the alert again.
+                                # Just need to reset the pod_restart value
+                                key = self._prepare_key(component, cluster_id=self.node_map['cluster_id'], \
+                                    site_id=self.node_map['site_id'], rack_id=self.node_map['rack_id'], \
+                                    node_id=self.node_id)
+                                latest_health_dict = json.loads(current_health)
+                                new_spec_info = {"generation_id": stored_genration_id, "pod_restart": 0}
+                                latest_health_dict["events"][0]["specific_info"] = new_spec_info
+                                updated_health = EntityHealth.write(latest_health_dict)
+                                self.healthmanager.set_key(key, updated_health)
+                        else:
+                            # current health is there and generation id is also already present.
+                            # That means its a normal failure scenario
+                            updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
                             self._check_and_update(current_health, updated_health, healthevent, next_component)
-                            current_health = updated_health
-                            # Now create an "online" event and update it in system health and publish
-                            healthevent.specific_info = {"generation_id": incoming_generation_id, "pod_restart": 1}
-                            healthevent.event_type = "online"
-                            updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
-                            self._check_and_update(current_health, updated_health, healthevent, next_component)
-                        elif pod_restart_val is not None and pod_restart_val:
-                            # Check the pod_restart value associated with Node, if its 1,
-                            # means this alert is already updated. No need to send the alert again.
-                            # Just need to reset the pod_restart value
-                            key = self._prepare_key(component, cluster_id=self.node_map['cluster_id'], \
-                                site_id=self.node_map['site_id'], rack_id=self.node_map['rack_id'], \
-                                node_id=self.node_id)
-                            latest_health_dict = json.loads(current_health)
-                            new_spec_info = {"generation_id": stored_genration_id, "pod_restart": 0}
-                            latest_health_dict["events"][0]["specific_info"] = new_spec_info
-                            updated_health = EntityHealth.write(latest_health_dict)
-                            self.healthmanager.set_key(key, updated_health)
                     else:
-                        # current health is there and generation id is also already present.
-                        # That means its a normal failure scenario
+                        # Update hierarchical components. such as site, rack
+                        latest_health = EntityHealth.read(current_health)
                         updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
                         self._check_and_update(current_health, updated_health, healthevent, next_component)
                 else:
-                    # Update hierarchical components. such as site, rack
-                    latest_health = EntityHealth.read(current_health)
-                    updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
-                    self._check_and_update(current_health, updated_health, healthevent, next_component)
+                    # Process events from any other sources
+                    pass
             else:
                 # Health value not present in the store currently, create now.
                 latest_health = EntityHealth()

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -38,7 +38,8 @@ from ha.core.system_health.system_health_manager import SystemHealthManager
 from ha.core.error import HaSystemHealthException
 from ha.core.system_health.health_evaluator_factory import HealthEvaluatorFactory
 from ha.core.cluster.const import SYSTEM_HEALTH_OUTPUT_V2, GET_SYS_HEALTH_ARGS
-from ha.core.system_health.const import CLUSTER_ELEMENTS, HEALTH_STATUSES, HEALTH_EVENT_ACTIONS
+from ha.core.system_health.const import (
+    CLUSTER_ELEMENTS, HEALTH_STATUSES, HEALTH_EVENT_ACTIONS, HEALTH_EVENTS)
 from ha.core.system_health.model.health_status import StatusOutput, ComponentStatus
 from ha.core.system_health.system_health_hierarchy import HealthHierarchy
 from ha.core.event_manager.resources import RESOURCE_TYPES
@@ -402,15 +403,17 @@ class SystemHealth(Subscriber):
                     # If health is already stored and its a node_health, check further
                     stored_genration_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
                     incoming_generation_id = healthevent.specific_info["generation_id"]
-                    incoming_health_status = current_health_dict["events"][0]["status"]
+                    stored_health_status = current_health_dict["events"][0]["status"]
+                    incoming_health_status = healthevent.event_type
                     pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
                     # Update the current health value itself.
                     latest_health = EntityHealth.read(current_health)
                     if stored_genration_id != incoming_generation_id:
-                        if incoming_health_status == status:
-                            # If the generation id matches and stored node health matches
-                            # with incoming node health, means online event received first
-                            # instead of failed event in delete scenario
+                        if incoming_health_status == HEALTH_EVENTS.ONLINE.value:
+                            # In delete scenario, online event comes first, followed by failed event.
+                            # System health is expected to update the failed event first, then online event.
+                            # If incoming is online event, change the stored event type to failed.
+                            # Update the failed event in system health and followed by incoming online event.
                             healthevent.specific_info = {"generation_id": stored_genration_id, "pod_restart": 1}
                             healthevent.event_type = "failed"
                             updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
@@ -423,7 +426,7 @@ class SystemHealth(Subscriber):
                             updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
                             self._check_and_update(current_health, updated_health, healthevent, next_component)
                         elif pod_restart_val is not None and pod_restart_val:
-                            # Check the pod_restart value assosciated with Node, if its 1,
+                            # Check the pod_restart value associated with Node, if its 1,
                             # means this alert is already updated. No need to send the alert again.
                             # Just need to reset the pod_restart value
                             key = self._prepare_key(component, cluster_id=self.node_map['cluster_id'], \
@@ -440,7 +443,7 @@ class SystemHealth(Subscriber):
                         updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
                         self._check_and_update(current_health, updated_health, healthevent, next_component)
                 else:
-                    # Update hierachical components. such as site, rack
+                    # Update hierarchical components. such as site, rack
                     latest_health = EntityHealth.read(current_health)
                     updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
                     self._check_and_update(current_health, updated_health, healthevent, next_component)


### PR DESCRIPTION
# Problem Statement
CORTX-27679: on new setup if data pod scale to 0 and then 1 no online event is sent to hare

# Design
System Health is updating health status after comparing new event and stored event.
While processing any new event, check event_type in new event is online. 
If new event is online, change stored event event_type to failed. Such that failed event will be reported first and then online event will be next.

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

```
kubectl scale deploy cortx-data-ssc-vm-rhev4-1667 --replicas 0

2022-03-01 20:54:09 health_monitor [7]: INFO [publish] Sending action event {'event': {'header': {'version': '1.0', 'timestamp': '1646168049', 'event_id': '1646168049a2147e3b6f394b03899cad8b6b435fac'}, 'payload': {'source': 'monitor', 'cluster_id': '266faed2854a4b758c51bfda97b27320', 'site_id': '1', 'rack_id': '1', 'storageset_id': '22b1e5a58aff44a684998c1e99b9411e', 'node_id': '22b1e5a58aff44a684998c1e99b9411e', 'resource_type': 'node', 'resource_id': '22b1e5a58aff44a684998c1e99b9411e', 'resource_status': 'failed', 'specific_info': {'generation_id': 'cortx-data-ssc-vm-rhev4-1667-9f59db655-mrmg5', 'pod_restart': 0}}}} to component hare

kubectl scale deploy cortx-data-ssc-vm-rhev4-1667 --replicas 1

2022-03-01 20:54:28 health_monitor [7]: INFO [publish] Sending action event {'event': {'header': {'version': '1.0', 'timestamp': '1646168067', 'event_id': '164616806763b9db792639441599436c82030c6ee5'}, 'payload': {'source': 'monitor', 'cluster_id': '266faed2854a4b758c51bfda97b27320', 'site_id': '1', 'rack_id': '1', 'storageset_id': '22b1e5a58aff44a684998c1e99b9411e', 'node_id': '22b1e5a58aff44a684998c1e99b9411e', 'resource_type': 'node', 'resource_id': '22b1e5a58aff44a684998c1e99b9411e', 'resource_status': 'online', 'specific_info': {'generation_id': 'cortx-data-ssc-vm-rhev4-1667-9f59db655-dzns6', 'pod_restart': 1}}}} to component hare
```

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: N
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [x] Side effects on other features (deployment/upgrade)? [Y/N] N
- [x] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
