### PR TITLE
CORTX-29984: Get machine_id for control node

### DIFF
--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -43,7 +43,6 @@ CLUSTER_CARDINALITY_LIST_NODES = "node_list"
 class GconfKeys(enum.Enum):
     NODE_CONST = "node"
     SERVICE_CONST = "services"
-    TYPE_CONST = "type"
     NAME_CONST = "name"
     CVG_NAME = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}name"
     CVG_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}num_cvg"
@@ -51,4 +50,3 @@ class GconfKeys(enum.Enum):
     METADATA_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}num_metadata"
     DATA_DISK = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}data[{d_index}]"
     METADATA_DISK = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}metadata[{m_index}]"
-    CONTROL_NODE = "control_node"

--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -43,6 +43,7 @@ CLUSTER_CARDINALITY_LIST_NODES = "node_list"
 class GconfKeys(enum.Enum):
     NODE_CONST = "node"
     SERVICE_CONST = "services"
+    TYPE_CONST = "type"
     NAME_CONST = "name"
     CVG_NAME = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}name"
     CVG_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}num_cvg"
@@ -50,3 +51,4 @@ class GconfKeys(enum.Enum):
     METADATA_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}num_metadata"
     DATA_DISK = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}data[{d_index}]"
     METADATA_DISK = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}metadata[{m_index}]"
+    CONTROL_NODE = "control_node"

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -224,18 +224,28 @@ class ConftStoreSearch:
             raise Exception(f"Unable to fetch Disk list. Error {e}")
 
     @staticmethod
-    def get_control_node_id(index):
+    def get_control_pods(index):
         """
-        Get machine_id for control-node pod.
+        Returns machine_id for control-node pod.
+        Args:
+            index(str): index of conf file
+            parent key : node
+            search key: type
+            search val: control_node
+        Returns:
+            list: list of node_ids
+
+        >>> Conf.search("cortx", 'node', 'type', 'control_node')
+        ['node>a3710eee36644f2fb60ba19486664495>type']
         """
-        node_id = ''
+        node_ids = []
         try:
             node_key = Conf.search(index, GconfKeys.NODE_CONST.value,
                                    GconfKeys.TYPE_CONST.value, GconfKeys.CONTROL_NODE.value)
             for key in node_key:
-                node_id = key.split('>')[1]
-            Log.info(f"Fetched control node machine-id: {node_id}")
-            return node_id
+                value = key.split('>')[1]
+                node_ids.append(value)
+            Log.info(f"Fetched control node machine-id: {node_ids}")
         except Exception as e:
             Log.error(f"Unable to fetch control node machine-id. Error:{e}")
-
+        return node_ids

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -224,11 +224,18 @@ class ConftStoreSearch:
             raise Exception(f"Unable to fetch Disk list. Error {e}")
 
     @staticmethod
-    def get_control_pods(index):
+    def get_control_node_id(index):
         """
-        Returns list of control pod machine ids.
+        Get machine_id for control-node pod.
         """
-        node_id = []
-        # TODO: Control node id will be fetched using Conf store search
+        node_id = ''
+        try:
+            node_key = Conf.search(index, GconfKeys.NODE_CONST.value,
+                                   GconfKeys.TYPE_CONST.value, GconfKeys.CONTROL_NODE.value)
+            for key in node_key:
+                node_id = key.split('>')[1]
+            Log.info(f"Fetched control node machine-id: {node_id}")
+            return node_id
+        except Exception as e:
+            Log.error(f"Unable to fetch control node machine-id. Error:{e}")
 
-        return node_id

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -98,7 +98,7 @@ class ConftStoreSearch:
 
         data_pods = ConftStoreSearch.get_data_pods(index)
         server_pods = ConftStoreSearch.get_server_pods(index)
-        control_pods = ConftStoreSearch.get_control_pods(index)
+        control_pods = ConftStoreSearch.get_control_nodes(index)
 
         # Combine the lists data_pods, server_pod, control_pods and find unique machine ids
         watch_pods = data_pods + server_pods + control_pods
@@ -224,28 +224,27 @@ class ConftStoreSearch:
             raise Exception(f"Unable to fetch Disk list. Error {e}")
 
     @staticmethod
-    def get_control_pods(index):
+    def get_control_nodes(index):
         """
-        Returns machine_id for control-node pod.
+        Returns list of machine_ids for control-node.
         Args:
             index(str): index of conf file
             parent key : node
-            search key: type
-            search val: control_node
+            search key: name
+            search val: csm
         Returns:
             list: list of node_ids
 
-        >>> Conf.search("cortx", 'node', 'type', 'control_node')
-        ['node>a3710eee36644f2fb60ba19486664495>type']
+        >>> Conf.search("cortx", 'node', 'name', 'csm')
+        ['node>a3710eee36644f2fb60ba19486664495>components[1]>name']
         """
         node_ids = []
         try:
             node_key = Conf.search(index, GconfKeys.NODE_CONST.value,
-                                   GconfKeys.TYPE_CONST.value, GconfKeys.CONTROL_NODE.value)
+                                   GconfKeys.NAME_CONST.value, Const.COMPONENT_CSM.value)
             for key in node_key:
                 value = key.split('>')[1]
                 node_ids.append(value)
-            Log.info(f"Fetched control node machine-id: {node_ids}")
         except Exception as e:
             Log.error(f"Unable to fetch control node machine-id. Error:{e}")
         return node_ids


### PR DESCRIPTION
Signed-off-by: Palak Garg <palak.garg@seagate.com>

# Problem Statement
- Get machine_id for control node

# Design
- Added function in ConfStoreSearch class to fetch control node machine-id

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
https://jts.seagate.com/secure/attachment/512925/test_results.txt
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
[test_results.txt](https://github.com/Seagate/cortx-ha/files/8457234/test_results.txt)
