### PR TITLE
CORTX-28973: Enhance parser and filter of event analyzer for disk and cvgs

### DIFF
--- a/ha/core/event_analyzer/filter/filter.py
+++ b/ha/core/event_analyzer/filter/filter.py
@@ -195,8 +195,7 @@ class ClusterResourceFilter(Filter):
             required_resource_type_list = Conf.get(const.HA_GLOBAL_INDEX, f"CLUSTER{_DELIM}resource_type")
             if event_resource_type in required_resource_type_list:
                 resource_alert_required = True
-                # Log.info(f'This alert needs an attention: resource_type: {event_resource_type}')
-                Log.error(f'### This alert needs an attention: resource_type: {required_resource_type_list} {event_resource_type}')
+                Log.info(f'This alert needs an attention: resource_type: {event_resource_type}')
             return resource_alert_required
         except Exception as e:
             raise EventFilterException(f"Failed to filter cluster resource event. Message: {msg}, Error: {e}")

--- a/ha/core/event_analyzer/filter/filter.py
+++ b/ha/core/event_analyzer/filter/filter.py
@@ -192,10 +192,11 @@ class ClusterResourceFilter(Filter):
             Log.debug('Received alert from fault tolerance')
             event_resource_type = message.get("event").get(EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value).get(HEALTH_ATTRIBUTES.RESOURCE_TYPE.value)
 
-            required_resource_type = Conf.get(const.HA_GLOBAL_INDEX, f"NODE{_DELIM}resource_type")
-            if event_resource_type == required_resource_type:
+            required_resource_type_list = Conf.get(const.HA_GLOBAL_INDEX, f"CLUSTER{_DELIM}resource_type")
+            if event_resource_type in required_resource_type_list:
                 resource_alert_required = True
-                Log.info(f'This alert needs an attention: resource_type: {event_resource_type}')
+                # Log.info(f'This alert needs an attention: resource_type: {event_resource_type}')
+                Log.error(f'### This alert needs an attention: resource_type: {required_resource_type_list} {event_resource_type}')
             return resource_alert_required
         except Exception as e:
             raise EventFilterException(f"Failed to filter cluster resource event. Message: {msg}, Error: {e}")

--- a/ha/core/event_analyzer/parser/parser.py
+++ b/ha/core/event_analyzer/parser/parser.py
@@ -187,8 +187,8 @@ class ClusterResourceParser(Parser):
             resource_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_ID.value]
             event_type = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_STATUS.value]
             specific_info = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]
-            if source == HEALTH_EVENT_SOURCES.MONITOR.value:
-                if specific_info and specific_info.get("generation_id"):
+            if resource_type == "node":
+                if specific_info and specific_info.get("generation_id") and source == HEALTH_EVENT_SOURCES.MONITOR.value:
                     generation_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]["generation_id"]
                     specific_info = {"generation_id": generation_id, "pod_restart": 0}
 

--- a/ha/core/event_analyzer/parser/parser.py
+++ b/ha/core/event_analyzer/parser/parser.py
@@ -187,9 +187,10 @@ class ClusterResourceParser(Parser):
             resource_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_ID.value]
             event_type = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_STATUS.value]
             specific_info = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]
-            if specific_info and specific_info["generation_id"] and source == HEALTH_EVENT_SOURCES.MONITOR.value:
-                generation_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]["generation_id"]
-                specific_info = {"generation_id": generation_id, "pod_restart": 0}
+            if source == HEALTH_EVENT_SOURCES.MONITOR.value:
+                if specific_info and specific_info.get("generation_id"):
+                    generation_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]["generation_id"]
+                    specific_info = {"generation_id": generation_id, "pod_restart": 0}
 
             event = {
                 event_attr.SOURCE : source,
@@ -211,6 +212,7 @@ class ClusterResourceParser(Parser):
             Log.debug(f"Parsed {event} schema")
             health_event = HealthEvent.dict_to_object(event)
             Log.debug(f"Event {event[event_attr.EVENT_ID]} is parsed and converted to object.")
+            Log.error(f"#### Event {health_event} is parsed and converted to object.")
             return health_event
 
         except Exception as err:

--- a/ha/core/event_analyzer/parser/parser.py
+++ b/ha/core/event_analyzer/parser/parser.py
@@ -187,9 +187,9 @@ class ClusterResourceParser(Parser):
             resource_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_ID.value]
             event_type = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.RESOURCE_STATUS.value]
             specific_info = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]
-            if resource_type == "node":
+            if resource_type == CLUSTER_ELEMENTS.NODE.value:
                 if specific_info and specific_info.get("generation_id") and source == HEALTH_EVENT_SOURCES.MONITOR.value:
-                    generation_id = cluster_resource_alert["event"][EVENT_ATTRIBUTES.HEALTH_EVENT_PAYLOAD.value][HEALTH_ATTRIBUTES.SPECIFIC_INFO.value]["generation_id"]
+                    generation_id = specific_info["generation_id"]
                     specific_info = {"generation_id": generation_id, "pod_restart": 0}
 
             event = {

--- a/ha/core/event_analyzer/parser/parser.py
+++ b/ha/core/event_analyzer/parser/parser.py
@@ -212,7 +212,6 @@ class ClusterResourceParser(Parser):
             Log.debug(f"Parsed {event} schema")
             health_event = HealthEvent.dict_to_object(event)
             Log.debug(f"Event {event[event_attr.EVENT_ID]} is parsed and converted to object.")
-            Log.error(f"#### Event {health_event} is parsed and converted to object.")
             return health_event
 
         except Exception as err:

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -229,7 +229,7 @@ class ConfigCmd(Cmd):
                                               'consumer_id' : '1'},
                          'CLUSTER_STOP_MON' : {'message_type' : 'cluster_stop', 'consumer_group' : 'cluster_mon',
                                               'consumer_id' : '2'},
-                         'NODE': {'resource_type': 'node'},
+                         'CLUSTER': {'resource_type': ['node', 'disk', 'cvg']},
                          'SYSTEM_HEALTH' : {'num_entity_health_events' : 2}
                          }
 


### PR DESCRIPTION
# Problem Statement
Enhance parser and filter of event analyzer for disk and cvgs

# Design
Modify filter of event analyzer which will also filter disk and cvg alert. For that, ha.conf can be modified with list of required resource type as ['node', 'disk', 'cvg'] and then this list can be checked against incoming resource type and alert can be filtered. Parser can be modified to skip the check for specific info generation id for resource type other than "node"

# Coding
-  [ ] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [x] Side effects on other features (deployment/upgrade)? [Y/N] N
- [ ] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide


Testing detais:
1. Modified ha.conf

CLUSTER:
  resource_type:
  - node
  - disk
  - cvg
CLUSTER_STOP_MON:
  consumer_group: cluster_mon
  consumer_id: '2'
  message_type: cluster_stop
COMMON_CONFIG:
  cluster_id: 26c6dcbb2b6b4fcfafc2c9346585b756
  rack_id: '1'
  site_id: '1'
EVENT_MANAGER:
  consumer_group: health_monitor
  consumer_id: '1'
  message_type: health_events
  producer_id: system_health

Filtered and parsed for node alert:
2022-03-03 04:40:26 fault_tolerance [536]: ERROR [filter_event] ### This alert needs an attention: resource_type: ['node', 'disk', 'cvg'] node
2022-03-03 04:40:26 fault_tolerance [536]: ERROR [parse_event] #### Event {"source": "monitor", "event_id": "1646307624a8d2fec2ab0b489fa09016fdb44e4dc4", "event_type": "online", "severity": "informational", "site_id": "1", "rack_id": "1", "cluster_id": "26c6dcbb2b6b4fcfafc2c9346585b756", "storageset_id": "27d9b5122785444444444444444", "node_id": "27d9b5122785444444444444444", "host_id": "27d9b5122785444444444444444", "resource_type": "node", "timestamp": "1646307624", "resource_id": "27d9b5122785444444444444444", "specific_info": {"generation_id": "dummy-pod", "pod_restart": 0}} is parsed and converted to object.

Filtered and parsed for disk alert
2022-03-03 04:44:29 fault_tolerance [536]: ERROR [filter_event] ### This alert needs an attention: resource_type: ['node', 'disk', 'cvg'] disk
2022-03-03 04:44:29 fault_tolerance [536]: ERROR [parse_event] #### Event {"source": "monitor", "event_id": "16463078687773f9bfdaa24ea58b1990e1ada0385d", "event_type": "online", "severity": "informational", "site_id": "1", "rack_id": "1", "cluster_id": "26c6dcbb2b6b4fcfafc2c9346585b756", "storageset_id": "27d9b5122785444444444444444", "node_id": "27d9b5122785444444444444444", "host_id": "27d9b5122785444444444444444", "resource_type": "disk", "timestamp": "1646307868", "resource_id": "123xyz", "specific_info": {}} is parsed and converted to object.
