### PR TITLE
CORTX-29667 Workaround to reduce consul access time during HA mini provisioning

### DIFF
--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -272,9 +272,11 @@ class ConfigCmd(Cmd):
                                         NODE_FUNCTIONAL_TYPES.SERVER.value, NODE_FUNCTIONAL_TYPES.DATA.value])])
             Log.info(f'event_manager subscription for {const.EVENT_COMPONENT}\
                        is successful for the event {const.POD_EVENT}')
-            event_manager.subscribe(const.EVENT_COMPONENT, [SubscribeEvent(const.DISK_EVENT, ["online", "failed"])])
-            Log.info(f'event_manager subscription for {const.EVENT_COMPONENT}\
-                       is successful for the event {const.DISK_EVENT}')
+            # Stopped disk event subscribption to reduce consul accesses
+            # till CORTX-29667i gets resolved
+            #event_manager.subscribe(const.EVENT_COMPONENT, [SubscribeEvent(const.DISK_EVENT, ["online", "failed"])])
+            #Log.info(f'event_manager subscription for {const.EVENT_COMPONENT}\
+            #           is successful for the event {const.DISK_EVENT}')
 
 
             Log.info('Creating cluster cardinality')
@@ -286,7 +288,9 @@ class ConfigCmd(Cmd):
             # Init node health
             self._add_node_health()
             # Init cvg and disk health
-            self._add_cvg_and_disk_health()
+            # Stopped disk, cvg resource key addition to consul to reduce consul accesses
+            # till CORTX-29667i gets resolved
+            #self._add_cvg_and_disk_health()
 
             Log.info("config command is successful")
             sys.stdout.write("config command is successful.\n")

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -273,7 +273,7 @@ class ConfigCmd(Cmd):
             Log.info(f'event_manager subscription for {const.EVENT_COMPONENT}\
                        is successful for the event {const.POD_EVENT}')
             # Stopped disk event subscribption to reduce consul accesses
-            # till CORTX-29667i gets resolved
+            # till CORTX-29667 gets resolved
             #event_manager.subscribe(const.EVENT_COMPONENT, [SubscribeEvent(const.DISK_EVENT, ["online", "failed"])])
             #Log.info(f'event_manager subscription for {const.EVENT_COMPONENT}\
             #           is successful for the event {const.DISK_EVENT}')

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -289,7 +289,7 @@ class ConfigCmd(Cmd):
             self._add_node_health()
             # Init cvg and disk health
             # Stopped disk, cvg resource key addition to consul to reduce consul accesses
-            # till CORTX-29667i gets resolved
+            # till CORTX-29667 gets resolved
             #self._add_cvg_and_disk_health()
 
             Log.info("config command is successful")


### PR DESCRIPTION
Signed-off-by: ArchanaLimaye <archana.limaye@seagate.com>

# Problem Statement
 Workaround to reduce consul access time during HA mini provisioning

# Design
 Workaround to reduce consul access time during HA mini provisioning
 All types of consul key creation stopped for disk and cvg resources

# Coding
-  [ ] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Review Checklist 
- [ ] PR is self reviewed
- [ ] JIRA number/GitHub Issue added to PR
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
