### PR TITLE
CORTX-30061 : The current status of resources as 'failed' to be conve…

### DIFF
--- a/ha/core/system_health/const.py
+++ b/ha/core/system_health/const.py
@@ -49,6 +49,7 @@ class HEALTH_EVENTS(Enum):
     RECOVERING = "recovering"
     ONLINE = "online"
     FAILED = "failed"
+    OFFLINE = "offline"
     DEGRADED = "degraded"
     THRESHOLD_BREACHED_LOW = "threshold_breached:low"
     THRESHOLD_BREACHED_HIGH = "threshold_breached:high"

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -293,10 +293,9 @@ class SystemHealth(Subscriber):
 
         # specific cases
         # TODO : CORTX-30819 : Decide when to mark resource as "online" after permanent failure.
-        # 1. Failed status can be overwritten only by online event
+        # 1. Failed status can be overwritten only by starting event
         if event.resource_type == RESOURCE_TYPES.NODE.value and \
-            old_status == HEALTH_STATUSES.FAILED.value and \
-            new_status in [HEALTH_STATUSES.OFFLINE.value, HEALTH_STATUSES.DEGRADED.value, HEALTH_STATUSES.RECOVERING.value]:
+            old_status == HEALTH_STATUSES.FAILED.value and new_status != HEALTH_STATUSES.STARTING.value:
             Log.info(f"Updating is not needed node is in {old_status} state and received {new_status} state")
             event_action = HEALTH_EVENT_ACTIONS.IGNORE.value
 

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -292,10 +292,10 @@ class SystemHealth(Subscriber):
             event_action = HEALTH_EVENT_ACTIONS.IGNORE.value
 
         # specific cases
-        # 1. Do not overwrite node status to offline if failed already
+        # 1. Failed status can be overwritten only by online event
         if event.resource_type == RESOURCE_TYPES.NODE.value and \
-            old_status == HEALTH_STATUSES.FAILED.value and new_status == HEALTH_STATUSES.OFFLINE.value:
-            Log.info(f"Updating is not needed node is in {old_status} and received {new_status}")
+            old_status == HEALTH_STATUSES.FAILED.value and new_status != HEALTH_STATUSES.ONLINE.value:
+            Log.info(f"Updating is not needed node is in {old_status} state and received {new_status} state")
             event_action = HEALTH_EVENT_ACTIONS.IGNORE.value
 
         return event_action

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -292,6 +292,7 @@ class SystemHealth(Subscriber):
             event_action = HEALTH_EVENT_ACTIONS.IGNORE.value
 
         # specific cases
+        # TODO : CORTX-30819 : Decide when to mark resource as "online" after permanent failure.
         # 1. Failed status can be overwritten only by online event
         if event.resource_type == RESOURCE_TYPES.NODE.value and \
             old_status == HEALTH_STATUSES.FAILED.value and \

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -294,7 +294,8 @@ class SystemHealth(Subscriber):
         # specific cases
         # 1. Failed status can be overwritten only by online event
         if event.resource_type == RESOURCE_TYPES.NODE.value and \
-            old_status == HEALTH_STATUSES.FAILED.value and new_status != HEALTH_STATUSES.ONLINE.value:
+            old_status == HEALTH_STATUSES.FAILED.value and \
+            new_status in [HEALTH_STATUSES.OFFLINE.value, HEALTH_STATUSES.DEGRADED.value, HEALTH_STATUSES.RECOVERING.value]:
             Log.info(f"Updating is not needed node is in {old_status} state and received {new_status} state")
             event_action = HEALTH_EVENT_ACTIONS.IGNORE.value
 

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -266,7 +266,7 @@ class ConfigCmd(Cmd):
 
             Log.info('Performing event_manager subscription')
             event_manager = EventManager.get_instance()
-            event_manager.subscribe(const.EVENT_COMPONENT, [SubscribeEvent(const.POD_EVENT, ["online", "failed"])])
+            event_manager.subscribe(const.EVENT_COMPONENT, [SubscribeEvent(const.POD_EVENT, ["online", "offline", "failed"])])
             Log.info(f'event_manager subscription for {const.EVENT_COMPONENT}\
                        is successful for the event {const.POD_EVENT}')
             event_manager.subscribe(const.EVENT_COMPONENT, [SubscribeEvent(const.DISK_EVENT, ["online", "failed"])])

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -59,7 +59,7 @@ class NodeEventParser(ObjectParser):
         Args:
         res_type: resource_type for which event needs to be created. Ex: node, disk
         res_name: actual resource name. Ex: machine_id in case of node alerts
-        health_status: health of that resource. Ex: online, failed
+        health_status: health of that resource. Ex: online, offline
         """
         self.payload[HealthAttr.RESOURCE_TYPE.value] = res_type
         self.payload[HealthAttr.RESOURCE_ID.value] = self.payload[HealthAttr.NODE_ID.value] = res_name
@@ -111,7 +111,7 @@ class NodeEventParser(ObjectParser):
                     return health_alert, self.event
                 elif cached_state[resource_name] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
                     cached_state[resource_name] = ready_status.lower()
-                    event_type = AlertStates.FAILED
+                    event_type = AlertStates.OFFLINE
                     health_alert = self._create_health_alert(resource_type, resource_name, event_type)
                     return health_alert, self.event
                 else:
@@ -143,7 +143,7 @@ class PodEventParser(ObjectParser):
         Args:
         res_type: resource_type for which event needs to be created. Ex: node, disk
         res_name: actual resource name. Ex: machine_id in case of node alerts
-        health_status: health of that resource. Ex: online, failed
+        health_status: health of that resource. Ex: online, offline
         generation_id: name of the node in case of node alert
         """
         self.payload[HealthAttr.RESOURCE_TYPE.value] = res_type
@@ -203,7 +203,7 @@ class PodEventParser(ObjectParser):
                     return health_alert, self.event
                 elif cached_state[resource_name] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
                     cached_state[resource_name] = ready_status.lower()
-                    event_type = AlertStates.FAILED
+                    event_type = AlertStates.OFFLINE
                     health_alert = self._create_health_alert(resource_type, resource_name, event_type, generation_id)
                     return health_alert, self.event
                 else:


### PR DESCRIPTION
…rted to 'offline' for all resources

Signed-off-by: Akash Dudhane <akash.a.dudhane@seagate.com>

# Problem Statement
- [CORTX-30061](https://jts.seagate.com/browse/CORTX-30061)
The current status of resources as 'failed' to be converted to 'offline' for all resources

# Design
-  At all places in HA and k8s monitor, existing 'failed' state should be converted to 'offline' wherever its being sent/assigned

# Coding
-  [ ] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
[test_results.txt](https://jts.seagate.com/secure/attachment/513615/30061_test_results.txt)
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: N
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N] NA
- [ ] Side effects on other features (deployment/upgrade)? [Y/N] N
- [ ] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
