### PR TITLE
CORTX-30057 : HA should accept events from CSM for resource status

### DIFF
--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -478,7 +478,10 @@ class SystemHealth(Subscriber):
                         updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
                         self._check_and_update(current_health, updated_health, healthevent, next_component)
                 else:
-                    # Update hierarchical components. such as site, rack
+                    # Update hierarchical components. such as node, site, rack
+                    if component_type == CLUSTER_ELEMENTS.NODE.value and healthevent.source == HEALTH_EVENT_SOURCES.CSM.value:
+                        generation_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
+                        healthevent.specific_info = {"generation_id": generation_id, "pod_restart": 0}
                     latest_health = EntityHealth.read(current_health)
                     updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
                     self._check_and_update(current_health, updated_health, healthevent, next_component)

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -478,10 +478,7 @@ class SystemHealth(Subscriber):
                         updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
                         self._check_and_update(current_health, updated_health, healthevent, next_component)
                 else:
-                    # Update hierarchical components. such as node, site, rack
-                    if component_type == CLUSTER_ELEMENTS.NODE.value and healthevent.source == HEALTH_EVENT_SOURCES.CSM.value:
-                        generation_id = current_health_dict["events"][0]["specific_info"]["generation_id"]
-                        healthevent.specific_info = {"generation_id": generation_id, "pod_restart": 0}
+                    # Update hierarchical components. such as site, rack
                     latest_health = EntityHealth.read(current_health)
                     updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, status, healthevent.specific_info, latest_health)
                     self._check_and_update(current_health, updated_health, healthevent, next_component)

--- a/ha/fault_tolerance/const.py
+++ b/ha/fault_tolerance/const.py
@@ -18,6 +18,7 @@ import enum
 from ha.util.enum_list import EnumListMeta
 
 class HEALTH_EVENT_SOURCES(enum.Enum, metaclass=EnumListMeta):
+    CSM = 'csm'
     HA = 'ha'
     HARE = 'hare'
     MONITOR = 'monitor'

--- a/ha/fault_tolerance/const.py
+++ b/ha/fault_tolerance/const.py
@@ -27,6 +27,7 @@ class HEALTH_EVENT_SOURCES(enum.Enum, metaclass=EnumListMeta):
 class FAULT_TOLERANCE_KEYS(enum.Enum, metaclass=EnumListMeta):
     HARE_HA_MESSAGE_TYPE = 'cortx_health_events'
     MONITOR_HA_MESSAGE_TYPE = 'cortx_health_events'
+    CSM_HA_MESSAGE_TYPE = 'cortx_health_events'
 
 # Used to set default value in const.HA_CONFIG_FILE
 # TODO : To be replaced by actual values when they are available in config

--- a/ha/fault_tolerance/fault_monitor.py
+++ b/ha/fault_tolerance/fault_monitor.py
@@ -71,7 +71,7 @@ class FaultMonitor:
 class HealthStatusMonitor(FaultMonitor):
     """
     Module responsible for:
-    -  consuming node messages from k8s monitor that come on message bus
+    -  consuming node messages from k8s monitor & csm that come on message bus
     -  analyzing the message and and publishing alert if required
     """
     def __init__(self):


### PR DESCRIPTION
Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

# Problem Statement
- Any 'source' based checks in fault_tolerance should be enhanced to accept 'csm' as a source for the events

# Design
-  Currently no checks present in HA for source filed, which are applicable for csm "failed" event.
-  Add "source" & "message_type" constants for CSM.

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added :  
[test_results.txt](https://github.com/Seagate/cortx-ha/files/8462020/test_results.txt)
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N] NA
- [ ] Side effects on other features (deployment/upgrade)? [Y/N] N
- [ ] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
