### PR TITLE
Cortx-29991: Event Subscription: API enhancements

### DIFF
--- a/ha/core/event_manager/event_manager.py
+++ b/ha/core/event_manager/event_manager.py
@@ -359,7 +359,6 @@ class EventManager:
                     self._delete_component_key(component, event.resource_type, func_type, event.states)
                     self._delete_event_key(component, event.resource_type, func_type, event.states)
                     for state in event.states:
-                        Log.error(f'{state}')
                         key = EVENT_MANAGER_KEYS.EVENT_KEY.value.replace(
                             "<resource>", event.resource_type).replace(
                                 "<functional_type>", func_type).replace(

--- a/ha/core/event_manager/event_manager.py
+++ b/ha/core/event_manager/event_manager.py
@@ -32,7 +32,7 @@ from ha.core.event_manager.error import InvalidEvent
 from ha.core.event_manager.error import SubscribeException
 from ha.core.event_manager.error import UnSubscribeException
 from ha.core.event_manager.error import PublishException
-from ha.core.event_manager.resources import SUBSCRIPTION_LIST, FUNCTIONAL_TYPES, NODE_FUNCTIONAL_TYPES
+from ha.core.event_manager.resources import SUBSCRIPTION_LIST, FUNCTIONAL_TYPES
 from ha.core.event_manager.const import EVENT_MANAGER_KEYS
 from ha.core.health_monitor.const import HEALTH_MON_ACTIONS
 from ha.core.health_monitor.monitor_rules_manager import MonitorRulesManager

--- a/ha/core/event_manager/event_manager.py
+++ b/ha/core/event_manager/event_manager.py
@@ -356,7 +356,6 @@ class EventManager:
                 action = HEALTH_MON_ACTIONS.PUBLISH_ACT.value
             for event in events:
                 for func_type in event.functional_types:
-                    Log.error(f'{event.resource_type}')
                     self._delete_component_key(component, event.resource_type, func_type, event.states)
                     self._delete_event_key(component, event.resource_type, func_type, event.states)
                     for state in event.states:

--- a/ha/core/health_monitor/monitor_rules_manager.py
+++ b/ha/core/health_monitor/monitor_rules_manager.py
@@ -146,7 +146,7 @@ class MonitorRulesManager:
             val = json.dumps(val)
             self._confstore.set(key, val)
 
-    def remove_rule(self, resource: str, event: HEALTH_STATUSES , action: HEALTH_MON_ACTIONS):
+    def remove_rule(self, resource: str, func_type: str, event: HEALTH_STATUSES , action: HEALTH_MON_ACTIONS):
         """
         For the rule resource/event  remove "action" from confstore.
         If actions list becomes empty, delete the rule
@@ -157,7 +157,7 @@ class MonitorRulesManager:
             action(str): action to be removed
         """
         self._validate_action(action)
-        key = self._prepare_key(resource, event)
+        key = self._prepare_key(resource, event, func_type)
         val = []
         Log.info(f"Removing rule for key: {key} ,value: {action}")
         kv = self._get_val(key)

--- a/ha/test/integration/health_monitor/test_event_subscriber.py
+++ b/ha/test/integration/health_monitor/test_event_subscriber.py
@@ -53,26 +53,21 @@ class TestEventManager(unittest.TestCase):
     def test_subscriber_with_functional_type(self):
         # pod event with functional type
         self.event_manager.subscribe(self.component, [self.pod_event_with_func_type])
-        # TODO: CORTX-29991 will validate unsubscribe
-        #self.event_manager.unsubscribe(self.component, [self.pod_event_with_func_type])
+        self.event_manager.unsubscribe(self.component, [self.pod_event_with_func_type])
 
     def test_subscriber_without_functional_type(self):
         # pod event without functional type
         self.event_manager.subscribe(self.component, [self.pod_event_without_func_type])
-        # TODO: CORTX-29991 will validate unsubscribe
-        #self.event_manager.unsubscribe(self.component, [self.pod_event_without_func_type])
+        self.event_manager.unsubscribe(self.component, [self.pod_event_without_func_type])
 
         # disk event without functional type
         self.event_manager.subscribe(self.component, [self.disk_event_without_func_type])
-        # TODO: CORTX-29991 will validate unsubscribe
-        #self.event_manager.unsubscribe(self.component, [self.disk_event_without_func_type])
+        self.event_manager.unsubscribe(self.component, [self.disk_event_without_func_type])
 
     def test_subscriber_with_functional_type_all(self):
         # pod event without functional type
         self.event_manager.subscribe(self.component, [self.pod_event_with_func_type_all])
-        # TODO: CORTX-29991 will validate unsubscribe
-        #self.event_manager.unsubscribe(self.component, [self.pod_event_with_func_type_all])
-
+        self.event_manager.unsubscribe(self.component, [self.pod_event_with_func_type_all])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Problem Statement
 HA subscription keys now include functional type as well such as 'date', 'server', 'control'. So, the new keys will look like:
    cortx>ha>v2>events>node>server>offline
    cortx>ha>v2>events>subscribe>hare:["node>server>offline"]
Need to verify if this is happening correctly or not. Also, after un-subscription,
    keys and values needs to be deleted properly. To achieve this, SubscribeEvent class
    will accept one more List parameter now which contains functional_type list.
    Ex:
    SubscribeEvent('node', ["online", "offline", "failed"], ['data'])
    This means, someone is subscribing to date node alerts for the events online, failed
    and offline


**https://jts.seagate.com/browse/CORTX-29991**

# Design
Modify HA mini provisioning to make new subscription

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
https://jts.seagate.com/secure/attachment/515571/CORTX-29991_Test_Results.txt

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide


Tested the publish option:

1. Published node failed alert using mock_monitor. This time, I sent functional_type and generation_id both in the specific_info:
[root@cortx-ha-headless-svc /]# python3 /tmp/mock_health_event_publisher.py publish -f /tmp/config.json
Publishing health event {"header": {"version": "1.0", "timestamp": "1651052909.09883", "event_id": "1651052909.09883866fa2f0282543a4b86d9992e2adf7b4"}, "payload": {"source": "hare", "cluster_id": "803b244e189a4e7c92183027af8111c2", "site_id": "NOT_DEFINED", "rack_id": "NOT_DEFINED", "storageset_id": "1", "node_id": "cfe8de9a6ed04cc6bc032aea64147bd8", "resource_type": "node", "resource_id": "cfe8de9a6ed04cc6bc032aea64147bd8", "resource_status": "failed", "specific_info": {"generation_id": "cortx-data-ssc-vm-rhev4-2391-84466ccfcf-9r7kd", "functional_type": "data"}}}

System health after:
cortx>ha>v2>cortx>ha>system>cluster>803b244e189a4e7c92183027af8111c2>site>NOT_DEFINED>rack>NOT_DEFINED>node>cfe8de9a6ed04cc6bc032aea64147bd8>health:{"events": [{"event_timestamp": "1651052909.09883", "created_timestamp": "1651052910", "status": "failed", "specific_info": {"generation_id": "cortx-data-ssc-vm-rhev4-2391-84466ccfcf-9r7kd", "functional_type": "data", "pod_restart": 0}}, {"event_timestamp": "1651052400.8897002", "created_timestamp": "1651052401", "status": "starting", "specific_info": {"generation_id": "cortx-data-ssc-vm-rhev4-2391-84466ccfcf-9r7kd", "is_status": "True", "pod_restart": 0}}], "action": {"modified_timestamp": "1651052910", "status": "pending"}, "attributes": {}}

2022-04-27 09:48:30 health_monitor [8]: INFO [evaluate] Evaluated action ['publish'] for key action>node>data>failed
2022-04-27 09:48:30 health_monitor [8]: INFO [process_event] Evaluated {"source": "hare", "event_id": "1651052909.09883866fa2f0282543a4b86d9992e2adf7b4", "event_type": "failed", "severity": "error", "site_id": "NOT_DEFINED", "rack_id": "NOT_DEFINED", "cluster_id": "803b244e189a4e7c92183027af8111c2", "storageset_id": "cfe8de9a6ed04cc6bc032aea64147bd8", "node_id": "cfe8de9a6ed04cc6bc032aea64147bd8", "host_id": "cfe8de9a6ed04cc6bc032aea64147bd8", "resource_type": "node", "timestamp": "1651052909.09883", "resource_id": "cfe8de9a6ed04cc6bc032aea64147bd8", "specific_info": {"generation_id": "cortx-data-ssc-vm-rhev4-2391-84466ccfcf-9r7kd", "functional_type": "data", "pod_restart": 0}} with action ['publish']
2022-04-27 09:48:30 health_monitor [8]: INFO [init] MessageBus initialized as kafka
2022-04-27 09:48:30 health_monitor [8]: INFO [act] Default action handler with Event: 1651052909.09883866fa2f0282543a4b86d9992e2adf7b4 and actions : ['publish']

2. Now again sent node failed alert via mock monitor without function_type and generation_id:
{
    "events": {
        "1": {
            "source": "hare",
            "node_id": "a90ad685c92c4ccba0f202994296f16f",
            "resource_type": "node",
            "resource_id": "a90ad685c92c4ccba0f202994296f16f",
            "resource_status": "failed",
            "specific_info": {}
        }
    },
    "delay": 1
}

consul_key:
cortx>ha>v2>cortx>ha>system>cluster>803b244e189a4e7c92183027af8111c2>site>NOT_DEFINED>rack>NOT_DEFINED>node>a90ad685c92c4ccba0f202994296f16f>health:{"events": [{"event_timestamp": "1651053683.0317917", "created_timestamp": "1651053684", "status": "failed", "specific_info": ""}, {"event_timestamp": "1651052401.2094564", "created_timestamp": "1651052401", "status": "starting", "specific_info": {"generation_id": "cortx-server-ssc-vm-rhev4-2391-6f88866d9-t5vvx", "is_status": "True", "pod_restart": 0}}], "action": {"modified_timestamp": "1651053684", "status": "pending"}, "attributes": {}}

Fault_tolerance:
2022-04-27 10:01:24 fault_tolerance [8]: INFO [process_message] Received the message from message bus: b'{"header": {"version": "1.0", "timestamp": "1651053683.0317917", "event_id": "1651053683.03179172d00b3106cbd4fcf8ce5e10200e67970"}, "payload": {"source": "hare", "cluster_id": "803b244e189a4e7c92183027af8111c2", "site_id": "NOT_DEFINED", "rack_id": "NOT_DEFINED", "storageset_id": "1", "node_id": "a90ad685c92c4ccba0f202994296f16f", "resource_type": "node", "resource_id": "a90ad685c92c4ccba0f202994296f16f", "resource_status": "failed", "specific_info": ""}}'
2022-04-27 10:01:24 fault_tolerance [8]: INFO [init_evaluators] Initialize all the health evaluator elements
2022-04-27 10:01:24 fault_tolerance [8]: INFO [init_evaluators] HealthEvaluator ha.core.system_health.health_evaluators.cluster_health_evaluator.ClusterHealthEvaluator is initalized...
2022-04-27 10:01:24 fault_tolerance [8]: INFO [init_evaluators] HealthEvaluator ha.core.system_health.health_evaluators.site_health_evaluator.SiteHealthEvaluator is initalized...
2022-04-27 10:01:24 fault_tolerance [8]: INFO [init_evaluators] HealthEvaluator ha.core.system_health.health_evaluators.rack_health_evaluator.RackHealthEvaluator is initalized...
2022-04-27 10:01:24 fault_tolerance [8]: INFO [__init__] All cluster element are loaded, Ready to process alerts .................
2022-04-27 10:01:24 fault_tolerance [8]: INFO [__init__] ClusterResource Parser is initialized ...
2022-04-27 10:01:24 fault_tolerance [8]: INFO [filter_event] This alert needs an attention: resource_type: node
2022-04-27 10:01:24 fault_tolerance [8]: INFO [process_event] SystemHealth: Processing node:node:a90ad685c92c4ccba0f202994296f16f with status failed
2022-04-27 10:01:24 fault_tolerance [8]: INFO [_update] SystemHealth: Updated status for node:node:a90ad685c92c4ccba0f202994296f16f


No alert in health_monitor(publish was not established by event manager)
2022-04-27 10:01:24 health_monitor [8]: INFO [evaluate] Evaluated action [] for key action>node>all>failed

