### PR TITLE
CORTX-29597 CORTX-30455 : (SystemHealth) Update HA conf store wrappers to get disk/CVG resource Ids from consul key & Adding debug check in ha_start

### DIFF
--- a/ha/const.py
+++ b/ha/const.py
@@ -57,7 +57,6 @@ HA_CONFIG_FILE="{}/ha.conf".format(CONFIG_DIR)
 FIDS_CONFIG_FILE="{}/fids.json".format(CONFIG_DIR)
 HA_GLOBAL_INDEX="ha_conf"
 SOURCE_CONFIG_FILE="{}/ha.conf".format(SOURCE_CONFIG_PATH)
-CLUSTER_GLOBAL_INDEX="cluster"
 BACKUP_DEST_DIR="/opt/seagate/cortx/ha_backup"
 BACKUP_DEST_DIR_CONF = "{}/conf".format(BACKUP_DEST_DIR)
 BACKUP_CONFIG_FILE="{}/ha.conf".format(BACKUP_DEST_DIR_CONF)

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -362,6 +362,14 @@ class SystemHealth(Subscriber):
             self._update(healthevent, updated_health, next_component=next_component)
 
     def _get_cvg_list(self, healthevent, match_with):
+        """
+        Parse system health key and get cvg id for matching criteria.
+        Args:
+            healthevent: health event of resource
+            match_with : Additional resource information to be matched with expecting key
+        Returns:
+            List of cvg ids.
+        """
         cvg_list = []
         cluster_prefix = self._prepare_key(CLUSTER_ELEMENTS.CLUSTER.value,
                                            cluster_id=healthevent.cluster_id)

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -415,6 +415,8 @@ class SystemHealth(Subscriber):
                     match_criteria = {CLUSTER_ELEMENTS.NODE.value: self.node_id,
                                       component_type: component_id}
                     cvg_list = self._get_cvg_list(healthevent, match_criteria)
+                    if len(cvg_list) > 1:
+                        Log.error(f"Expected only 1 cvg_id, but received {len(cvg_list)}")
                     self.cvg_id = cvg_list[0] if cvg_list else None
                     healthevent.specific_info[NODE_MAP_ATTRIBUTES.CVG_ID.value] = self.cvg_id
 

--- a/ha/core/system_health/system_health_manager.py
+++ b/ha/core/system_health/system_health_manager.py
@@ -63,9 +63,24 @@ class SystemHealthManager:
 
     def parse_key(self, lookup, match_with, prefix):
         """
-        lookup: cvg
-        match_with: {"node": "1", "device": "/dev/sdd"}
-        prefix: cluster_key
+        Parse the matching key and return values for the lookup(resource).
+        Args:
+            lookup: resource for that value to be parsed
+            match_with: {"node": "1", "device": "/dev/sdd"}
+            prefix: keys starts with this prefix.
+        Return:
+            List of values parsed from matching keys.
+
+        Example:
+            matched_keys = [
+                "cortx>ha>v1>cortx>ha>system>cluster>c01>site>1>rack>1>node>100>cvg>cvg-01>disk>/dev/sdd>health",
+                "cortx>ha>v1>cortx>ha>system>cluster>c01>site>1>rack>1>node>100>cvg>cvg-01>disk>/dev/sde>health"
+                ]
+            lookup: cvg
+            match_with: {"node": "100", "device": "/dev/sdd"}
+            prefix: "cortx>ha>v1>cortx>ha>system>cluster>c01"
+
+            Returns, values = ["cvg-01"]
         """
         match_str = [ _DELIM.join(i) for i in match_with.items() ]
         values = []

--- a/ha/fault_tolerance/fault_tolerance_driver.py
+++ b/ha/fault_tolerance/fault_tolerance_driver.py
@@ -25,7 +25,6 @@ from cortx.utils.log import Log
 from ha.core.config.config_manager import ConfigManager
 from ha.fault_tolerance.fault_monitor import HealthStatusMonitor
 from ha.fault_tolerance.cluster_stop_monitor import ClusterStopMonitor
-from ha.util.conf_store import ConftStoreSearch
 
 class FaultTolerance:
     """
@@ -41,7 +40,6 @@ class FaultTolerance:
         ConfigManager.init("fault_tolerance")
         self.node_fault_monitor = HealthStatusMonitor()
         self.cluster_stop_monitor = ClusterStopMonitor()
-        ConftStoreSearch()
 
     def set_sigterm(self, signum, frame):
         """

--- a/ha/k8s_setup/ha_start.py
+++ b/ha/k8s_setup/ha_start.py
@@ -65,7 +65,7 @@ def handle_debug_option():
 def main(argv: list):
     try:
         print(str(args))
-        if args.debug not in [0,1]:
+        if is_debug_build() and args.debug not in [0,1]:
             sys.stderr.write('Please provide a valid debug value.')
             usage('ha_start')
             sys.exit(22)

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -28,8 +28,6 @@ from ha.k8s_setup.const import CLUSTER_CARDINALITY_KEY, CLUSTER_CARDINALITY_NUM_
 from ha.k8s_setup.const import _DELIM, GconfKeys
 from cortx.utils.log import Log
 from ha.core.error import ClusterCardinalityError
-from ha.const import CLUSTER_GLOBAL_INDEX
-from cortx.utils.const import CLUSTER_CONF
 
 
 class ConftStoreSearch:
@@ -41,8 +39,6 @@ class ConftStoreSearch:
         """Init method"""
         if conf_store_req:
             self._confstore = ConfigManager.get_confstore()
-        # Load cluster config
-        ConfigManager._safe_load(CLUSTER_GLOBAL_INDEX, CLUSTER_CONF)
 
     @staticmethod
     def get_data_pods(index):
@@ -225,23 +221,3 @@ class ConftStoreSearch:
         except Exception as e:
             Log.error(f"Unable to fetch Disk list from GConf. Error {e}")
             raise Exception(f"Unable to fetch Disk list. Error {e}")
-
-
-    @staticmethod
-    def get_cvg_for_disk(node_id, disk_id):
-        """
-        Returns cvg id for given node_id and disk_id.
-        Args:
-            node_id (str): node id
-            disk_id (str): disk id
-        Returns:
-            cvg id in string format
-
-        >>> ConftStoreSearch.get_cvg_for_disk('21d6291109304485b3daff43a06cff77', '/dev/sdd')
-        'cvg-01'
-        """
-        cvg_list = ConftStoreSearch.get_cvg_list(CLUSTER_GLOBAL_INDEX, node_id)
-        for cvg_id in cvg_list:
-            if disk_id in ConftStoreSearch.get_disk_list_for_cvg(CLUSTER_GLOBAL_INDEX, node_id, cvg_id):
-                return cvg_id
-        return

--- a/ha/util/consul_kv_store.py
+++ b/ha/util/consul_kv_store.py
@@ -180,6 +180,14 @@ class ConsulKvStore:
         return data
 
     def get_keys(self, prefix):
+        """
+        Get list of values match with given prefix.
+        The requested keys will be stored with prefix for reference.
+        Args:
+            prefix(str): Prefix that matches with keys
+        Return:
+            List of keys
+        """
         if not ConsulKvStore._keys.get(prefix):
             ConsulKvStore._keys[prefix] = self._consul.kv.get(prefix, keys=True)[1]
         return ConsulKvStore._keys[prefix]

--- a/ha/util/consul_kv_store.py
+++ b/ha/util/consul_kv_store.py
@@ -23,6 +23,8 @@ from ha.const import HA_DELIM
 class ConsulKvStore:
     """ Represents a Consul kv Store """
 
+    _keys = {}
+
     def __init__(self, prefix: str, host: str="localhost", port: int=8500):
         """
         Consul KV store.
@@ -176,3 +178,8 @@ class ConsulKvStore:
         data = self.get(key)
         self._consul.kv.delete(self._prepare_key(key), recurse=recurse)
         return data
+
+    def get_keys(self, prefix):
+        if not ConsulKvStore._keys.get(prefix):
+            ConsulKvStore._keys[prefix] = self._consul.kv.get(prefix, keys=True)[1]
+        return ConsulKvStore._keys[prefix]


### PR DESCRIPTION
1. [CORTX-29597](https://jts.seagate.com/browse/CORTX-29597) - (SystemHealth) Update HA conf store wrappers to get disk/CVG resource Ids from consul key
2. [CORTX-30455](https://jts.seagate.com/browse/CORTX-30455) - HA container is crashed due to missing debug validation in ha_start.py

# Problem Statement
Code that was added to get cvg ids in system health process_event  function should be removed (added in PR https://github.com/Seagate/cortx-ha/pull/674/)

While testing above work, found container crash issue due to debug option validation in ha_start.py This PR includes that fix as well.

# Design
Remove /etc/cortx/cluster.conf dependency and get cvg_id from SystemHealth consul key.

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
https://jts.seagate.com/secure/attachment/511768/disk_test.txt
https://jts.seagate.com/secure/attachment/511813/cvg_test.txt

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
