### PR TITLE
CORTX-29667 Optimizing ha_setup to reduce consul accesses

### DIFF
--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -286,7 +286,7 @@ class ConfigCmd(Cmd):
             # Init cluster,site,rack health
             self._add_cluster_component_health()
             # Init node health
-            self._add_node_health(data_pods, server_pods, control_pods, num_pods, watch_pods)
+            self._add_node_health(data_pods, server_pods, control_pods, watch_pods)
             # Init cvg and disk health
             # Stopped disk, cvg resource key addition to consul to reduce consul accesses
             # till CORTX-29667 gets resolved
@@ -322,7 +322,7 @@ class ConfigCmd(Cmd):
                                    specific_info=specific_info)
 
 
-    def _add_node_health(self, data_node_ids, server_node_ids, control_node_ids, num_pods, nodes_list) -> None:
+    def _add_node_health(self, data_node_ids, server_node_ids, control_node_ids, nodes_list) -> None:
         """
         Add node health
         """

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -281,12 +281,12 @@ class ConfigCmd(Cmd):
 
             Log.info('Creating cluster cardinality')
             self._confStoreAPI = ConftStoreSearch()
-            self._confStoreAPI.set_cluster_cardinality(self._index)
+            data_pods, server_pods, control_pods, num_pods, watch_pods = self._confStoreAPI.set_cluster_cardinality(self._index)
 
             # Init cluster,site,rack health
             self._add_cluster_component_health()
             # Init node health
-            self._add_node_health()
+            self._add_node_health(data_pods, server_pods, control_pods, num_pods, watch_pods)
             # Init cvg and disk health
             # Stopped disk, cvg resource key addition to consul to reduce consul accesses
             # till CORTX-29667 gets resolved
@@ -322,14 +322,10 @@ class ConfigCmd(Cmd):
                                    specific_info=specific_info)
 
 
-    def _add_node_health(self) -> None:
+    def _add_node_health(self, data_node_ids, server_node_ids, control_node_ids, num_pods, nodes_list) -> None:
         """
         Add node health
         """
-        _, nodes_list = self._confStoreAPI.get_cluster_cardinality()
-        data_node_ids = self._confStoreAPI.get_data_pods(self._index)
-        server_node_ids = self._confStoreAPI.get_server_pods(self._index)
-        control_node_ids = self._confStoreAPI.get_control_nodes(self._index)
         for node in nodes_list:
             functional_type = None
             if node in data_node_ids:

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -281,7 +281,7 @@ class ConfigCmd(Cmd):
 
             Log.info('Creating cluster cardinality')
             self._confStoreAPI = ConftStoreSearch()
-            data_pods, server_pods, control_pods, num_pods, watch_pods = self._confStoreAPI.set_cluster_cardinality(self._index)
+            data_pods, server_pods, control_pods, _, watch_pods = self._confStoreAPI.set_cluster_cardinality(self._index)
 
             # Init cluster,site,rack health
             self._add_cluster_component_health()

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -115,6 +115,8 @@ class ConftStoreSearch:
         cluster_cardinality_value = {CLUSTER_CARDINALITY_NUM_NODES: num_pods, CLUSTER_CARDINALITY_LIST_NODES : watch_pods }
         self._confstore.update(cluster_cardinality_key, json.dumps(cluster_cardinality_value))
 
+        return data_pods, server_pods, control_pods, num_pods, watch_pods
+
     @staticmethod
     def _get_cvg_count(index, node_id):
         cvg_count = Conf.get(index, GconfKeys.CVG_COUNT.value.format(_DELIM=_DELIM, node_id=node_id))


### PR DESCRIPTION
Signed-off-by: ArchanaLimaye <archana.limaye@seagate.com>

# Problem Statement
CORTX-29667  HA deployment takes too long 

# Design
 Optimizing ha_setup code to reduce consul accesses

# Coding
-  [ ] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
Verified that values of data_node_ids , server_node_ids, control_node_ids, nodes_list remain same as before after this change 

# Review Checklist 
- [ ] PR is self reviewed
- [ ] JIRA number/GitHub Issue added to PR
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
