### PR TITLE
CORTX-28313 : Add debug option to HA_start

### DIFF
--- a/ha/k8s_setup/ha_start.py
+++ b/ha/k8s_setup/ha_start.py
@@ -5,6 +5,8 @@ import signal
 from subprocess import Popen, PIPE, STDOUT # nosec
 import sys
 
+AUTO_RESTART = 1
+
 driver_process = None
 
 my_parser = argparse.ArgumentParser(prog="ha_start",
@@ -13,7 +15,8 @@ my_parser = argparse.ArgumentParser(prog="ha_start",
                                     )
 
 my_parser.add_argument('--services', '-s', help='service_name', required=True, action='store')
-my_parser.add_argument('--config', '-c', help='config file', required=False, action='store')
+my_parser.add_argument('--config', '-c', help='config file url', required=False, action='store')
+my_parser.add_argument('--debug', '-d', help='debug level {0|1}', type=int, nargs='?', const=1, default=0, required=False, action='store')
 args = my_parser.parse_args()
 
 service_entry_mapping = {
@@ -26,44 +29,65 @@ def usage(prog: str):
         """
         Print usage instructions
         """
-        sys.stderr.write(
-            f"usage: {prog} [-h] <--config url> <--services service to start>...\n"
+        print(
+            f"usage: {prog} [-h] <-s/--services service to start> <-c/--config url> [-d/--debug [0|1]]...\n"
             f"where:\n"
-            f"--services health_monitor, fault_tolerance, k8s_monitor\n"
-            f"--config   Config URL\n")
+            f"-s --services health_monitor, fault_tolerance, k8s_monitor\n"
+            f"[-c --config   Config file URL : yaml://<file_path>] E.g. yaml:///etc/cortx/cluster.conf\n"
+            f"[-d --debug   [level]] (if level is not provided, then it considered as 1)"
+            f"\n\t\t0 : No debug.\n\t\t1 : Auto restarts child process if it dia.", file=sys.stderr, flush=True)
 
 def handle_signal(signum, frame):
     """
     Signal handler call beck function, to forward the received signal to driver process
     """
-    sys.stdout.write(f"Signal {signum} at frame {frame} received.")
-    sys.stdout.write(f"Sending {signum} to driver process pid: {driver_process.pid}.")
+    print(f"Signal {signum} at frame {frame} received.", flush=True)
+    print(f"Sending {signum} to driver process pid: {driver_process.pid}.", flush=True)
     driver_process.send_signal(signum)
 
-try:
-    if args.services not in service_entry_mapping:
-        sys.stdout.write('Please provide a valid service name')
-        usage('ha_start')
-        sys.exit(22)
-    # setting Signal handlers for all standered signals
-    signal.signal(signal.SIGABRT, handle_signal)
-    signal.signal(signal.SIGFPE, handle_signal)
-    signal.signal(signal.SIGILL, handle_signal)
-    signal.signal(signal.SIGINT, handle_signal)
-    signal.signal(signal.SIGSEGV, handle_signal)
-    signal.signal(signal.SIGTERM, handle_signal)
-
+def start_driver_process():
+    global driver_process
     driver_process = Popen(['/usr/bin/python3', service_entry_mapping[args.services]], shell=False, stdout=PIPE, stderr=STDOUT) # nosec
+    print(f"The driver process with pid {driver_process.pid}, and args {driver_process.args} started successfully.", flush=True)
 
-    sys.stdout.write(f"The driver process with pid {driver_process.pid}, and args {driver_process.args} started successfully.")
+def main(argv: list):
+    try:
+        print(str(args))
+        if args.debug not in [0,1]:
+            sys.stderr.write('Please provide a valid debug value.')
+            usage('ha_start')
+            sys.exit(22)
+        if args.services not in service_entry_mapping:
+            print('Please provide a valid service name', flush=True)
+            usage('ha_start')
+            sys.exit(22)
+        # setting Signal handlers for all standered signals
+        signal.signal(signal.SIGABRT, handle_signal)
+        signal.signal(signal.SIGFPE, handle_signal)
+        signal.signal(signal.SIGILL, handle_signal)
+        signal.signal(signal.SIGINT, handle_signal)
+        signal.signal(signal.SIGSEGV, handle_signal)
+        signal.signal(signal.SIGTERM, handle_signal)
 
-    # Poll process.stdout to show stdout live
-    while True:
-        output = driver_process.stdout.readline()
-        if driver_process.poll() is not None:
-            break
-        if output:
-            print(output.strip().decode("utf-8"))
-    exit(driver_process.poll())
-except Exception as proc_err:
-    sys.stderr.write(f'Driver execution stopped because of some reason: {proc_err}')
+        start_driver_process()
+
+        # Poll process.stdout to show stdout live
+        while True:
+            output = driver_process.stdout.readline()
+            if driver_process.poll() is not None:
+                if((args.debug&AUTO_RESTART)!=0):
+                    if output:
+                        print(output.strip().decode("utf-8"), flush=True)
+                    print(f'Warning: Driver \'{args.services}\' exited with return code: {driver_process.poll()}, restarting again.', flush=True)
+                    start_driver_process()
+
+                else:
+                    break
+            if output:
+                print(output.strip().decode("utf-8"), flush=True)
+        exit(driver_process.poll())
+    except Exception as proc_err:
+        print(f'Driver execution stopped because of some reason: {proc_err}', file=sys.stderr, flush=True)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Signed-off-by: Mukhtar Inamdar <mukhtar.p.inamdar@seagate.com>

# Problem Statement
- Add debug option to HA_start

# Design
-  Add debug option to HA_start (-d/--debug)
-  updated and corrected usage
- added flushing to ha_start

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
[test_ha_start_debug_option_3.txt](https://github.com/Seagate/cortx-ha/files/8371749/test_ha_start_debug_option_3.txt)


# Review Checklist
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: **N**
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N] **N**
- [x] Side effects on other features (deployment/upgrade)? [Y/N] **N**
- [x] Dependencies on other component(s)? [Y/N] **N**
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
[Debug option for cortx-ha](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/956891431/Debug+option+for+cortx-ha)
