### PR TITLE
CORTX-29884: Get machine-id for control_node.

### DIFF
--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -98,7 +98,7 @@ class ConftStoreSearch:
 
         data_pods = ConftStoreSearch.get_data_pods(index)
         server_pods = ConftStoreSearch.get_server_pods(index)
-        control_pods = ConftStoreSearch.get_control_pods(index)
+        control_pods = ConftStoreSearch.get_control_nodes(index)
 
         # Combine the lists data_pods, server_pod, control_pods and find unique machine ids
         watch_pods = data_pods + server_pods + control_pods
@@ -224,11 +224,26 @@ class ConftStoreSearch:
             raise Exception(f"Unable to fetch Disk list. Error {e}")
 
     @staticmethod
-    def get_control_pods(index):
+    def get_control_nodes(index):
         """
-        Returns list of control pod machine ids.
+        Returns list of machine_ids for control-node.
+        Args:
+            index(str): index of conf file
+            parent key : node
+            search key: name
+            search val: csm
+        Returns:
+            list: list of node_ids
+        >>> Conf.search("cortx", 'node', 'name', 'csm')
+        ['node>a3710eee36644f2fb60ba19486664495>components[1]>name']
         """
-        node_id = []
-        # TODO: Control node id will be fetched using Conf store search
-
-        return node_id
+        node_ids = []
+        try:
+            node_key = Conf.search(index, GconfKeys.NODE_CONST.value,
+                                    GconfKeys.NAME_CONST.value, Const.COMPONENT_CSM.value)
+            for key in node_key:
+                value = key.split('>')[1]
+                node_ids.append(value)
+        except Exception as e:
+            Log.error(f"Unable to fetch control node machine-id. Error:{e}")
+        return node_ids


### PR DESCRIPTION
Signed-off-by: Palak Garg <palak.garg@seagate.com>

# Problem Statement
- Get machine-id for control_node.

# Design
- Added function to fetch machine-id from control_node in HA's conf_stor.py file

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
https://jts.seagate.com/secure/attachment/513161/test_results.txt

*Note:  This PR is duplicate of PR: https://github.com/Seagate/cortx-ha/pull/683
All review comments were received , discussed, closed on PR 683 and all approvals are also there on that same PR
However when the base branch was changed from main to fault_k8s PR 683 started showing DCO failures.  This fresh PR is started on fault_k8s main directly with same code changes to avoid DCO failures*
