### PR TITLE
CORTX-29399 : When pod is restarted via replicas or kubectl delete, pod_restart count is not set properly.

### DIFF
--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -420,9 +420,9 @@ class SystemHealth(Subscriber):
                     pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
                     # Update the current health value itself.
                     latest_health = EntityHealth.read(current_health)
-                    if stored_genration_id and (stored_genration_id != incoming_generation_id):
-                        # TODO: Add stored_status != offline. 
-                        if (incoming_health_status == HEALTH_EVENTS.ONLINE.value) and (stored_status != HEALTH_EVENTS.FAILED.value):
+                    # TODO: Add stored_status != offline.
+                    if stored_genration_id and (stored_genration_id != incoming_generation_id) and (stored_status != HEALTH_EVENTS.FAILED.value):
+                        if (incoming_health_status == HEALTH_EVENTS.ONLINE.value):
                             # In delete scenario, online event comes first, followed by failed event.
                             # System health is expected to update the failed event first, then online event.
                             # If incoming is online event, change the stored event type to failed.

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -421,6 +421,7 @@ class SystemHealth(Subscriber):
                     # Update the current health value itself.
                     latest_health = EntityHealth.read(current_health)
                     if stored_genration_id and (stored_genration_id != incoming_generation_id):
+                        # TODO: Add stored_status != offline. 
                         if (incoming_health_status == HEALTH_EVENTS.ONLINE.value) and (stored_status != HEALTH_EVENTS.FAILED.value):
                             # In delete scenario, online event comes first, followed by failed event.
                             # System health is expected to update the failed event first, then online event.

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -426,6 +426,7 @@ class SystemHealth(Subscriber):
                             # System health is expected to update the failed event first, then online event.
                             # If incoming is online event, change the stored event type to failed.
                             # Update the failed event in system health and followed by incoming online event.
+                            # If stored_status is set as failed, then no need to send alert, as its replicaset pod down.
                             healthevent.specific_info = {"generation_id": stored_genration_id, "pod_restart": 1}
                             healthevent.event_type = "failed"
                             updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -420,7 +420,7 @@ class SystemHealth(Subscriber):
                     # Update the current health value itself.
                     latest_health = EntityHealth.read(current_health)
                     if stored_genration_id and (stored_genration_id != incoming_generation_id):
-                        if incoming_health_status == HEALTH_EVENTS.ONLINE.value:
+                        if incoming_health_status in [HEALTH_EVENTS.ONLINE.value, status]:
                             # In delete scenario, online event comes first, followed by failed event.
                             # System health is expected to update the failed event first, then online event.
                             # If incoming is online event, change the stored event type to failed.

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -414,13 +414,14 @@ class SystemHealth(Subscriber):
                     and healthevent.source == HEALTH_EVENT_SOURCES.MONITOR.value:
                     # If health is already stored and its a node_health, check further
                     stored_genration_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
+                    stored_status = current_health_dict["events"][0]["status"]
                     incoming_generation_id = healthevent.specific_info["generation_id"]
                     incoming_health_status = healthevent.event_type
                     pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
                     # Update the current health value itself.
                     latest_health = EntityHealth.read(current_health)
                     if stored_genration_id and (stored_genration_id != incoming_generation_id):
-                        if incoming_health_status in [HEALTH_EVENTS.ONLINE.value, status]:
+                        if (incoming_health_status == HEALTH_EVENTS.ONLINE.value) and (stored_status != HEALTH_EVENTS.FAILED.value):
                             # In delete scenario, online event comes first, followed by failed event.
                             # System health is expected to update the failed event first, then online event.
                             # If incoming is online event, change the stored event type to failed.

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -422,12 +422,15 @@ class SystemHealth(Subscriber):
                     latest_health = EntityHealth.read(current_health)
                     # TODO: Add stored_status != offline.
                     if stored_genration_id and (stored_genration_id != incoming_generation_id) and (stored_status != HEALTH_EVENTS.FAILED.value):
+                        # If stored_generation_id and incoming_generation_id is not same means,
+                        # pod has been restarted, but for replicaset pod down/up,
+                        # stored_status is already set as failed, no need to count pod_restart,
+                        # in this case it will go to else part.
                         if (incoming_health_status == HEALTH_EVENTS.ONLINE.value):
                             # In delete scenario, online event comes first, followed by failed event.
                             # System health is expected to update the failed event first, then online event.
                             # If incoming is online event, change the stored event type to failed.
                             # Update the failed event in system health and followed by incoming online event.
-                            # If stored_status is set as failed, then no need to send alert, as its replicaset pod down.
                             healthevent.specific_info = {"generation_id": stored_genration_id, "pod_restart": 1}
                             healthevent.event_type = "failed"
                             updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)


### PR DESCRIPTION
Signed-off-by: gauri.bhosale <gauri.bhosale@seagate.com>

# Problem Statement
- When pod is restarted via replicas or kubectl delete, pod_restart count is not set properly.
- 

# Design
- system_health status checked incoming genericId and stored genericId if its not same 
checked for status but status not only my online it may 'starting' also  
# Coding
-  [X] Coding conventions are followed and code is consistent

# Testing 
- [X] Unit and System Tests are added
- [X] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [X] Testing was performed with RPM
- https://jts.seagate.com/secure/attachment/513156/Test_Results.txt

# Review Checklist 
- [X] PR is self reviewed
- [X] JIRA number/GitHub Issue added to PR
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Review Checklist 
- [X] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 


Testing result :https://jts.seagate.com/secure/attachment/513156/Test_Results.txt