### PR TITLE
CORTX-31528 : Handle FQDN based pod identifiers in k8s monitor

### DIFF
--- a/ha/monitor/k8s/const.py
+++ b/ha/monitor/k8s/const.py
@@ -24,7 +24,10 @@ class K8SEventsConst:
     LABELS ='labels'
     # cortx specific key for fetching machine id from event.
     # k8s event: ['raw_object']['metadata']['labels']['cortx.io/machine-id']
-    MACHINEID = 'cortx.io/machine-id'
+    LABEL_MACHINEID = 'cortx.io/machine-id'
+    # TODO: CORTX-31875: check if pod has same label 'statefulset.kubernetes.io/pod-name'
+    # k8s event: ['raw_object']['metadata']['labels']['statefulset.kubernetes.io/pod-name']
+    LABEL_PODNAME = 'statefulset.kubernetes.io/pod-name'
     SPEC = 'spec'
     NODE_NAME = 'nodeName'
     PHASE = 'phase'

--- a/ha/monitor/k8s/parser.py
+++ b/ha/monitor/k8s/parser.py
@@ -15,9 +15,6 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
-
-import time
-
 from ha.monitor.k8s.error import NotSupportedObjectError
 from ha.monitor.k8s.const import K8SEventsConst
 from ha.monitor.k8s.const import AlertStates
@@ -42,7 +39,7 @@ class ObjectParser:
                     HealthAttr.RESOURCE_ID.value: '', HealthAttr.RESOURCE_STATUS.value: '',
                     HealthAttr.SPECIFIC_INFO.value: {}}
 
-    def parse(self, an_event, cached_state):
+    def parse(self, an_event, cached_state, resource_id_map):
         pass
 
 
@@ -70,7 +67,7 @@ class NodeEventParser(ObjectParser):
         self.event = HealthEvent(**self.payload)
         return self.event.json
 
-    def parse(self, an_event, cached_state):
+    def parse(self, an_event, cached_state, resource_id_map):
         resource_type = self._type
         raw_object = an_event[K8SEventsConst.RAW_OBJECT]
 
@@ -156,13 +153,49 @@ class PodEventParser(ObjectParser):
         self.event.set_specific_info({"generation_id": generation_id})
         return self.event.json
 
-    def parse(self, an_event, cached_state):
+    @staticmethod
+    def _get_resource_id(labels: dict, resource_id_map: dict) -> str:
+        """
+        get resource id
+
+        Check if pod name label exist if yes then check if resource map contains it
+        if resource id doesn't found then check if machine id label is exists if yes
+        then find resource id for same.
+
+        Note: machine id in label is different from the actual machine id inside pod
+        in file '/etc/machine-id' and the actual machine id is resource id.
+
+        Args:
+            labels (dict): pod labels with values
+            resource_id_map (dict): map of label (name/machine-id) with actual machine id
+            label 'statefulset.kubernetes.io/pod-name' : pod fqdn, key in resource map
+            label 'cortx.io/machine-id' : uniq id, key in resource map
+        Returns:
+            str: resource id which is nothing but actual machine id
+                inside pod in file '/etc/machine-id'
+        """
+        resource_id = None
+        # NOTE: All the cortx pods from the deployment that are being watched
+        # will have either label 'cortx.io/machine-id' or 'statefulset.kubernetes.io/pod-name'
+        # both label will not co-exist in a deployment
+        # TODO: CORTX-31875 remove check for label 'cortx.io/machine-id'
+        if K8SEventsConst.LABEL_PODNAME in labels:
+            resource_id = resource_id_map.get(labels[K8SEventsConst.LABEL_PODNAME], None)
+            Log.debug(f"pod name {labels[K8SEventsConst.LABEL_PODNAME]} resource id: {resource_id}")
+        # Check pod id label
+        if K8SEventsConst.LABEL_MACHINEID in labels:
+            resource_id = resource_id_map.get(labels[K8SEventsConst.LABEL_MACHINEID], None)
+            Log.debug(f"pod m-id {labels[K8SEventsConst.LABEL_MACHINEID]} resource id: {resource_id}")
+
+        return resource_id
+
+    def parse(self, an_event, cached_state, resource_id_map):
         resource_type = self._type
         raw_object = an_event[K8SEventsConst.RAW_OBJECT]
 
-        labels = raw_object[K8SEventsConst.METADATA][K8SEventsConst.LABELS]
-        if K8SEventsConst.MACHINEID in labels:
-            resource_name = labels[K8SEventsConst.MACHINEID]
+        resource_id = PodEventParser._get_resource_id(raw_object[K8SEventsConst.METADATA][K8SEventsConst.LABELS],\
+            resource_id_map)
+
         if K8SEventsConst.TYPE in an_event:
             event_type = an_event[K8SEventsConst.TYPE]
         # Actual physical host information is not needed now.
@@ -180,37 +213,37 @@ class PodEventParser(ObjectParser):
             Log.debug(f"Exception received during parsing {e}")
 
         if ready_status is None:
-            Log.debug(f"ready_status is None for pod resource {resource_name}")
-            cached_state[resource_name] = ready_status
+            Log.debug(f"ready_status is None for pod resource {resource_id}")
+            cached_state[resource_id] = ready_status
             return (None, None)
 
         if an_event[K8SEventsConst.TYPE] == EventStates.ADDED:
-            cached_state[resource_name] = ready_status.lower()
+            cached_state[resource_id] = ready_status.lower()
             if ready_status.lower() != K8SEventsConst.true:
-                Log.debug(f"[EventStates ADDED] No change detected for pod resource {resource_name}")
+                Log.debug(f"[EventStates ADDED] No change detected for pod resource {resource_id}")
                 return (None, None)
             else:
                 event_type = AlertStates.ONLINE
-                health_alert = self._create_health_alert(resource_type, resource_name, event_type, generation_id)
+                health_alert = self._create_health_alert(resource_type, resource_id, event_type, generation_id)
                 return health_alert, self.event
 
         if event_type == EventStates.MODIFIED:
-            if resource_name in cached_state:
-                if cached_state[resource_name] != K8SEventsConst.true and ready_status.lower() == K8SEventsConst.true:
-                    cached_state[resource_name] = ready_status.lower()
+            if resource_id in cached_state:
+                if cached_state[resource_id] != K8SEventsConst.true and ready_status.lower() == K8SEventsConst.true:
+                    cached_state[resource_id] = ready_status.lower()
                     event_type = AlertStates.ONLINE
-                    health_alert = self._create_health_alert(resource_type, resource_name, event_type, generation_id)
+                    health_alert = self._create_health_alert(resource_type, resource_id, event_type, generation_id)
                     return health_alert, self.event
-                elif cached_state[resource_name] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
-                    cached_state[resource_name] = ready_status.lower()
+                elif cached_state[resource_id] == K8SEventsConst.true and ready_status.lower() != K8SEventsConst.true:
+                    cached_state[resource_id] = ready_status.lower()
                     event_type = AlertStates.OFFLINE
-                    health_alert = self._create_health_alert(resource_type, resource_name, event_type, generation_id)
+                    health_alert = self._create_health_alert(resource_type, resource_id, event_type, generation_id)
                     return health_alert, self.event
                 else:
-                    Log.debug(f"[EventStates MODIFIED] No change detected for pod resource {resource_name}")
+                    Log.debug(f"[EventStates MODIFIED] No change detected for pod resource {resource_id}")
                     return (None, None)
             else:
-                Log.debug(f"[EventStates MODIFIED] No cached state detected for pod resource {resource_name}")
+                Log.debug(f"[EventStates MODIFIED] No cached state detected for pod resource {resource_id}")
                 return (None, None)
 
         # Handle DELETED event - Not required for Cortx
@@ -225,9 +258,9 @@ class EventParser:
     }
 
     @staticmethod
-    def parse(k_object, an_event, cached_state):
+    def parse(k_object, an_event, cached_state, resource_id_map):
         if k_object in EventParser.parser_map:
             object_event_parser = EventParser.parser_map[k_object]
-            return object_event_parser.parse(an_event, cached_state)
+            return object_event_parser.parse(an_event, cached_state, resource_id_map)
 
         raise NotSupportedObjectError(f"object = {k_object}")


### PR DESCRIPTION
Signed-off-by: Mukhtar Inamdar <mukhtar.p.inamdar@seagate.com>

# Problem Statement
- added a pod monitor to monitor pods having some label 'cortx.io/pod_name' which value is a constant that persists within the reboot, and map it with resource id which is in '/etc/machine-id' file as use it in alert

# Design
-  create an object of object_monitor and provide a list of values of 'cortx.io/pod_name' to monitor its events.
- also take a parameter resource_id_map dict received from const_store.get_cluster_cardinality()
- use this map to get '/etc/machine-id with the value pod label 'statefulset.kubernetes.io/pod-name'
- Ref: https://jts.seagate.com/browse/CORTX-30991?focusedCommentId=2367465&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2367465
- use this resource id '/etc/machine-id in alert

# Coding
-  [x] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path, and Scalability
- [x] Testing was performed with RPM
- [x]  Testing log: tested with HA CORTX-31529 and re changes.
- Testing done with all changes from Tanuja, shailesh vaidya using below custom image provided by @tanujashinde0405
    cortx-docker.colo.seagate.com/seagate/cortx-rgw:2.0.0-6259-custom-ci
    cortx-docker.colo.seagate.com/seagate/cortx-data:2.0.0-6259-custom-ci
    cortx-docker.colo.seagate.com/seagate/cortx-control:2.0.0-6259-custom-c
- combined changes from @Madhura-08  in my changes and created the rpm and replace this rpm in the image by committing the docker command and did test
- As pod name, related changes are not available so added pod manually see below
- Confirm Pod name label from comment: https://jts.seagate.com/browse/CORTX-30991?focusedCommentId=2367465&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2367465
- Below file updated testing details
Link: https://jts.seagate.com/secure/attachment/520280/CORTX-31528-2.log


# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained
- [x] Is there a change in filename/package/module or signature? [Y/N]: N
- [x] If yes for above point, is a notification sent to all other cortx components? [Y/N] N.A.
- [x] Side effects on other features (deployment/upgrade)? [Y/N] N
- [x] Dependencies on other component(s)? [Y/N] N
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

# Note
As discussed needs to remove the pod monitor for machine-id label once pod name label is available hence added new task https://jts.seagate.com/browse/CORTX-31875 