### PR TITLE
CORTX-28892 : Write wrappers to get disk and cvg ids from gconf

### DIFF
--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -13,6 +13,8 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
+import enum
+
 HA_LOG_LEVEL="INFO"
 CONFIG_DIR="/etc/cortx/ha"
 HA_CONFIG_FILE="{}/ha.conf".format(CONFIG_DIR)
@@ -32,9 +34,18 @@ POD_EVENT="node"
 DISK_EVENT="disk"
 EVENT_COMPONENT="hare"
 
-# confStore search API constants
-NODE_CONST = "node"
-SERVICE_CONST = "services"
+# Cluster Cardinality Keys
 CLUSTER_CARDINALITY_KEY = "cluster_cardinality"
 CLUSTER_CARDINALITY_NUM_NODES = "num_nodes"
 CLUSTER_CARDINALITY_LIST_NODES = "node_list"
+
+# GConf keys
+class GconfKeys(enum.Enum):
+    NODE_CONST = "node"
+    SERVICE_CONST = "services"
+    CVG_NAME = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}name"
+    CVG_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}num_cvg"
+    DATA_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}num_data"
+    METADATA_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}num_metadata"
+    DATA_DISK = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}data[{d_index}]"
+    METADATA_DISK = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}metadata[{m_index}]"

--- a/ha/test/integration/test_conf_store_search_api.py
+++ b/ha/test/integration/test_conf_store_search_api.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         ConfigManager.init("test_conf_store_search_api")
         cluster_card  = ConftStoreSearch()
 
-        print("******** Testing confstore search APIs for data and server PODs ********")
+        print("\n******** Testing confstore search APIs for data and server PODs ********\n")
         cluster_card.set_cluster_cardinality("cortx")
         cc = cluster_card.get_cluster_cardinality()
         print(f"Following clsuter cardinality is set: {cc}")
@@ -37,13 +37,13 @@ if __name__ == "__main__":
         print("\n\n**************   Testing confstore APIs for CVG & disk  ***********\n")
         node_id = cluster_card._get_data_pods("cortx")[0]
 
-        cvg_list = cluster_card.get_cvg_list("cortx", node_id)
+        cvg_list = ConftStoreSearch.get_cvg_list("cortx", node_id)
         print(f"\nCVGs present under node {node_id} are : ", cvg_list)
 
-        disk_list = cluster_card.get_disk_list("cortx", node_id)
+        disk_list = ConftStoreSearch.get_disk_list("cortx", node_id)
         print(f"\nDisks present under node {node_id} are : ", disk_list)
 
-        disk_list_per_cvg = cluster_card.get_disk_list_for_cvg("cortx", node_id, cvg_id=cvg_list[0])
+        disk_list_per_cvg = ConftStoreSearch.get_disk_list_for_cvg("cortx", node_id, cvg_id=cvg_list[0])
         print(f"\nDisk present under node {node_id} & CVG {cvg_list[0]} are : ", disk_list_per_cvg)
 
     except Exception as e:

--- a/ha/test/integration/test_conf_store_search_api.py
+++ b/ha/test/integration/test_conf_store_search_api.py
@@ -24,14 +24,27 @@ from ha.core.config.config_manager import ConfigManager
 sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..', '..'))
 
 if __name__ == "__main__":
-    print("******** Testing confstore search APIs for data and server PODs ********")
     try:
         Conf.load("cortx", "yaml:///etc/cortx/cluster.conf")
         ConfigManager.init("test_conf_store_search_api")
         cluster_card  = ConftStoreSearch()
+
+        print("******** Testing confstore search APIs for data and server PODs ********")
         cluster_card.set_cluster_cardinality("cortx")
         cc = cluster_card.get_cluster_cardinality()
         print(f"Following clsuter cardinality is set: {cc}")
 
+        print("\n\n**************   Testing confstore APIs for CVG & disk  ***********\n")
+        node_id = cluster_card._get_data_pods("cortx")[0]
+
+        cvg_list = cluster_card.get_cvg_list("cortx", node_id)
+        print(f"\nCVG's presents under node {node_id} are : ", cvg_list)
+
+        disk_list = cluster_card.get_disk_list("cortx", node_id)
+        print(f"\nDisks present under node {node_id} are : ", disk_list)
+
+        disk_list_per_cvg = cluster_card.get_disk_list_for_cvg("cortx", node_id, cvg_id=cvg_list[0])
+        print(f"\nDisk present under node {node_id} & CVG {cvg_list[0]} are : ", disk_list_per_cvg)
+
     except Exception as e:
-        print(f"Failed to test confstore search APIs for data and server PODs, Error: {e}")
+        print(f"Failed to test confstore search APIs, Error: {e}")

--- a/ha/test/integration/test_conf_store_search_api.py
+++ b/ha/test/integration/test_conf_store_search_api.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         node_id = cluster_card._get_data_pods("cortx")[0]
 
         cvg_list = cluster_card.get_cvg_list("cortx", node_id)
-        print(f"\nCVG's presents under node {node_id} are : ", cvg_list)
+        print(f"\nCVGs present under node {node_id} are : ", cvg_list)
 
         disk_list = cluster_card.get_disk_list("cortx", node_id)
         print(f"\nDisks present under node {node_id} are : ", disk_list)

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -164,10 +164,14 @@ class ConftStoreSearch:
                                             .replace("(cvg_index)", str(cvg_index)))
                 num_of_metadata_disks = Conf.get(index, GconfKeys.METADATA_COUNT.value.replace("(node_id)", node_id)
                                                 .replace("(cvg_index)", str(cvg_index)))
-                [disk_list.append(Conf.get(index, GconfKeys.DATA_DISK.value.replace("(node_id)", node_id).
-                                            replace("(cvg_index)", str(cvg_index)).replace("(d_index)", str(d)))) for d in range(num_of_data_disks)]
-                [disk_list.append(Conf.get(index, GconfKeys.METADATA_DISK.value.replace("(node_id)", node_id).
-                                            replace("(cvg_index)", str(cvg_index)).replace("(m_index)", str(m)))) for m in range(num_of_metadata_disks)]
+
+                for d_index in range(num_of_data_disks):
+                    disk_list.append(Conf.get(index, GconfKeys.DATA_DISK.value.replace("(node_id)", node_id).
+                                              replace("(cvg_index)", str(cvg_index)).replace("(d_index)", str(d_index))))
+
+                for m_index in range(num_of_metadata_disks):
+                    disk_list.append(Conf.get(index, GconfKeys.METADATA_DISK.value.replace("(node_id)", node_id).
+                                              replace("(cvg_index)", str(cvg_index)).replace("(m_index)", str(m_index))))
             return disk_list
         except Exception as e:
             Log.error(f"Unable to fetch Disk list from GConf. Error {e}")
@@ -195,10 +199,14 @@ class ConftStoreSearch:
                                             replace("(node_id)", node_id).replace("(cvg_index)", str(cvg_index)))
                 num_of_metadata_disks = Conf.get(index, GconfKeys.METADATA_COUNT.value.
                                                 replace("(node_id)", node_id).replace("(cvg_index)", str(cvg_index)))
-                [disk_list.append(Conf.get(index, GconfKeys.DATA_DISK.value.replace("(node_id)", node_id).
-                                            replace("(cvg_index)", str(cvg_index)).replace("(d_index)", str(d)))) for d in range(num_of_data_disks)]
-                [disk_list.append(Conf.get(index, GconfKeys.METADATA_DISK.value.replace("(node_id)", node_id).
-                                            replace("(cvg_index)", str(cvg_index)).replace("(m_index)", str(m)))) for m in range(num_of_metadata_disks)]
+
+                for d_index in range(num_of_data_disks):
+                    disk_list.append(Conf.get(index, GconfKeys.DATA_DISK.value.replace("(node_id)", node_id).
+                                              replace("(cvg_index)", str(cvg_index)).replace("(d_index)", str(d_index))))
+
+                for m_index in range(num_of_metadata_disks):
+                    disk_list.append(Conf.get(index, GconfKeys.METADATA_DISK.value.replace("(node_id)", node_id).
+                                              replace("(cvg_index)", str(cvg_index)).replace("(m_index)", str(m_index))))
             return disk_list
         except Exception as e:
             Log.error(f"Unable to fetch Disk list from GConf. Error {e}")

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -19,6 +19,7 @@
 Wrappeprs for using the search APIs from conf store
 """
 
+import enum
 import json
 
 from cortx.utils.conf_store import Conf
@@ -29,6 +30,17 @@ from ha.k8s_setup.const import NODE_CONST, SERVICE_CONST
 from cortx.utils.log import Log
 from ha.core.error import ClusterCardinalityError
 
+
+# Confstore keys
+class GconfKeys(enum.Enum):
+    CVG_NAME = "node>(node_id)>storage>cvg[(cvg_index)]>name"
+    CVG_COUNT = "node>(node_id)>storage>num_cvg"
+    DATA_COUNT = "node>(node_id)>storage>cvg[(cvg_index)]>devices>num_data"
+    METADATA_COUNT = "node>(node_id)>storage>cvg[(cvg_index)]>devices>num_metadata"
+    DATA_DISK = "node>(node_id)>storage>cvg[(cvg_index)]>devices>data[(d_index)]"
+    METADATA_DISK = "node>(node_id)>storage>cvg[(cvg_index)]>devices>metadata[(m_index)]"
+
+
 class ConftStoreSearch:
     """
     Wrapper class for using the confstore search APIs
@@ -37,7 +49,6 @@ class ConftStoreSearch:
     def __init__(self):
         """Init method"""
         self._confstore = ConfigManager.get_confstore()
-
 
     def _get_data_pods(self, index):
         """
@@ -110,3 +121,85 @@ class ConftStoreSearch:
         cluster_cardinality_key = CLUSTER_CARDINALITY_KEY
         cluster_cardinality_value = {CLUSTER_CARDINALITY_NUM_NODES: num_pods, CLUSTER_CARDINALITY_LIST_NODES : watch_pods }
         self._confstore.update(cluster_cardinality_key, json.dumps(cluster_cardinality_value))
+
+    def get_cvg_list(self, index, node_id):
+        """
+        Return list of CVG's for any given node.
+        Args:
+            index(str): index of conf file
+            node_id (str): node id
+        Returns:
+            list: list of CVG's
+
+        >>> get_cvg_list(index, '21d6291109304485b3daff43a06cff77')
+        ['cvg-01', 'cvg-02']
+        """
+        try:
+            cvg_list = []
+            cvg_count = Conf.get(index, GconfKeys.CVG_COUNT.value.replace("(node_id)", node_id))
+            cvg_list = [Conf.get(index, GconfKeys.CVG_NAME.value.replace("(node_id)", node_id)
+                            .replace("(cvg_index)", str(c))) for c in range(cvg_count)]
+            return cvg_list
+        except Exception as e:
+            Log.error(f"Unable to fetch CVG list from GConf. Error {e}")
+            raise Exception(f"Unable to fetch CVG list. Error {e}")
+
+    def get_disk_list(self, index, node_id):
+        """
+        Return list of disks for any given node
+        Args:
+            index(str): index of conf file
+            node_id (str): node id
+        Returns:
+            list: list of disks id's
+
+        >>> get_disk_list(index, '21d6291109304485b3daff43a06cff77')
+        ['/dev/sdd', '/dev/sde', '/dev/sdc', '/dev/sdg', '/dev/sdh', '/dev/sdf']
+        """
+        try:
+            cvg_count = Conf.get(index, GconfKeys.CVG_COUNT.value.replace("(node_id)", node_id))
+            disk_list = []
+            for cvg_index in range(cvg_count):
+                num_of_data_disks = Conf.get(index, GconfKeys.DATA_COUNT.value.replace("(node_id)", node_id)
+                                            .replace("(cvg_index)", str(cvg_index)))
+                num_of_metadata_disks = Conf.get(index, GconfKeys.METADATA_COUNT.value.replace("(node_id)", node_id)
+                                                .replace("(cvg_index)", str(cvg_index)))
+                [disk_list.append(Conf.get(index, GconfKeys.DATA_DISK.value.replace("(node_id)", node_id).
+                                            replace("(cvg_index)", str(cvg_index)).replace("(d_index)", str(d)))) for d in range(num_of_data_disks)]
+                [disk_list.append(Conf.get(index, GconfKeys.METADATA_DISK.value.replace("(node_id)", node_id).
+                                            replace("(cvg_index)", str(cvg_index)).replace("(m_index)", str(m)))) for m in range(num_of_metadata_disks)]
+            return disk_list
+        except Exception as e:
+            Log.error(f"Unable to fetch Disk list from GConf. Error {e}")
+            raise Exception(f"Unable to fetch Disk list. Error {e}")
+
+    def get_disk_list_for_cvg(self, index, node_id, cvg_id):
+        """
+        Return list of disks for any given node and CVG.
+        Args:
+            index(str): index of conf file
+            node_id (str): node id
+            cvg_id (str): cvg id
+        Returns:
+            list: list of disks id's
+
+        >>> get_disk_list_for_cvg(index, '21d6291109304485b3daff43a06cff77', 'cvg-01')
+        ['/dev/sdd', '/dev/sde', '/dev/sdc']
+        """
+        try:
+            disk_list = []
+            cvg_list = self.get_cvg_list(index, node_id)
+            if cvg_id in cvg_list:
+                cvg_index = cvg_list.index(cvg_id)
+                num_of_data_disks = Conf.get(index, GconfKeys.DATA_COUNT.value.
+                                            replace("(node_id)", node_id).replace("(cvg_index)", str(cvg_index)))
+                num_of_metadata_disks = Conf.get(index, GconfKeys.METADATA_COUNT.value.
+                                                replace("(node_id)", node_id).replace("(cvg_index)", str(cvg_index)))
+                [disk_list.append(Conf.get(index, GconfKeys.DATA_DISK.value.replace("(node_id)", node_id).
+                                            replace("(cvg_index)", str(cvg_index)).replace("(d_index)", str(d)))) for d in range(num_of_data_disks)]
+                [disk_list.append(Conf.get(index, GconfKeys.METADATA_DISK.value.replace("(node_id)", node_id).
+                                            replace("(cvg_index)", str(cvg_index)).replace("(m_index)", str(m)))) for m in range(num_of_metadata_disks)]
+            return disk_list
+        except Exception as e:
+            Log.error(f"Unable to fetch Disk list from GConf. Error {e}")
+            raise Exception(f"Unable to fetch Disk list. Error {e}")

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -26,19 +26,9 @@ from cortx.utils.conf_store import Conf
 from cortx.utils.cortx.const import Const
 from ha.core.config.config_manager import ConfigManager
 from ha.k8s_setup.const import CLUSTER_CARDINALITY_KEY, CLUSTER_CARDINALITY_NUM_NODES, CLUSTER_CARDINALITY_LIST_NODES
-from ha.k8s_setup.const import NODE_CONST, SERVICE_CONST
+from ha.k8s_setup.const import _DELIM, GconfKeys
 from cortx.utils.log import Log
 from ha.core.error import ClusterCardinalityError
-
-
-# Confstore keys
-class GconfKeys(enum.Enum):
-    CVG_NAME = "node>{node_id}>storage>cvg[{cvg_index}]>name"
-    CVG_COUNT = "node>{node_id}>storage>num_cvg"
-    DATA_COUNT = "node>{node_id}>storage>cvg[{cvg_index}]>devices>num_data"
-    METADATA_COUNT = "node>{node_id}>storage>cvg[{cvg_index}]>devices>num_metadata"
-    DATA_DISK = "node>{node_id}>storage>cvg[{cvg_index}]>devices>data[{d_index}]"
-    METADATA_DISK = "node>{node_id}>storage>cvg[{cvg_index}]>devices>metadata[{m_index}]"
 
 
 class ConftStoreSearch:
@@ -60,7 +50,7 @@ class ConftStoreSearch:
         # ['node>5f3dc3a153454a918277ee4a2c57f36b>components[1]>services[0]',
         # 'node>6203a14bde204e8ea798ad9d42583fb5>components[1]>services[0]', 'node>8cc8b13101e34b3ca1e51ed6e3228d5b>components[1]>services[0]']
 
-        data_pod_keys = Conf.search(index, NODE_CONST, SERVICE_CONST, Const.SERVICE_MOTR_IO.value)
+        data_pod_keys = Conf.search(index, GconfKeys.NODE_CONST.value, GconfKeys.SERVICE_CONST.value, Const.SERVICE_MOTR_IO.value)
         for key in data_pod_keys:
             machine_id = key.split('>')[1]
             # Add machine id to list
@@ -72,7 +62,7 @@ class ConftStoreSearch:
         Get machine ids for server pods: returns list of machine ids.
         """
         machine_ids = []
-        server_pod_keys = Conf.search(index, NODE_CONST, SERVICE_CONST, Const.SERVICE_S3_HAPROXY.value)
+        server_pod_keys = Conf.search(index, GconfKeys.NODE_CONST.value, GconfKeys.SERVICE_CONST.value, Const.SERVICE_S3_HAPROXY.value)
         for key in server_pod_keys:
             machine_id = key.split('>')[1]
             # Add machine id to list
@@ -123,6 +113,13 @@ class ConftStoreSearch:
         self._confstore.update(cluster_cardinality_key, json.dumps(cluster_cardinality_value))
 
     @staticmethod
+    def _get_cvg_count(index, node_id):
+        cvg_count = Conf.get(index, GconfKeys.CVG_COUNT.value.format(_DELIM=_DELIM, node_id=node_id))
+        if not cvg_count:
+            Log.warn(f"CVGs are not available for this node {node_id}")
+        return cvg_count
+
+    @staticmethod
     def get_cvg_list(index, node_id):
         """
         Return list of CVG's for any given node.
@@ -137,15 +134,36 @@ class ConftStoreSearch:
         """
         cvg_list = []
         try:
-            cvg_count = Conf.get(index, GconfKeys.CVG_COUNT.value.format(node_id=node_id))
-            if cvg_count is None:
-                raise Exception(f"CVGs are not available for this node {node_id}")
-            cvg_list = [Conf.get(index, GconfKeys.CVG_NAME.value.format
-                                 (node_id=node_id, cvg_index=cvg_index)) for cvg_index in range(cvg_count)]
+            cvg_count = ConftStoreSearch._get_cvg_count(index, node_id)
+            if cvg_count:
+                cvg_list = [Conf.get(index, GconfKeys.CVG_NAME.value.format
+                                     (_DELIM=_DELIM, node_id=node_id, cvg_index=cvg_index)) for cvg_index in range(cvg_count)]
             return cvg_list
         except Exception as e:
             Log.error(f"Unable to fetch CVG list from GConf. Error {e}")
             raise Exception(f"Unable to fetch CVG list. Error {e}")
+
+    @staticmethod
+    def _get_data_disks(index, node_id, cvg_index):
+        disk_list = []
+        num_of_data_disks = Conf.get(index, GconfKeys.DATA_COUNT.value.format
+                                     (_DELIM=_DELIM, node_id=node_id, cvg_index=cvg_index))
+        if num_of_data_disks:
+            for d_index in range(num_of_data_disks):
+                disk_list.append(Conf.get(index, GconfKeys.DATA_DISK.value.format
+                                          (_DELIM=_DELIM, node_id=node_id, cvg_index=cvg_index, d_index=d_index)))
+        return disk_list
+
+    @staticmethod
+    def _get_metadata_disks(index, node_id, cvg_index):
+        mdisk_list = []
+        num_of_metadata_disks = Conf.get(index, GconfKeys.METADATA_COUNT.value.format
+                                         (_DELIM=_DELIM, node_id=node_id, cvg_index=cvg_index))
+        if num_of_metadata_disks:
+            for m_index in range(num_of_metadata_disks):
+                mdisk_list.append(Conf.get(index, GconfKeys.METADATA_DISK.value.format
+                                           (_DELIM=_DELIM, node_id=node_id, cvg_index=cvg_index, m_index=m_index)))
+        return mdisk_list
 
     @staticmethod
     def get_disk_list(index, node_id):
@@ -162,20 +180,13 @@ class ConftStoreSearch:
         """
         disk_list = []
         try:
-            cvg_count = Conf.get(index, GconfKeys.CVG_COUNT.value.format(node_id=node_id))
-            if cvg_count is None:
-                raise Exception(f"CVGs are not available for this node {node_id}")
-            for cvg_index in range(cvg_count):
-                num_of_data_disks = Conf.get(index, GconfKeys.DATA_COUNT.value.format(node_id=node_id, cvg_index=cvg_index))
-                if num_of_data_disks:
-                    for d_index in range(num_of_data_disks):
-                        disk_list.append(Conf.get(index, GconfKeys.DATA_DISK.value.
-                                                  format(node_id=node_id, cvg_index=cvg_index, d_index=d_index)))
-                num_of_metadata_disks = Conf.get(index, GconfKeys.METADATA_COUNT.value.format(node_id=node_id, cvg_index=cvg_index))
-                if num_of_metadata_disks:
-                    for m_index in range(num_of_metadata_disks):
-                        disk_list.append(Conf.get(index, GconfKeys.METADATA_DISK.value.
-                                                  format(node_id=node_id, cvg_index=cvg_index, m_index=m_index)))
+            cvg_count = ConftStoreSearch._get_cvg_count(index, node_id)
+            if cvg_count:
+                for cvg_index in range(cvg_count):
+                    for disk in ConftStoreSearch._get_data_disks(index, node_id, cvg_index):
+                        disk_list.append(disk)
+                    for mdisk in ConftStoreSearch._get_metadata_disks(index, node_id, cvg_index):
+                        disk_list.append(mdisk)
             return disk_list
         except Exception as e:
             Log.error(f"Unable to fetch Disk list from GConf. Error {e}")
@@ -200,16 +211,10 @@ class ConftStoreSearch:
             cvg_list = ConftStoreSearch.get_cvg_list(index, node_id)
             if cvg_id in cvg_list:
                 cvg_index = cvg_list.index(cvg_id)
-                num_of_data_disks = Conf.get(index, GconfKeys.DATA_COUNT.value.format(node_id=node_id, cvg_index=cvg_index))
-                if num_of_data_disks:
-                    for d_index in range(num_of_data_disks):
-                        disk_list.append(Conf.get(index, GconfKeys.DATA_DISK.value.
-                                                  format(node_id=node_id, cvg_index=cvg_index, d_index=d_index)))
-                num_of_metadata_disks = Conf.get(index, GconfKeys.METADATA_COUNT.value.format(node_id=node_id, cvg_index=cvg_index))
-                if num_of_metadata_disks:
-                    for m_index in range(num_of_metadata_disks):
-                        disk_list.append(Conf.get(index, GconfKeys.METADATA_DISK.value.
-                                                  format(node_id=node_id, cvg_index=cvg_index, m_index=m_index)))
+                for disk in ConftStoreSearch._get_data_disks(index, node_id, cvg_index):
+                    disk_list.append(disk)
+                for mdisk in ConftStoreSearch._get_metadata_disks(index, node_id, cvg_index):
+                    disk_list.append(mdisk)
             return disk_list
         except Exception as e:
             Log.error(f"Unable to fetch Disk list from GConf. Error {e}")

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -19,7 +19,6 @@
 Wrappeprs for using the search APIs from conf store
 """
 
-import enum
 import json
 
 from cortx.utils.conf_store import Conf


### PR DESCRIPTION
Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

# Problem Statement
- Write wrappers to get disk and cvg ids from gconf

# Design
-  Added 3 functions to:
Return list of CVGs for any given node using search APIs
Return list of disks for any given node and CVG using search APIs
Return list of disks for any given node using search APIs

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]: NA
- [ ] Side effects on other features (deployment/upgrade)? [Y/N] N
- [ ] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
