### PR TITLE
CORTX-29037 : Remove 'pytest' dependency

### DIFF
--- a/ha/test/main.py
+++ b/ha/test/main.py
@@ -25,9 +25,12 @@
 import os
 import pathlib
 import sys
-import pytest
+import unittest
 
 if __name__ == '__main__':
+    loader = unittest.TestLoader()
     sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..'))
     path = sys.argv[1] if len(sys.argv) == 2 else os.path.join(os.path.dirname(pathlib.Path(__file__)), '.')
-    pytest.main(['-v', path])
+    test_suite = loader.discover(path)
+    runner = unittest.TextTestRunner()
+    runner.run(test_suite)


### PR DESCRIPTION
Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

# Problem Statement
-  CORTX-29037 : Remove 'pytest' dependency

# Design
-  cortx-ha granular image creation is failing due to newly added package `pytest`.  As per new HA test framework, pytest package is not required so removing pytest package from ha requirements ( for creation of granular image )

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N] NA
- [ ] Side effects on other features (deployment/upgrade)? [Y/N] N
- [ ] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

# Test Details:
Note :  Most of the testcases are failing due to unknown reason ( either it's a legacy code Or design changes )
 
[results_with_pytest.txt](https://github.com/Seagate/cortx-ha/files/8390289/results_with_pytest.txt)
[results_with_unittest.txt](https://github.com/Seagate/cortx-ha/files/8390295/results_with_unittest.txt)

