### PR TITLE
CORTX-29987 : system_health get details of functionla_type

### DIFF
--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -439,6 +439,9 @@ class SystemHealth(Subscriber):
             if current_health:
                 current_health_dict = json.loads(current_health)
                 specific_info = current_health_dict["events"][0]["specific_info"]
+                # Get specific_info data from consul
+                if specific_info and specific_info.get('functional_type') and not healthevent.specific_info.get('functional_type'):
+                   healthevent.specific_info['functional_type'] = specific_info.get('functional_type')
                 if (component_type == CLUSTER_ELEMENTS.NODE.value) and specific_info \
                     and specific_info.get('generation_id', None) \
                     and healthevent.source == HEALTH_EVENT_SOURCES.MONITOR.value:


### PR DESCRIPTION
Signed-off-by: gauri-bhosale <gauri.bhosale@seagate.com>

# Problem Statement
-https://jts.seagate.com/browse/CORTX-29987

# Design
- system_health should pick functional_type from current_health

# Coding
-  [X] Coding conventions are followed and code is consistent

# Testing 
- [X] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [X] Testing was performed with RPM
https://jts.seagate.com/secure/attachment/515832/Test_Results.txt

# Review Checklist 
- [X] PR is self reviewed
- [X] JIRA number/GitHub Issue added to PR
- [X] Jira and state/status is updated and JIRA is updated with PR link
- [X] Check if the description is clear and explained
-
# Review Checklist 
- [X] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [X] Changes done to WIKI / Confluence page / Quick Start Guide

https://jts.seagate.com/secure/attachment/515832/Test_Results.txt