### PR TITLE
CORTX-28560: Fix multiple events publish issue (Alert publish validation skipped due to new change in schema)

### DIFF
--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -187,36 +187,41 @@ class ObjectMonitor(threading.Thread):
             True if it is published already
             False if it is a new alert
         """
-        if not isinstance(alert, dict):
-            return False
+        if isinstance(alert, str):
+            alert = json.loads(alert)
 
         incoming_alert = copy.deepcopy(alert)
 
-        header = incoming_alert["event"]["header"]
-        payload = incoming_alert["event"]["payload"]
+        try:
+            header = incoming_alert["header"]
+            payload = incoming_alert["payload"]
 
-        if payload["specific_info"].get("generation_id"):
-            alert_key = "%s_%s_%s" % (payload["node_id"],
-                                      payload["resource_type"],
-                                      payload["specific_info"]["generation_id"])
+            if payload["specific_info"].get("generation_id"):
+                alert_key = "%s_%s_%s" % (payload["node_id"],
+                                        payload["resource_type"],
+                                        payload["specific_info"]["generation_id"])
+            else:
+                alert_key = "%s_%s_%s" % (payload["node_id"],
+                                        payload["resource_type"],
+                                        payload["resource_id"])
+
+            # Alert which is getting repeated also has new timestamp.
+            # So timestamp field should be ignored for validation.
+            if "timestamp" in header.keys():
+                del incoming_alert["header"]["timestamp"]
+
+        except KeyError as err:
+            Log.error(f"Alert validation failed as key {err} not found")
+
         else:
-            alert_key = "%s_%s_%s" % (payload["node_id"],
-                                      payload["resource_type"],
-                                      payload["resource_id"])
+            incoming_alert_msg = json.dumps(payload, sort_keys=True)
+            published_alert = self._published_alerts.get(alert_key)
 
-        # Alert which is getting repeated also has new timestamp.
-        # So timestamp field should be ignored for validation.
-        if "timestamp" in header.keys():
-            del incoming_alert["event"]["header"]["timestamp"]
-
-        incoming_alert_msg = json.dumps(payload, sort_keys=True)
-        published_alert = self._published_alerts.get(alert_key)
-
-        if incoming_alert_msg == published_alert:
-            # Published already
-            return True
-        else:
-            # New alert
-            self._published_alerts[alert_key] = incoming_alert_msg
+            if incoming_alert_msg == published_alert:
+                # Published already
+                return True
+            else:
+                # New alert
+                self._published_alerts[alert_key] = incoming_alert_msg
 
         return False

--- a/ha/monitor/k8s/object_monitor.py
+++ b/ha/monitor/k8s/object_monitor.py
@@ -190,6 +190,10 @@ class ObjectMonitor(threading.Thread):
         if isinstance(alert, str):
             alert = json.loads(alert)
 
+        # Validation expects dictionary data type of alert
+        if not isinstance(alert, dict):
+            return False
+
         incoming_alert = copy.deepcopy(alert)
 
         try:

--- a/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
+++ b/ha/test/integration/k8s_monitor/test_no_duplicate_alerts.py
@@ -40,7 +40,7 @@ class MockAlert:
     @staticmethod
     def get_host_alert():
         # Alert without generation_id
-        return { "event": {
+        return {
                 "header":{
                     "version":"1.0",
                     "timestamp":"112255",
@@ -60,12 +60,11 @@ class MockAlert:
                     }
                 }
             }
-        }
 
     @staticmethod
     def get_pod_alert():
         # Alert with generation_id
-        return { "event":{
+        return {
                 "header":{
                     "version":"1.0",
                     "timestamp":"112233",
@@ -86,14 +85,13 @@ class MockAlert:
                     }
                 }
             }
-        }
 
     @staticmethod
     def toggle_status(alert):
-        if alert["event"]["payload"]["resource_status"] == "online":
-            alert["event"]["payload"]["resource_status"] = "offline"
+        if alert["payload"]["resource_status"] == "online":
+            alert["payload"]["resource_status"] = "offline"
         else:
-            alert["event"]["payload"]["resource_status"] = "online"
+            alert["payload"]["resource_status"] = "online"
         return alert
 
 
@@ -101,7 +99,7 @@ class MockAlert:
 if __name__ == "__main__":
     print("******** Testing K8s Not Publishing Duplicate Alerts ********")
     try:
-        ConfigManager.init("test_k8s_resource_monitor")
+        ConfigManager.init(None)
 
         pod_labels =  ['cortx-data', 'cortx-server']
         pod_label_str = ', '.join(pod_label for pod_label in pod_labels)


### PR DESCRIPTION
CORTX-28560: Alert publish validation skipped due to new change in schema

# Problem Statement
- Repeating already published k8s_monitor events 

# Design
Previously Event.json returned,
{'event': { 'header': {}, 'payload': {} }}
Now,
"{ 'header': {}, 'payload': {} }"
[CORTX-28560](https://jts.seagate.com/browse/CORTX-28560)

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
```
[root@cortx-ha-headless-svc ~]# python3 test_no_duplicate_alerts.py
******** Testing K8s Not Publishing Duplicate Alerts ********
2022-03-22 08:35:05 test_k8s_resource_monitor [360]: INFO [init] Started logging for service test_k8s_resource_monitor
Producer id: mock_producer, message_type: mock_message, partition: 1
2022-03-22 08:35:05 test_k8s_resource_monitor [360]: INFO [__init__] Initialization done for pod monitor
Publishing alert..
{'header': {'version': '1.0', 'timestamp': '112255', 'event_id': '11225568919c5ba8f88ad24cc18f632a75de115aca'}, 'payload': {'source': 'monitor', 'cluster_id': 'None', 'site_id': 'None', 'rack_id': 'None', 'storageset_id': 'None', 'node_id': 'dummy.colo.seagate.com', 'resource_type': 'host', 'resource_id': 'dummy.colo.seagate.com', 'resource_status': 'online', 'specific_info': {}}}
Publishing alert..
{'header': {'version': '1.0', 'timestamp': '112233', 'event_id': '11223368911c9b81b8d3c84305a49c191e6a8c3bb5'}, 'payload': {'source': 'monitor', 'cluster_id': 'None', 'site_id': 'None', 'rack_id': 'None', 'storageset_id': 'None', 'node_id': 'dummy0fff6f947e8aecc6a27a25b7329', 'resource_type': 'node', 'resource_id': 'dummy02fff6f947e8aecc6a27a25b7329', 'resource_status': 'online', 'specific_info': {'generation_id': 'cortx-data-dummy0'}}}
Publishing alert..
{'header': {'version': '1.0', 'timestamp': '112233', 'event_id': '11223368911c9b81b8d3c84305a49c191e6a8c3bb5'}, 'payload': {'source': 'monitor', 'cluster_id': 'None', 'site_id': 'None', 'rack_id': 'None', 'storageset_id': 'None', 'node_id': 'dummy0fff6f947e8aecc6a27a25b7329', 'resource_type': 'node', 'resource_id': 'dummy02fff6f947e8aecc6a27a25b7329', 'resource_status': 'offline', 'specific_info': {'generation_id': 'cortx-data-dummy0'}}}
Successfully verified the alert.
```


# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
