### PR TITLE
CORTX-29933: System health update for control node

### DIFF
--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -427,13 +427,13 @@ class SystemHealth(Subscriber):
                     'rack_id':healthevent.rack_id, 'storageset_id':healthevent.storageset_id}
 
 
+            # Read the currently stored health value
             current_health = self.get_status_raw(component, component_id, comp_type=component_type,
                                         cluster_id=healthevent.cluster_id, site_id=healthevent.site_id,
                                         rack_id=healthevent.rack_id, storageset_id=healthevent.storageset_id,
                                         node_id=healthevent.node_id, server_id=healthevent.node_id,
                                         storage_id=healthevent.node_id, cvg_id=self.cvg_id)
 
-            # Read the currently stored health value
             if current_health:
                 current_health_dict = json.loads(current_health)
                 specific_info = current_health_dict["events"][0]["specific_info"]

--- a/ha/core/system_health/system_health.py
+++ b/ha/core/system_health/system_health.py
@@ -390,7 +390,6 @@ class SystemHealth(Subscriber):
 
         # TODO: Check the user and see if allowed to update the system health.
         try:
-            status = self.statusmapper.map_event(healthevent)
             component = SystemHealthComponents.get_component(healthevent.resource_type)
 
             # Get the health update hierarchy
@@ -406,7 +405,6 @@ class SystemHealth(Subscriber):
             # Get the component type and id received in the event.
             component_type = healthevent.resource_type.split(':')[-1]
             component_id = healthevent.resource_id
-            Log.info(f"SystemHealth: Processing {component}:{component_type}:{component_id} with status {status}")
 
             # Update the node map
             self.node_id = healthevent.node_id
@@ -428,14 +426,14 @@ class SystemHealth(Subscriber):
             self.node_map = {'cluster_id':healthevent.cluster_id, 'site_id':healthevent.site_id,
                     'rack_id':healthevent.rack_id, 'storageset_id':healthevent.storageset_id}
 
-            # Read the currently stored health value
+
             current_health = self.get_status_raw(component, component_id, comp_type=component_type,
                                         cluster_id=healthevent.cluster_id, site_id=healthevent.site_id,
                                         rack_id=healthevent.rack_id, storageset_id=healthevent.storageset_id,
                                         node_id=healthevent.node_id, server_id=healthevent.node_id,
                                         storage_id=healthevent.node_id, cvg_id=self.cvg_id)
 
-            current_timestamp = str(int(time.time()))
+            # Read the currently stored health value
             if current_health:
                 current_health_dict = json.loads(current_health)
                 specific_info = current_health_dict["events"][0]["specific_info"]
@@ -444,6 +442,12 @@ class SystemHealth(Subscriber):
                 # healthevent is functional_type
                 if specific_info and specific_info.get('functional_type'):
                    healthevent.specific_info['functional_type'] = specific_info.get('functional_type')
+
+            status = self.statusmapper.map_event(healthevent)
+            Log.info(f"SystemHealth: Processing {component}:{component_type}:{component_id} with status {status}")
+
+            current_timestamp = str(int(time.time()))
+            if current_health:
                 if (component_type == CLUSTER_ELEMENTS.NODE.value) and specific_info \
                     and specific_info.get('generation_id', None) \
                     and healthevent.source == HEALTH_EVENT_SOURCES.MONITOR.value:


### PR DESCRIPTION
# Problem Statement
System health update for control node
For control node, the node health state needs to be consumed and updatedas it is received by HA. For now, the node health state is "unknown". After, first time, the state is marked as "starting". And then hare updates HA whether that POD is ready or not and then HA marks it as ONLINE in system health. But, HARE will not be informing HA regarding control node. Hence, code update is needed when its a control node alert, consume and update the state as it is.

# Design
For control node, consume the alert state as it is. Stopped updating the health.

# Coding
-  [ ] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
https://jts.seagate.com/secure/attachment/516264/CORTX-29933_Test_Results.txt

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
