### PR TITLE
CORTX-29931 : Enhance System health schema for control node 

### DIFF
--- a/ha/core/event_manager/resources.py
+++ b/ha/core/event_manager/resources.py
@@ -66,3 +66,8 @@ class RESOURCE_TYPES(enum.Enum, metaclass=EnumListMeta):
     NODE_SW_OS_SERVICE = "node:sw:os:service"
     CVG = "cvg"
     DISK = "disk"
+
+class NODE_FUNCTIONAL_TYPES(enum.Enum, metaclass=EnumListMeta):
+    SERVER = "server"
+    DATA = "data"
+    CONTROL = "control"

--- a/ha/core/system_health/const.py
+++ b/ha/core/system_health/const.py
@@ -93,3 +93,8 @@ class HEALTH_EVENT_ACTIONS(Enum):
     UPDATE = "update"
     UPDATEPUBLISH = "updatepublish"
     PUBLISH = "publish"
+
+# Specific_info attributes
+class SPECIFIC_INFO_ATTRIBUTES(Enum):
+    GENERATION_ID = 'generation_id'
+    FUNCTIONAL_TYPE = 'functional_type'

--- a/ha/core/system_health/const.py
+++ b/ha/core/system_health/const.py
@@ -49,6 +49,7 @@ class HEALTH_EVENTS(Enum):
     RECOVERING = "recovering"
     ONLINE = "online"
     FAILED = "failed"
+    OFFLINE = "offline"
     DEGRADED = "degraded"
     THRESHOLD_BREACHED_LOW = "threshold_breached:low"
     THRESHOLD_BREACHED_HIGH = "threshold_breached:high"

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -292,11 +292,13 @@ class SystemHealth(Subscriber):
             event_action = HEALTH_EVENT_ACTIONS.IGNORE.value
 
         # specific cases
-        # 1. Do not overwrite node status to failed if offline already
+        # TODO : CORTX-30819 : Decide when to mark resource as "online" after permanent failure.
+        # 1. Failed status can be overwritten only by starting event
         if event.resource_type == RESOURCE_TYPES.NODE.value and \
-            old_status == HEALTH_STATUSES.OFFLINE.value and new_status == HEALTH_STATUSES.FAILED.value:
-            Log.info(f"Updating is not needed node is in {old_status} and received {new_status}")
+            old_status == HEALTH_STATUSES.FAILED.value and new_status != HEALTH_STATUSES.STARTING.value:
+            Log.info(f"Updating is not needed node is in {old_status} state and received {new_status} state")
             event_action = HEALTH_EVENT_ACTIONS.IGNORE.value
+
         return event_action
 
     def publish_event(self, healthevent: HealthEvent):
@@ -447,21 +449,20 @@ class SystemHealth(Subscriber):
                     pod_restart_val = current_health_dict["events"][0]["specific_info"]["pod_restart"]
                     # Update the current health value itself.
                     latest_health = EntityHealth.read(current_health)
-                    # TODO: Add stored_status != offline.
-                    if stored_genration_id and (stored_genration_id != incoming_generation_id) and (stored_status != HEALTH_EVENTS.FAILED.value):
+                    if stored_genration_id and (stored_genration_id != incoming_generation_id) and stored_status not in [HEALTH_EVENTS.OFFLINE.value, HEALTH_EVENTS.FAILED.value]:
                         # If stored_generation_id and incoming_generation_id is not same means,
                         # pod has been restarted, but for replicaset pod down/up,
-                        # stored_status is already set as failed, no need to count pod_restart,
+                        # stored_status is already set as offline/failed, no need to count pod_restart,
                         # in this case it will go to else part.
                         if (incoming_health_status == HEALTH_EVENTS.ONLINE.value):
-                            # In delete scenario, online event comes first, followed by failed event.
-                            # System health is expected to update the failed event first, then online event.
-                            # If incoming is online event, change the stored event type to failed.
-                            # Update the failed event in system health and followed by incoming online event.
+                            # In delete scenario, online event comes first, followed by offline event.
+                            # System health is expected to update the offline event first, then online event.
+                            # If incoming is online event, change the stored event type to offline.
+                            # Update the offline event in system health and followed by incoming online event.
                             healthevent.specific_info = {"generation_id": stored_genration_id, "pod_restart": 1}
-                            healthevent.event_type = "failed"
+                            healthevent.event_type = "offline"
                             updated_health = SystemHealth.create_updated_event_object(healthevent.timestamp, current_timestamp, healthevent.event_type, healthevent.specific_info, latest_health)
-                            # Create a "failed" event and update it in system health and publish
+                            # Create a "offline" event and update it in system health and publish
                             self._check_and_update(current_health, updated_health, healthevent, next_component)
                             current_health = updated_health
                             # Now create an "online" event and update it in system health and publish

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -440,6 +440,7 @@ class SystemHealth(Subscriber):
                 current_health_dict = json.loads(current_health)
                 specific_info = current_health_dict["events"][0]["specific_info"]
                 if (component_type == CLUSTER_ELEMENTS.NODE.value) and specific_info \
+                    and specific_info.get('generation_id', None) \
                     and healthevent.source == HEALTH_EVENT_SOURCES.MONITOR.value:
                     # If health is already stored and its a node_health, check further
                     stored_genration_id = current_health_dict["events"][0]["specific_info"]["generation_id"]

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -266,7 +266,7 @@ class ConfigCmd(Cmd):
 
             Log.info('Performing event_manager subscription')
             event_manager = EventManager.get_instance()
-            event_manager.subscribe(const.EVENT_COMPONENT, [SubscribeEvent(const.POD_EVENT, ["online", "failed"])])
+            event_manager.subscribe(const.EVENT_COMPONENT, [SubscribeEvent(const.POD_EVENT, ["online", "offline", "failed"])])
             Log.info(f'event_manager subscription for {const.EVENT_COMPONENT}\
                        is successful for the event {const.POD_EVENT}')
             event_manager.subscribe(const.EVENT_COMPONENT, [SubscribeEvent(const.DISK_EVENT, ["online", "failed"])])

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -37,8 +37,9 @@ from ha.core.error import SetupError
 from ha.k8s_setup.const import _DELIM
 from ha.core.event_manager.event_manager import EventManager
 from ha.core.event_manager.subscribe_event import SubscribeEvent
+from ha.core.event_manager.resources import NODE_FUNCTIONAL_TYPES
 from ha.util.conf_store import ConftStoreSearch
-from ha.core.system_health.const import CLUSTER_ELEMENTS, HEALTH_EVENTS, EVENT_SEVERITIES, NODE_MAP_ATTRIBUTES
+from ha.core.system_health.const import CLUSTER_ELEMENTS, HEALTH_EVENTS, EVENT_SEVERITIES, NODE_MAP_ATTRIBUTES, SPECIFIC_INFO_ATTRIBUTES
 from ha.const import EVENT_ATTRIBUTES
 from ha.fault_tolerance.const import FAULT_TOLERANCE_KEYS, HEALTH_EVENT_SOURCES, NOT_DEFINED
 from ha.core.system_health.model.health_event import HealthEvent
@@ -316,10 +317,22 @@ class ConfigCmd(Cmd):
         Add node health
         """
         _, nodes_list = self._confStoreAPI.get_cluster_cardinality()
+        data_node_ids = self._confStoreAPI.get_data_pods(self._index)
+        server_node_ids = self._confStoreAPI.get_server_pods(self._index)
+        control_node_ids = self._confStoreAPI.get_control_nodes(self._index)
         for node in nodes_list:
+            functional_type = None
+            if node in data_node_ids:
+                functional_type = NODE_FUNCTIONAL_TYPES.DATA.value
+            elif node in server_node_ids:
+                functional_type = NODE_FUNCTIONAL_TYPES.SERVER.value
+            elif node in control_node_ids:
+                functional_type = NODE_FUNCTIONAL_TYPES.CONTROL.value
+            specific_info = {SPECIFIC_INFO_ATTRIBUTES.FUNCTIONAL_TYPE.value: functional_type}
             self._add_health_event(node_id=node,
                                    resource_type=CLUSTER_ELEMENTS.NODE.value,
-                                   resource_id=node)
+                                   resource_id=node,
+                                   specific_info=specific_info)
 
     def _add_cvg_and_disk_health(self) -> None:
         """

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -59,7 +59,7 @@ class NodeEventParser(ObjectParser):
         Args:
         res_type: resource_type for which event needs to be created. Ex: node, disk
         res_name: actual resource name. Ex: machine_id in case of node alerts
-        health_status: health of that resource. Ex: online, failed
+        health_status: health of that resource. Ex: online, offline
         """
         self.payload[HealthAttr.RESOURCE_TYPE.value] = res_type
         self.payload[HealthAttr.RESOURCE_ID.value] = self.payload[HealthAttr.NODE_ID.value] = res_name
@@ -111,7 +111,7 @@ class NodeEventParser(ObjectParser):
                     return health_alert, self.event
                 elif cached_state[resource_name] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
                     cached_state[resource_name] = ready_status.lower()
-                    event_type = AlertStates.FAILED
+                    event_type = AlertStates.OFFLINE
                     health_alert = self._create_health_alert(resource_type, resource_name, event_type)
                     return health_alert, self.event
                 else:
@@ -143,7 +143,7 @@ class PodEventParser(ObjectParser):
         Args:
         res_type: resource_type for which event needs to be created. Ex: node, disk
         res_name: actual resource name. Ex: machine_id in case of node alerts
-        health_status: health of that resource. Ex: online, failed
+        health_status: health of that resource. Ex: online, offline
         generation_id: name of the node in case of node alert
         """
         self.payload[HealthAttr.RESOURCE_TYPE.value] = res_type
@@ -203,7 +203,7 @@ class PodEventParser(ObjectParser):
                     return health_alert, self.event
                 elif cached_state[resource_name] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
                     cached_state[resource_name] = ready_status.lower()
-                    event_type = AlertStates.FAILED
+                    event_type = AlertStates.OFFLINE
                     health_alert = self._create_health_alert(resource_type, resource_name, event_type, generation_id)
                     return health_alert, self.event
                 else:


### PR DESCRIPTION
added functional_type into specific_info during mini provisioning
later specific_info will be overwritten in k8s monitor and system_health, that will be handle in another PR.

Signed-off-by: gauri.bhosale <gauri.bhosale@seagate.com>

# Problem Statement
- https://jts.seagate.com/browse/CORTX-29931

# Design
- detect functional_Type using confstoreAPI
- add functional_type in json specific_info during mini provisioning
-

# Coding
-  [X] Coding conventions are followed and code is consistent

# Testing 
- [X] Testing was performed with RPM
- https://jts.seagate.com/secure/attachment/514398/Test_Results.txt

# Review Checklist 
- [X] PR is self reviewed
- [X] JIRA number/GitHub Issue added to PR
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained

# Review Checklist 
- [X] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [X] Changes done to WIKI / Confluence page / Quick Start Guide
- https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/891781277/Action+Status+Update+LLD#specific_info%3A
https://jts.seagate.com/secure/attachment/514398/Test_Results.txt