### PR TITLE
CORTX-34166: [cortx-ha] Consul transaction changes to address 64 KV limit - part #1

### DIFF
--- a/ha/k8s_setup/const.py
+++ b/ha/k8s_setup/const.py
@@ -34,6 +34,7 @@ _DELIM=">"
 
 # consul endpoint scheme: http
 consul_scheme = 'http'
+CONSUL_TRANSACTIONS_LIMIT = 64
 # kafka endpoint scheme: tcp
 kafka_scheme = 'tcp'
 

--- a/ha/k8s_setup/ha_setup.py
+++ b/ha/k8s_setup/ha_setup.py
@@ -305,7 +305,6 @@ class ConfigCmd(Cmd):
             event_manager.subscribe(const.EVENT_COMPONENT,
                                     [SubscribeEvent(const.POD_EVENT, ["online", "offline", "failed"], [
                                         NODE_FUNCTIONAL_TYPES.SERVER.value, NODE_FUNCTIONAL_TYPES.DATA.value])])
-
             Log.info(f'event_manager subscription for {const.EVENT_COMPONENT}\
                        is successful for the event {const.POD_EVENT}')
             # Stopped disk event subscribption to reduce consul accesses
@@ -322,7 +321,7 @@ class ConfigCmd(Cmd):
             # Init cluster,site,rack health
             self._add_cluster_component_health()
 
-            # Note: if batch put is enabled needs to commit
+            # Note: if batch put is enabled, need to commit
             # to push all the local cashed values to consul server
             if kv_enable_batch_put:
                 Log.debug(f"Pushing event manager subscription and cluster/site/rack health transactions to store")
@@ -334,11 +333,6 @@ class ConfigCmd(Cmd):
             # Stopped disk, cvg resource key addition to consul to reduce consul accesses
             # till CORTX-29667 gets resolved
             # self._add_cvg_and_disk_health()
-
-            # Note: if batch put is enabled needs to commit
-            # to push all the local cashed values to consul server
-            # if kv_enable_batch_put:
-            #    self._confstore.commit()
 
             Log.info("config command is successful")
             sys.stdout.write("config command is successful.\n")
@@ -391,7 +385,7 @@ class ConfigCmd(Cmd):
         for node_id in node_mapping.values():
             node_id_list.append(node_id)
             if len(node_id_list) > CONSUL_TRANSACTIONS_LIMIT:
-                # Note: if batch put is enabled needs to commit
+                # Note: if batch put is enabled, need to commit
                 # to push all the local cashed values to consul server
                 if kv_enable_batch_put:
                     Log.debug(f"pushing {CONSUL_TRANSACTIONS_LIMIT} node health transactions to store")


### PR DESCRIPTION
…imit - part #1

consul transactions have limitations of pushing 64 keys/64 transactions in one request. Because of this, HA was failing on 27 node deployment setup because more than 64 keys creation request was getting executed in one transaction request.

Solution:
Divide the HA key creation into parts. First event manager subscription, cluster, site, and rack health keys which are fixed in numbers will be created in one request. For node health keys creation, every 64 keys creation request will be sent sequentially. If keys are less than that, it will be done in one request.

Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

# Problem Statement
https://jts.seagate.com/browse/CORTX-34166)

# Design
Divide the HA key creation into parts. First event manager subscription, cluster, site, and rack health keys which are fixed in numbers will be created in one request. For node health keys creation, every 64 keys creation request will be sent sequentially. If keys are less than that, it will be done in one request.

# Coding
-  [ ] Coding conventions are followed and code is consistent

# Testing 
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM
https://jts.seagate.com/secure/attachment/535097/CORTX-34166_Test_details.txt

# Review Checklist 
- [x] PR is self reviewed
- [x] JIRA number/GitHub Issue added to PR
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained
- [ ] Is there a change in filename/package/module or signature? [Y/N]: 
- [ ] If yes for above point, is a notification sent to all other cortx components? [Y/N]
- [ ] Side effects on other features (deployment/upgrade)? [Y/N]
- [ ] Dependencies on other component(s)? [Y/N]
-     If yes for above point, post link to the corresponding PR.

# Review Checklist 
- [ ] Is perfline test run and the report with and without the changes updated in the PR? [Y/N]: 

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
