### PR TITLE
CORTX-32740: HA - Consul Support for GCONF

### DIFF
--- a/ha/core/config/config_manager.py
+++ b/ha/core/config/config_manager.py
@@ -39,9 +39,10 @@ class ConfigManager:
     _cluster_confstore = None
 
     @staticmethod
-    def init(log_name, log_path=None, level="INFO",
+    def init(log_name, log_path=None, level=None,
             backup_count=5, file_size_in_mb=10, syslog_server=None,
-            syslog_port=None, console_output=True, config_file=None):
+            syslog_port=None, console_output=True, config_file=None,
+            skip_load=False, initialize_log=True):
         """
         Initialize ha conf and log
         Args:
@@ -49,11 +50,17 @@ class ConfigManager:
         """
         # log_path will be piked from cluster config only
         # log_path can be updated for testing only
-        ConfigManager._conf_init(config_file)
+        if not skip_load:
+            ConfigManager._conf_init(config_file)
+        if not initialize_log:
+            return
         if log_name:
             if not log_path:
                 log_path = Conf.get(const.HA_GLOBAL_INDEX, f"LOG{_DELIM}path")
-            level = Conf.get(const.HA_GLOBAL_INDEX, f"LOG{_DELIM}level")
+            if level is not None:
+                level = level
+            else:
+                level = Conf.get(const.HA_GLOBAL_INDEX, f"LOG{_DELIM}level")
             # console_output=True will redirect all log to console and log file both
             # TODO: CORTX-28795 filter redirect log for console and file
             Log.init(service_name=log_name, log_path=log_path, level=level,

--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -28,6 +28,8 @@ _DELIM=">"
 
 # consul endpoint scheme: http
 consul_scheme = 'http'
+# kafka endpoint scheme: tcp
+kafka_scheme = 'tcp'
 
 # Event_manager keys
 POD_EVENT="node"
@@ -45,9 +47,14 @@ class GconfKeys(enum.Enum):
     NODE_CONST = "node"
     SERVICE_CONST = "services"
     NAME_CONST = "name"
-    CVG_NAME = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}name"
-    CVG_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}num_cvg"
-    DATA_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}num_data"
-    METADATA_COUNT = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}num_metadata"
-    DATA_DISK = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}data[{d_index}]"
-    METADATA_DISK = "node{_DELIM}{node_id}{_DELIM}storage{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}metadata[{m_index}]"
+    CONSUL_ENDPOINTS_NUM_KEY = "cortx{_DELIM}external{_DELIM}consul{_DELIM}num_endpoints"
+    CONSUL_ENDPOINT_KEY = "cortx{_DELIM}external{_DELIM}consul{_DELIM}endpoints[{endpoint_index}]"
+    KAFKA_ENDPOINTS_NUM_KEY = "cortx{_DELIM}external{_DELIM}kafka{_DELIM}num_endpoints"
+    KAFKA_ENDPOINT_KEY = "cortx{_DELIM}external{_DELIM}kafka{_DELIM}endpoints[{endpoint_index}]"
+    NUM_CVG = "num_cvg"
+    CVG_NAME = "node{_DELIM}{node_id}{_DELIM}cvg[{cvg_index}]{_DELIM}name"
+    CVG_COUNT = "node{_DELIM}{node_id}{_DELIM}num_cvg"
+    DATA_COUNT = "node{_DELIM}{node_id}{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}num_data"
+    METADATA_COUNT = "node{_DELIM}{node_id}{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}num_metadata"
+    DATA_DISK = "node{_DELIM}{node_id}{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}data[{d_index}]"
+    METADATA_DISK = "node{_DELIM}{node_id}{_DELIM}cvg[{cvg_index}]{_DELIM}devices{_DELIM}metadata[{m_index}]"

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -34,7 +34,7 @@ from ha.k8s_setup import const
 from ha.core.config.config_manager import ConfigManager
 from ha.core.error import HaCleanupException
 from ha.core.error import SetupError
-from ha.k8s_setup.const import _DELIM
+from ha.k8s_setup.const import _DELIM, GconfKeys
 from ha.core.event_manager.event_manager import EventManager
 from ha.core.event_manager.subscribe_event import SubscribeEvent
 from ha.core.event_manager.resources import NODE_FUNCTIONAL_TYPES
@@ -186,6 +186,31 @@ class ConfigCmd(Cmd):
         """
         super().__init__(args)
 
+    def _get_endpoints(self, num_endpoints_key: str, endpoint_key: str, scheme: str) -> str:
+        """Get endpoints"""
+        ep = None
+        num_endpoints = Conf.get(self._index, num_endpoints_key.format(_DELIM=_DELIM))
+        if num_endpoints is None:
+            Log.error(f"number of endpoints found: {num_endpoints}")
+            raise SetupError(f"number of endpoints found: {num_endpoints}")
+        try:
+            for num in range(int(num_endpoints)):
+                endpoint = Conf.get(self._index, endpoint_key.format(_DELIM=_DELIM, endpoint_index=num))
+                if endpoint is None:
+                    continue
+                ep = ' '.join((filter(lambda x: isinstance(x, str) and \
+                        urlparse(x).scheme == scheme, endpoint.split())))
+                if ep: break
+            if ep is None:
+                Log.error("No endpoints are configured")
+                raise SetupError("No endpoints are configured")
+        except Exception as err:
+            Log.error(f"Problem occured while fetcting the endpoint for consul or \
+                        kakfa service: {err}")
+            raise SetupError(f"Problem occured while fecting the endpoint for consul or \
+                        fakfa service: {err}")
+        return ep
+
     def process(self):
         """
         Process config command.
@@ -196,7 +221,11 @@ class ConfigCmd(Cmd):
             machine_id = Conf.machine_id
             ha_log_path = os.path.join(log_path, f'ha/{machine_id}')
 
-            consul_endpoints = Conf.get(self._index, f'cortx{_DELIM}external{_DELIM}consul{_DELIM}endpoints')
+            ConfigManager.init("ha_setup", log_path=ha_log_path, level="INFO", skip_load=True)
+            # With new changes in GConf, consul http endpoint will be available at
+            # cortx>external>consul>endpoints[1] key
+            consul_endpoint = self._get_endpoints(GconfKeys.CONSUL_ENDPOINTS_NUM_KEY.value, \
+                                GconfKeys.CONSUL_ENDPOINT_KEY.value, const.consul_scheme)
             #========================================================#
             # consul Service endpoints from cluster.conf             #
             #____________________ cluster.conf ______________________#
@@ -204,24 +233,26 @@ class ConfigCmd(Cmd):
             # - tcp://consul-server.default.svc.cluster.local:8301   #
             # - http://consul-server.default.svc.cluster.local:8500  #
             #========================================================#
-            # search for supported consul endpoint url from list of configured consul endpoints
-            filtered_consul_endpoints = list(filter(lambda x: isinstance(x, str) and urlparse(x).scheme == const.consul_scheme, consul_endpoints))
-            if not filtered_consul_endpoints:
+            if not consul_endpoint:
                 sys.stderr.write(f'Failed to get consul config. consul_config: {filtered_consul_endpoints}. \n')
                 sys.exit(1)
-            # discussed and confirmed to select the first hhtp endpoint
-            consul_endpoint = filtered_consul_endpoints[0]
+            # discussed and confirmed to select the http endpoint
 
-            kafka_endpoint = Conf.get(self._index, f'cortx{_DELIM}external{_DELIM}kafka{_DELIM}endpoints')
+            kafka_endpoints = []
+            # With new changes in GConf, kafka endpoint will be available at
+            # cortx>external>kafka>endpoints[0] key
+            kafka_endpoint = self._get_endpoints(GconfKeys.KAFKA_ENDPOINTS_NUM_KEY.value, \
+                                GconfKeys.KAFKA_ENDPOINT_KEY.value, const.kafka_scheme)
             if not kafka_endpoint:
                 sys.stderr.write(f'Failed to get kafka config. kafka_config: {kafka_endpoint}. \n')
                 sys.exit(1)
+            kafka_endpoints.append(kafka_endpoint)
 
             health_comm_msg_type = FAULT_TOLERANCE_KEYS.MONITOR_HA_MESSAGE_TYPE.value
 
             conf_file_dict = {'LOG' : {'path' : ha_log_path, 'level' : const.HA_LOG_LEVEL},
                          'consul_config' : {'endpoint' : consul_endpoint},
-                         'kafka_config' : {'endpoints': kafka_endpoint},
+                         'kafka_config' : {'endpoints': kafka_endpoints},
                          'event_topic' : 'hare',
                          'MONITOR' : {'message_type' : health_comm_msg_type, 'producer_id' : 'cluster_monitor'},
                          'EVENT_MANAGER' : {'message_type' : 'health_events', 'producer_id' : 'system_health',
@@ -244,7 +275,7 @@ class ConfigCmd(Cmd):
             Cmd.copy_file(const.SOURCE_HEALTH_HIERARCHY_FILE, const.HEALTH_HIERARCHY_FILE)
             # First populate the ha.conf and then do init. Because, in the init, this file will
             # be stored in the confstore as key values
-            ConfigManager.init("ha_setup")
+            ConfigManager.init("ha_setup", initialize_log=False)
 
             # Inside cluster.conf, cluster_id will be present under
             # "node".<actual POD machind id>."cluster_id". So,
@@ -266,7 +297,8 @@ class ConfigCmd(Cmd):
             kv_enable_batch_put = True
             self._confstore = ConfigManager.get_confstore(kv_enable_batch=kv_enable_batch_put)
 
-            Log.info(f'Populating the ha config file with consul_endpoint: {consul_endpoint}')
+            Log.info(f'Populating the ha config file with consul and kafka endpoint: \
+                     {consul_endpoint}, {kafka_endpoints}')
 
             Log.info('Performing event_manager subscription')
             event_manager = EventManager.get_instance()
@@ -303,12 +335,16 @@ class ConfigCmd(Cmd):
             Log.info("config command is successful")
             sys.stdout.write("config command is successful.\n")
         except TypeError as type_err:
+            Log.error(f'HA config command failed: Type mismatch: {type_err}.\n')
             sys.stderr.write(f'HA config command failed: Type mismatch: {type_err}.\n')
         except yaml.YAMLError as exc:
+            Log.error(f'HA config command failed: Invalid yaml configuration: {exc}.\n')
             sys.stderr.write(f'Ha config failed. Invalid yaml configuration: {exc}.\n')
         except OSError as os_err:
+            Log.error(f'HA config command failed: OS_error: {os_err}.\n')
             sys.stderr.write(f'HA Config failed. OS_error: {os_err}.\n')
         except Exception as c_err:
+            Log.error(f'HA config command failed: {c_err}.\n')
             sys.stderr.write(f'HA config command failed: {c_err}.\n')
 
     def _add_cluster_component_health(self) -> None:

--- a/ha/util/conf_store.py
+++ b/ha/util/conf_store.py
@@ -53,7 +53,7 @@ class ConftStoreSearch:
         # ['node>5f3dc3a153454a918277ee4a2c57f36b>components[1]>services[0]',
         # 'node>6203a14bde204e8ea798ad9d42583fb5>components[1]>services[0]', 'node>8cc8b13101e34b3ca1e51ed6e3228d5b>components[1]>services[0]']
 
-        data_pod_keys = Conf.search(index, GconfKeys.NODE_CONST.value, GconfKeys.SERVICE_CONST.value, Const.SERVICE_MOTR_IO.value)
+        data_pod_keys = Conf.search(index, GconfKeys.NODE_CONST.value, GconfKeys.NUM_CVG.value)
         for key in data_pod_keys:
             machine_id = key.split('>')[1]
             # Add machine id to list


### PR DESCRIPTION
- Change the mechanism to fetch consul and kafka endpoints in order to
  adhere to consul based Gconf and it should also be backward compatible
  supporting yaml based Gconf.
- Remove storage keyword from the keys which is used to fetch cvg, data
  and metadata disks
- Add more logging

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

# Problem Statement
https://jts.seagate.com/browse/CORTX-32740. 
As yaml based Gconf is changed to consul based Gconf, HA is failing to fetch consul and kafka endpoints. So, now HA need changed to support for consul based Gconf for HA mini provisioning to work. 

# Design
In order to get consul and kafka endpoints correctly, first number of endpoints can be fetched. Then after iterating, matching protocol scheme(like http, tcp) can be found in order to get correct endpoint 

# Coding
-  [ ] Coding conventions are followed and code is consistent

# Testing 
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Review Checklist 
- [ ] PR is self reviewed
- [ ] JIRA number/GitHub Issue added to PR
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
